### PR TITLE
chart: first-class support for externally-managed JWT_SECRET

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,4 +62,4 @@ Temporary Items
 # local docker data
 data/
 internal/db/migrations_archive/
-librarium-api
+/librarium-api

--- a/deploy/helm/librarium-api/.gitignore
+++ b/deploy/helm/librarium-api/.gitignore
@@ -1,0 +1,2 @@
+# Pulled in by `helm dependency update`. Tracked via Chart.lock for reproducibility.
+charts/

--- a/deploy/helm/librarium-api/.helmignore
+++ b/deploy/helm/librarium-api/.helmignore
@@ -1,0 +1,15 @@
+# Patterns to ignore when building packages.
+.DS_Store
+.git/
+.gitignore
+.idea/
+.vscode/
+*.tmproj
+*.bak
+*.swp
+*~
+.project
+.tox/
+.flake8
+.mypy_cache/
+__pycache__/

--- a/deploy/helm/librarium-api/Chart.lock
+++ b/deploy/helm/librarium-api/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: common
+  repository: https://fireball1725.github.io/firelabs-helm-common/
+  version: 5.0.3
+digest: sha256:67a6701215db65a670930d37d677d6c964b0d0320502bb76265ada096bdba5ec
+generated: "2026-04-18T21:39:19.717449-04:00"

--- a/deploy/helm/librarium-api/Chart.yaml
+++ b/deploy/helm/librarium-api/Chart.yaml
@@ -1,0 +1,32 @@
+apiVersion: v2
+name: librarium-api
+description: Librarium API - Go backend for the self-hosted Librarium library tracker.
+type: application
+
+# Chart version. Bump on template/values changes; does not need to match appVersion.
+version: 0.1.0
+
+# Tracks the librarium-api release. Keep in sync with the pinned image tag in values.yaml.
+appVersion: "26.4.0"
+
+kubeVersion: ">=1.25.0-0"
+
+home: https://github.com/fireball1725/librarium-api
+sources:
+  - https://github.com/fireball1725/librarium-api
+maintainers:
+  - name: fireball1725
+    url: https://github.com/fireball1725
+
+keywords:
+  - librarium
+  - library
+  - books
+  - ebooks
+  - audiobooks
+  - self-hosted
+
+dependencies:
+  - name: common
+    version: 5.0.3
+    repository: https://fireball1725.github.io/firelabs-helm-common/

--- a/deploy/helm/librarium-api/README.md
+++ b/deploy/helm/librarium-api/README.md
@@ -1,0 +1,248 @@
+# librarium-api Helm chart
+
+Helm chart for deploying [librarium-api](https://github.com/fireball1725/librarium-api) to Kubernetes.
+
+Built on top of [firelabs-helm-common](https://github.com/FireBall1725/firelabs-helm-common) (a k8s-at-home library-chart fork) and [CloudNativePG](https://cloudnative-pg.io/) for Postgres.
+
+## Prerequisites
+
+- Kubernetes 1.25+
+- Helm 3.8+
+- [CloudNativePG operator](https://cloudnative-pg.io/documentation/current/installation_upgrade/) installed in the cluster (only if `postgres.create=true`, which is the default)
+- A StorageClass that supports `ReadWriteOnce` (or `ReadWriteMany` if you want to run multiple api replicas)
+
+## Install
+
+```bash
+cd deploy/helm/librarium-api
+
+# Fetch the common library chart
+helm dependency update
+
+# Quick install — generate a JWT secret inline (good for local tests).
+# For GitOps / production, use an externally-managed Secret instead. See §Secrets.
+helm install librarium . \
+  --namespace librarium --create-namespace \
+  --set secret.JWT_SECRET="$(openssl rand -base64 48)"
+```
+
+Once the pod is ready, port-forward or set up ingress:
+
+```bash
+kubectl -n librarium port-forward svc/librarium-api 8080:8080
+# then open http://localhost:8080/api/v1/version
+```
+
+## Upgrade
+
+```bash
+# Bump the image tag
+helm upgrade librarium . \
+  --namespace librarium --reuse-values \
+  --set image.tag=26.4.1
+```
+
+Migrations run automatically on api startup.
+
+## Uninstall
+
+```bash
+helm uninstall librarium -n librarium
+```
+
+This removes the Deployment, Service, ConfigMap, Secret, and — if `postgres.create=true` — the CNPG `Cluster` CR. **PVCs are retained** by default (CNPG's and this chart's `persistence.*`) so your data survives. Delete them manually if you really want them gone:
+
+```bash
+kubectl -n librarium delete pvc -l app.kubernetes.io/instance=librarium
+```
+
+## Configuration
+
+Most of the schema comes from [firelabs-helm-common](https://github.com/FireBall1725/firelabs-helm-common/blob/main/values.yaml). The librarium-specific knobs:
+
+### Image
+
+| Key | Default | Notes |
+|---|---|---|
+| `image.repository` | `ghcr.io/fireball1725/librarium-api` | |
+| `image.tag` | `latest` | Pin in production. |
+| `image.pullPolicy` | `IfNotPresent` | |
+
+### Storage
+
+Two PVCs are created by default:
+
+| Key | Default | Holds |
+|---|---|---|
+| `persistence.covers` | 5Gi, RWO | Book cover images |
+| `persistence.media` | 100Gi, RWO | Uploaded ebooks and audiobooks |
+
+To point media at an existing NFS share, pre-create a matching `PersistentVolume` and set:
+
+```yaml
+persistence:
+  media:
+    existingClaim: librarium-media-nfs
+```
+
+Or switch to ReadWriteMany on an RWX-capable class and drop the Recreate strategy to run multiple replicas:
+
+```yaml
+controller:
+  replicas: 2
+  strategy: RollingUpdate
+
+persistence:
+  media:
+    accessMode: ReadWriteMany
+    storageClass: nfs
+```
+
+### Non-sensitive config (ConfigMap)
+
+Everything under `configmap.config.data` is rendered as a ConfigMap and loaded via `envFrom`:
+
+```yaml
+configmap:
+  config:
+    data:
+      LOG_LEVEL: info
+      EBOOK_STORAGE_PATH: /data/media/ebooks
+      AUDIOBOOK_STORAGE_PATH: /data/media/audiobooks
+      EBOOK_PATH_TEMPLATE: "{title}"
+      AUDIOBOOK_PATH_TEMPLATE: "{title}"
+      JWT_ACCESS_TTL: 15m
+      JWT_REFRESH_TTL: 168h
+      REGISTRATION_ENABLED: "true"
+```
+
+Change a value and `helm upgrade` — you'll get a new ConfigMap hash and the Deployment will roll. (Or restart manually: `kubectl rollout restart deploy/librarium-api`.)
+
+### Secrets
+
+The api needs exactly one secret value: `JWT_SECRET` (used to sign access and refresh tokens). `DATABASE_URL` is handled separately — CloudNativePG generates it into the `<postgres.clusterName>-app` secret (key: `uri`) and the chart's default `env.DATABASE_URL` reads it from there via `valueFrom`.
+
+You have two equally supported ways to provide `JWT_SECRET`. Pick one.
+
+#### Path A — inline value (simple; good for local tests and CI)
+
+Let the chart render a `Secret` named after the release and wire it into the pod via `envFrom`:
+
+```yaml
+secret:
+  JWT_SECRET: "<openssl rand -base64 48>"
+```
+
+Or at install time:
+
+```bash
+helm install librarium . --namespace librarium \
+  --set secret.JWT_SECRET="$(openssl rand -base64 48)"
+```
+
+Helm owns the Secret and removes it on `helm uninstall`.
+
+#### Path B — externally-managed Secret (recommended for GitOps)
+
+Commit a SealedSecret / ExternalSecret / SOPS-encrypted Secret into your repo, then point the chart at it:
+
+```yaml
+secret: {}   # leave empty so the chart does NOT render its own Secret
+
+env:
+  JWT_SECRET:
+    valueFrom:
+      secretKeyRef:
+        name: librarium-api-jwt   # your Secret
+        key: JWT_SECRET
+```
+
+Helm never sees the plaintext value, and the Secret's lifecycle is decoupled from the release (it survives `helm uninstall`).
+
+<details>
+<summary>Example: create a SealedSecret</summary>
+
+```bash
+kubectl create secret generic librarium-api-jwt \
+  --namespace librarium \
+  --from-literal=JWT_SECRET="$(openssl rand -base64 48)" \
+  --dry-run=client -o yaml \
+| kubeseal --scope strict -o yaml > sealed-secret-jwt.yaml
+```
+
+Apply `sealed-secret-jwt.yaml` into the namespace (or bundle it into an umbrella chart alongside this one).
+</details>
+
+#### What if neither is set?
+
+The chart validates at render time. `helm install` / `helm template` fails with a clear error if `JWT_SECRET` is missing from both paths, and also if `secret.JWT_SECRET` is still the literal placeholder `CHANGE_ME`.
+
+### Postgres (CloudNativePG)
+
+| Key | Default | Notes |
+|---|---|---|
+| `postgres.create` | `true` | Render a CNPG `Cluster` CR. Set `false` to use an external DB. |
+| `postgres.clusterName` | `librarium-db` | Determines the auto-generated secret name (`<clusterName>-app`). |
+| `postgres.instances` | `1` | Bump to 3 for HA. |
+| `postgres.database` | `librarium` | |
+| `postgres.owner` | `librarium` | DB role that owns the database. |
+| `postgres.storage.size` | `10Gi` | CNPG's own PVC size. |
+| `postgres.storage.storageClass` | *(unset)* | Uses cluster default. |
+| `postgres.imageName` | *(unset)* | Leave blank for CNPG's default. |
+| `postgres.extraSpec` | `{}` | Merged into the Cluster `spec:` verbatim (backup, resources, monitoring, etc.). |
+
+Advanced CNPG example — nightly backups to S3-compatible storage:
+
+```yaml
+postgres:
+  extraSpec:
+    backup:
+      barmanObjectStore:
+        destinationPath: s3://my-bucket/librarium
+        endpointURL: https://s3.example.com
+        s3Credentials:
+          accessKeyId:
+            name: s3-creds
+            key: ACCESS_KEY_ID
+          secretAccessKey:
+            name: s3-creds
+            key: SECRET_ACCESS_KEY
+      retentionPolicy: "30d"
+```
+
+### External Postgres
+
+Skip CNPG and point at your own DB:
+
+```yaml
+postgres:
+  create: false
+
+env:
+  DATABASE_URL: "postgres://user:pass@db.example.com:5432/librarium?sslmode=require"
+```
+
+(Override `env.DATABASE_URL` entirely — the default uses `valueFrom` to read from CNPG's generated secret.)
+
+### Ingress
+
+Disabled by default. Enable and point at your controller:
+
+```yaml
+ingress:
+  main:
+    enabled: true
+    ingressClassName: nginx
+    hosts:
+      - host: librarium-api.example.com
+        paths:
+          - path: /
+            pathType: Prefix
+    tls:
+      - secretName: librarium-api-tls
+        hosts: [librarium-api.example.com]
+```
+
+## Chart vs. raw manifests
+
+The raw manifests under [`../kubernetes/`](../kubernetes/) are equivalent for a simple deployment. Use this chart when you want templating, reusable values across environments, or the CNPG integration.

--- a/deploy/helm/librarium-api/templates/NOTES.txt
+++ b/deploy/helm/librarium-api/templates/NOTES.txt
@@ -1,0 +1,34 @@
+Thanks for installing librarium-api.
+
+Release:   {{ .Release.Name }}
+Namespace: {{ .Release.Namespace }}
+Image:     {{ .Values.image.repository }}:{{ .Values.image.tag }}
+
+{{- if .Values.secret }}
+JWT_SECRET: inline (managed by this Helm release).
+{{- else }}
+JWT_SECRET: external (expected via env.JWT_SECRET.valueFrom).
+{{- end }}
+
+{{- if .Values.postgres.create }}
+
+Postgres (CloudNativePG) is managed by this release:
+  Cluster:  {{ .Values.postgres.clusterName }}
+  Database: {{ .Values.postgres.database }}
+
+Check status:
+  kubectl -n {{ .Release.Namespace }} get cluster.postgresql.cnpg.io {{ .Values.postgres.clusterName }}
+  kubectl -n {{ .Release.Namespace }} get pods -l cnpg.io/cluster={{ .Values.postgres.clusterName }}
+
+The api reads DATABASE_URL from the auto-generated secret
+"{{ .Values.postgres.clusterName }}-app" (key: uri).
+{{- else }}
+
+Postgres is NOT managed by this release. Make sure env.DATABASE_URL is pointing
+at an external Postgres that already exists.
+{{- end }}
+
+Access the api:
+  kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "common.names.fullname" . }} 8080:8080
+
+Then open http://localhost:8080/api/v1/version

--- a/deploy/helm/librarium-api/templates/_validate.tpl
+++ b/deploy/helm/librarium-api/templates/_validate.tpl
@@ -1,0 +1,25 @@
+{{/*
+Chart-wide validation. Runs before any resource is rendered so that
+misconfigurations fail at `helm install`/`helm template` time rather than at
+pod startup.
+
+Two supported paths for JWT_SECRET:
+  A. inline    — set .Values.secret.JWT_SECRET
+  B. external  — leave .Values.secret empty and set .Values.env.JWT_SECRET
+                 (typically a secretKeyRef into a SealedSecret/ExternalSecret).
+*/}}
+{{- define "librarium-api.validate" -}}
+  {{- $secretMap := default dict .Values.secret -}}
+  {{- $envMap := default dict .Values.env -}}
+  {{- $inlineVal := get $secretMap "JWT_SECRET" -}}
+  {{- $hasInline := ne (toString $inlineVal) "" -}}
+  {{- $hasExternal := hasKey $envMap "JWT_SECRET" -}}
+
+  {{- if not (or $hasInline $hasExternal) -}}
+    {{- fail (printf "\nlibrarium-api: JWT_SECRET is not configured.\n\nChoose one of:\n  (A) inline:   set `secret.JWT_SECRET` to a generated value\n  (B) external: leave `secret: {}` and set `env.JWT_SECRET.valueFrom.secretKeyRef`\n                (pointing at a SealedSecret/ExternalSecret/SOPS Secret)\n\nGenerate a value with:  openssl rand -base64 48\nSee the chart README §Secrets for details.\n") -}}
+  {{- end -}}
+
+  {{- if eq (toString $inlineVal) "CHANGE_ME" -}}
+    {{- fail "\nlibrarium-api: `secret.JWT_SECRET` is still set to the placeholder 'CHANGE_ME'.\nGenerate a real value:  openssl rand -base64 48\n" -}}
+  {{- end -}}
+{{- end -}}

--- a/deploy/helm/librarium-api/templates/cnpg-cluster.yaml
+++ b/deploy/helm/librarium-api/templates/cnpg-cluster.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.postgres.create -}}
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: {{ .Values.postgres.clusterName }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+spec:
+  instances: {{ .Values.postgres.instances | default 1 }}
+  {{- with .Values.postgres.imageName }}
+  imageName: {{ . | quote }}
+  {{- end }}
+  bootstrap:
+    initdb:
+      database: {{ .Values.postgres.database | quote }}
+      owner: {{ .Values.postgres.owner | quote }}
+  storage:
+    size: {{ .Values.postgres.storage.size | quote }}
+    {{- with .Values.postgres.storage.storageClass }}
+    storageClass: {{ . | quote }}
+    {{- end }}
+  {{- with .Values.postgres.extraSpec }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/librarium-api/templates/common.yaml
+++ b/deploy/helm/librarium-api/templates/common.yaml
@@ -1,0 +1,2 @@
+{{- include "librarium-api.validate" . -}}
+{{- include "common.all" . -}}

--- a/deploy/helm/librarium-api/values.yaml
+++ b/deploy/helm/librarium-api/values.yaml
@@ -1,0 +1,212 @@
+# Default values for librarium-api.
+#
+# This chart uses firelabs-helm-common as a library chart, so most keys under
+# the top level (image, service, ingress, persistence, env, envFrom, secret,
+# configmap, probes, ...) are interpreted by the common chart. See:
+#   https://github.com/FireBall1725/firelabs-helm-common
+
+global:
+  # Keep release names predictable (otherwise common prepends the release name).
+  fullnameOverride: librarium-api
+
+image:
+  repository: ghcr.io/fireball1725/librarium-api
+  # Pin to a release in production. `latest` is fine for trying the chart.
+  tag: latest
+  pullPolicy: IfNotPresent
+
+# Cover and media PVCs are ReadWriteOnce by default, so we can only run one pod.
+# If you switch `persistence.media` to RWX (NFS, CephFS, Longhorn RWX), bump this
+# and drop the Recreate strategy below.
+controller:
+  replicas: 1
+  strategy: Recreate
+
+# -----------------------------------------------------------------------------
+# HTTP service
+# -----------------------------------------------------------------------------
+service:
+  main:
+    enabled: true
+    type: ClusterIP
+    ports:
+      http:
+        enabled: true
+        primary: true
+        port: 8080
+
+# -----------------------------------------------------------------------------
+# Ingress (disabled by default - most homelabs wire this up separately)
+# -----------------------------------------------------------------------------
+ingress:
+  main:
+    enabled: false
+    # ingressClassName: nginx
+    # annotations: {}
+    # hosts:
+    #   - host: librarium-api.example.com
+    #     paths:
+    #       - path: /
+    #         pathType: Prefix
+    # tls:
+    #   - secretName: librarium-api-tls
+    #     hosts: [librarium-api.example.com]
+
+# -----------------------------------------------------------------------------
+# Health probes - point at the api version endpoint
+# -----------------------------------------------------------------------------
+probes:
+  liveness:
+    enabled: true
+    custom: true
+    spec:
+      httpGet:
+        path: /api/v1/version
+        port: http
+      initialDelaySeconds: 30
+      periodSeconds: 30
+  readiness:
+    enabled: true
+    custom: true
+    spec:
+      httpGet:
+        path: /api/v1/version
+        port: http
+      initialDelaySeconds: 5
+      periodSeconds: 10
+  startup:
+    enabled: false
+
+# -----------------------------------------------------------------------------
+# Storage
+#   covers - small, server-managed, fast local block is ideal
+#   media  - ebooks/audiobooks, can grow large; point at NAS/NFS via
+#            `existingClaim` or switch accessMode to ReadWriteMany on an
+#            RWX-capable StorageClass
+# -----------------------------------------------------------------------------
+persistence:
+  covers:
+    enabled: true
+    type: pvc
+    mountPath: /data/covers
+    accessMode: ReadWriteOnce
+    size: 5Gi
+    # storageClass: ""
+    # existingClaim: ""
+  media:
+    enabled: true
+    type: pvc
+    mountPath: /data/media
+    accessMode: ReadWriteOnce
+    size: 100Gi
+    # storageClass: ""
+    # existingClaim: librarium-media-nfs   # bind to a pre-created NFS PV
+
+# -----------------------------------------------------------------------------
+# Non-sensitive configuration - rendered as a ConfigMap and mounted via envFrom
+# -----------------------------------------------------------------------------
+configmap:
+  config:
+    enabled: true
+    data:
+      LOG_LEVEL: info
+      COVER_STORAGE_PATH: /data/covers
+      EBOOK_STORAGE_PATH: /data/media/ebooks
+      AUDIOBOOK_STORAGE_PATH: /data/media/audiobooks
+      EBOOK_PATH_TEMPLATE: "{title}"
+      AUDIOBOOK_PATH_TEMPLATE: "{title}"
+      JWT_ACCESS_TTL: 15m
+      JWT_REFRESH_TTL: 168h
+      REGISTRATION_ENABLED: "true"
+
+# -----------------------------------------------------------------------------
+# Sensitive configuration: JWT_SECRET
+#
+# The api signs access/refresh tokens with JWT_SECRET. You have two equally
+# supported ways to provide it — pick one.
+#
+# Path A — inline (simple): let Helm render the Secret from values.
+#
+#   secret:
+#     JWT_SECRET: "<openssl rand -base64 48>"
+#
+#   The common chart renders a Secret named after the release and auto-wires
+#   it into the container via envFrom. Helm owns the Secret lifecycle.
+#
+# Path B — externally-managed (recommended for GitOps): bring your own
+# Secret (SealedSecret, ExternalSecret, SOPS-decrypted, ...) and reference
+# it here.
+#
+#   secret: {}                          # leave empty so the chart skips it
+#   env:
+#     JWT_SECRET:
+#       valueFrom:
+#         secretKeyRef:
+#           name: librarium-api-jwt     # your Secret
+#           key: JWT_SECRET
+#
+#   Plaintext never appears in Helm values. The Secret outlives the release.
+#
+# The chart validates at render time and fails the install if JWT_SECRET is
+# missing (or still set to the literal placeholder "CHANGE_ME").
+#
+# Generate a strong value with:   openssl rand -base64 48
+# -----------------------------------------------------------------------------
+secret: {}
+
+# Pull every ConfigMap key into the container as env vars. The common chart
+# already attaches the release Secret to envFrom automatically when `secret`
+# above is non-empty, so we only add the ConfigMap here.
+envFrom:
+  - configMapRef:
+      name: librarium-api-config
+
+# DATABASE_URL comes from the CNPG-generated <clusterName>-app secret. CNPG
+# writes the full DSN to the `uri` key. If you disable `postgres.create` and
+# bring your own Postgres, set `env.DATABASE_URL` to a literal value instead.
+#
+# If you use Path B above for JWT_SECRET, add its `valueFrom` block here too.
+env:
+  DATABASE_URL:
+    valueFrom:
+      secretKeyRef:
+        name: librarium-db-app
+        key: uri
+
+# -----------------------------------------------------------------------------
+# Resources
+# -----------------------------------------------------------------------------
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    memory: 512Mi
+
+# -----------------------------------------------------------------------------
+# CloudNativePG-managed Postgres cluster
+#
+# When `postgres.create=true` (default), this chart renders a
+# postgresql.cnpg.io/v1 Cluster CR. CNPG will:
+#   - provision Postgres with the given instance count and storage
+#   - create a database + role named after `postgres.database` / `postgres.owner`
+#   - generate a Secret named `<clusterName>-app` with a `uri` key the api reads
+#
+# Requires the CloudNativePG operator to be installed in the cluster:
+#   https://cloudnative-pg.io/documentation/current/installation_upgrade/
+#
+# To use an external Postgres instead, set `postgres.create=false` and override
+# `env.DATABASE_URL` with a literal DSN.
+# -----------------------------------------------------------------------------
+postgres:
+  create: true
+  clusterName: librarium-db
+  instances: 1
+  imageName: ""   # leave blank to let CNPG pick its default
+  database: librarium
+  owner: librarium
+  storage:
+    size: 10Gi
+    # storageClass: ""
+  # Extra Cluster spec fields merged verbatim into spec: (backup config, etc.)
+  extraSpec: {}


### PR DESCRIPTION
## Summary

- The Helm chart directory was silently gitignored by the `librarium-api` build-binary rule. Anchor that rule (`/librarium-api`) and bring the chart into version control.
- Reshape `JWT_SECRET` handling so GitOps users (SealedSecret / ExternalSecret / SOPS) are a first-class option, not a footnote.
- Fail `helm install`/`helm template` at render time when JWT_SECRET is missing or still set to the `CHANGE_ME` placeholder.

## Why

During a homelab GitOps deploy (`helm template` dry-run under ArgoCD), the default `secret.JWT_SECRET: "CHANGE_ME"` collided with the pattern of bringing an external SealedSecret — the chart rendered its own `Secret/librarium-api` with placeholder data *and* auto-attached it via `envFrom`, which fought the `env.JWT_SECRET.valueFrom` override. The "bring your own Secret" recipe was present in the README but buried, and nothing prevented the placeholder from shipping to prod.

## What changed

### Chart tracked for the first time

The repo `.gitignore` had a bare `librarium-api` pattern (intended for `go build` output) that greedy-matched `deploy/helm/librarium-api/` — so no chart file had ever been committed. Anchor the rule to the repo root and add the chart files (minus the vendored `charts/common-*.tgz`, which `helm dependency update` fetches via `Chart.lock`).

### Two equally-documented paths for `JWT_SECRET`

**Path A — inline** (simple; local/CI):

```yaml
secret:
  JWT_SECRET: "<openssl rand -base64 48>"
```

Chart renders a `Secret/<fullname>` and auto-wires it via `envFrom`. Helm owns the lifecycle.

**Path B — externally-managed** (recommended for GitOps):

```yaml
secret: {}   # chart renders no Secret
env:
  JWT_SECRET:
    valueFrom:
      secretKeyRef:
        name: librarium-api-jwt
        key: JWT_SECRET
```

Plaintext never enters Helm values; Secret lifecycle decoupled from the release.

### Render-time validation (`templates/_validate.tpl`)

Fails the install with a clear, actionable message if:
- neither `secret.JWT_SECRET` nor `env.JWT_SECRET` is set, or
- `secret.JWT_SECRET` is still the placeholder `"CHANGE_ME"`.

### Docs

- `values.yaml` — comments describe both paths symmetrically; default is now `secret: {}`.
- `README.md` — §Secrets rewritten with side-by-side A/B subsections and a worked SealedSecret example.
- `NOTES.txt` — reports which path was used; drops the stale `CHANGE_ME` branch (validation now enforces it).

## Test plan

- [x] `helm lint .` — clean under both Path A and Path B values
- [x] `helm template` Path A (`--set secret.JWT_SECRET=…`) — renders `Secret/librarium-api` with stringData; Deployment `envFrom` includes `- secretRef: {name: librarium-api}`
- [x] `helm template` Path B (`secret: {}` + `env.JWT_SECRET.valueFrom`) — **no** Secret rendered; Deployment has `env: - name: JWT_SECRET; valueFrom: secretKeyRef: …`; `envFrom` has only the ConfigMap
- [x] `helm template` misconfigured (no secret, no env entry) — fails with the multi-line "choose one of" message
- [x] `helm template --set secret.JWT_SECRET=CHANGE_ME` — fails with the "placeholder 'CHANGE_ME'" message
- [ ] Merge + bump `librarium-api` chart/values in the GitOps umbrella chart to drop the `secret: {}` workaround in favour of the now-default shape

## Notes

No application code changes — chart only. Version bump deferred until a user-facing change ships.