### PR TITLE
fix: point probes and docs at /health

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ docker compose up -d --build
 The API listens on `:8080`. A healthy response:
 
 ```bash
-curl http://localhost:8080/api/v1/version
+curl http://localhost:8080/health
 ```
 
 API documentation is served at `http://localhost:8080/swagger/index.html` once the container is up.

--- a/deploy/helm/librarium-api/README.md
+++ b/deploy/helm/librarium-api/README.md
@@ -30,7 +30,7 @@ Once the pod is ready, port-forward or set up ingress:
 
 ```bash
 kubectl -n librarium port-forward svc/librarium-api 8080:8080
-# then open http://localhost:8080/api/v1/version
+# then open http://localhost:8080/health
 ```
 
 ## Upgrade

--- a/deploy/helm/librarium-api/templates/NOTES.txt
+++ b/deploy/helm/librarium-api/templates/NOTES.txt
@@ -31,4 +31,4 @@ at an external Postgres that already exists.
 Access the api:
   kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "common.names.fullname" . }} 8080:8080
 
-Then open http://localhost:8080/api/v1/version
+Then open http://localhost:8080/health

--- a/deploy/helm/librarium-api/values.yaml
+++ b/deploy/helm/librarium-api/values.yaml
@@ -53,7 +53,7 @@ ingress:
     #     hosts: [librarium-api.example.com]
 
 # -----------------------------------------------------------------------------
-# Health probes - point at the api version endpoint
+# Health probes - hit the unauthenticated /health endpoint
 # -----------------------------------------------------------------------------
 probes:
   liveness:
@@ -61,7 +61,7 @@ probes:
     custom: true
     spec:
       httpGet:
-        path: /api/v1/version
+        path: /health
         port: http
       initialDelaySeconds: 30
       periodSeconds: 30
@@ -70,7 +70,7 @@ probes:
     custom: true
     spec:
       httpGet:
-        path: /api/v1/version
+        path: /health
         port: http
       initialDelaySeconds: 5
       periodSeconds: 10

--- a/deploy/kubernetes/40-api.yaml
+++ b/deploy/kubernetes/40-api.yaml
@@ -75,13 +75,13 @@ spec:
               mountPath: /data/media
           readinessProbe:
             httpGet:
-              path: /api/v1/version
+              path: /health
               port: http
             initialDelaySeconds: 5
             periodSeconds: 10
           livenessProbe:
             httpGet:
-              path: /api/v1/version
+              path: /health
               port: http
             initialDelaySeconds: 30
             periodSeconds: 30


### PR DESCRIPTION
## Summary

- Helm chart + raw Kubernetes manifest probes now hit `/health` (the path the binary actually serves) instead of `/api/v1/version` (which doesn't exist).
- Docs (top-level README, chart README, chart NOTES) updated to match.

## Why

`internal/api/router.go:133` registers `GET /health` only. There is no `/api/v1/version` route on the mux. On a homelab rollout of `librarium-api 26.4.0`, kubelet liveness probes 404'd the non-existent path and killed the pod on every cycle — CrashLoopBackOff despite the app being otherwise healthy (migrations ran, listener bound, river worker started).

Docker Compose doesn't run Kubernetes probes, which is why this shipped undetected.

## Options considered

1. **Chart-only: flip probes to `/health`** ← this PR
2. Add a `GET /api/v1/version` handler alongside `/health` (keeps both paths working, lets probes read a version-aware payload)

Going with (1) for now because `/health` already returns `{status, version, started_at}` — same payload we'd want from a version endpoint — and there's no in-tree consumer relying on `/api/v1/version`. If we later want the dedicated path, it's cheap to add.

## Files touched

- `deploy/helm/librarium-api/values.yaml` — liveness + readiness probe paths
- `deploy/kubernetes/40-api.yaml` — liveness + readiness probe paths
- `deploy/helm/librarium-api/templates/NOTES.txt` — post-install hint
- `deploy/helm/librarium-api/README.md` — install example
- `README.md` — quickstart curl

## Test plan

- [x] `helm lint` clean
- [x] `helm template` shows both probes rendered as `path: /health`
- [x] Already live-tested on the homelab via an equivalent patch in the wrapper chart (`homelab-applications@e9f2dd7`) — pod went 1/1 Running, zero restarts; `curl -sk https://librarium.k8s.firekatt.ca/health` returns `{"status":"ok","version":"26.4.0 ..."}`
- [ ] No version bump: chart-only, fine to ship with the next API release