### PR TITLE
fix(version): auto-compute dev version and drop timestamp from releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,31 +12,24 @@ on:
           - auto    # next revision in current YY.MM (rolls to .0 on month change)
           - major   # force YY.MM.0 from today's date
       dry-run:
-        description: "Compute the version but don't tag, push, or publish"
+        description: "Compute the version but don't tag or push"
         required: false
         default: false
         type: boolean
 
 permissions:
   contents: write
-  packages: write
 
 jobs:
   release:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
-      next_dev: ${{ steps.version.outputs.next_dev }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: actions/setup-go@v5
-        with:
-          go-version: "1.25"
-          cache: true
 
       - name: Configure git
         run: |
@@ -66,40 +59,15 @@ jobs:
           fi
 
           VERSION="${PREFIX}.${REV}"
-          NEXT_DEV="${PREFIX}.$((REV + 1))-dev"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "next_dev=$NEXT_DEV" >> "$GITHUB_OUTPUT"
           echo "Releasing version: $VERSION"
-          echo "Post-release dev bump: $NEXT_DEV"
 
-      - name: Update version.go (release)
-        run: |
-          set -euo pipefail
-          VERSION="${{ steps.version.outputs.version }}"
-          sed -i -E "s/^var Version = \".*\"/var Version = \"${VERSION}\"/" internal/version/version.go
-          grep -n "^var Version" internal/version/version.go
-
-      - name: Commit + tag release
+      # The version lives only in the git tag. version.go has no hardcoded
+      # string — dev builds compute "{YY}.{M}.DEV" at startup, and publish.yml
+      # injects the tagged version into release images via ldflags.
+      - name: Tag release
         if: ${{ inputs.dry-run == false }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          git add internal/version/version.go
-          git commit -m "release: ${VERSION}"
           git tag "v${VERSION}"
-
-      - name: Bump to next -dev
-        if: ${{ inputs.dry-run == false }}
-        run: |
-          NEXT_DEV="${{ steps.version.outputs.next_dev }}"
-          sed -i -E "s/^var Version = \".*\"/var Version = \"${NEXT_DEV}\"/" internal/version/version.go
-          git add internal/version/version.go
-          git commit -m "chore: bump to ${NEXT_DEV}"
-
-      # Push the tag first so publish.yml starts building the image immediately,
-      # then push the next-dev commit on main. Image build + GitHub release are
-      # handled by publish.yml on tag push.
-      - name: Push tag and commits
-        if: ${{ inputs.dry-run == false }}
-        run: |
-          git push origin "v${{ steps.version.outputs.version }}"
-          git push origin HEAD:main
+          git push origin "v${VERSION}"

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -8,15 +8,25 @@ import (
 	"time"
 )
 
-// Version is the current release. Format: YY.MM.revision (e.g. 26.4.0).
-// A "-dev" suffix marks local unshipped builds. Set via ldflags in production builds.
-var Version = "26.4.0"
+// Version is the current release, set at link time via ldflags for release
+// builds (e.g. "26.4.1"). When empty (local dev builds), it's auto-computed
+// from the current date as "{YY}.{M}.DEV" during package init. Format:
+// YY.MM.revision, not zero-padded.
+var Version = ""
 
 // StartTime is when this process started.
 var StartTime = time.Now()
 
 // BuildVersion is the human-readable combined string used in API responses
-// and the UI. Format: {version} {YYYY-MM-DD HH:MM ZONE}, e.g. 26.0.0-dev 2026-04-19 19:56 EDT.
-// The timezone comes from the $TZ env var in the container (falls back to UTC).
-// This lets you tell deployments apart at a glance without bumping the version.
-var BuildVersion = fmt.Sprintf("%s %s", Version, StartTime.Local().Format("2006-01-02 15:04 MST"))
+// and the UI. Release builds: "{YY.MM.rev}". Dev builds: the auto-computed
+// version plus a local timestamp so deployments are distinguishable at a
+// glance, e.g. "26.4.DEV 2026-04-19 19:56 EDT".
+var BuildVersion = buildVersion()
+
+func buildVersion() string {
+	if Version == "" {
+		Version = fmt.Sprintf("%d.%d.DEV", StartTime.Year()%100, int(StartTime.Month()))
+		return fmt.Sprintf("%s %s", Version, StartTime.Local().Format("2006-01-02 15:04 MST"))
+	}
+	return Version
+}


### PR DESCRIPTION
Closes #2.

## Summary

- Release builds now expose a clean version string in `/health` and the UI (e.g. `"26.4.1"`); the process start timestamp is no longer appended to shipped artifacts.
- Local dev builds auto-compute `{YY}.{M}.DEV` from the current date at startup (e.g. `26.4.DEV 2026-04-19 07:59 EDT`) and retain the timestamp so deployments are distinguishable at a glance.
- `internal/version/version.go` no longer hardcodes a version string, so there is nothing to bump by hand between releases. Rolling into a new month just starts producing `26.5.DEV ...` with zero source changes.
- `release.yml` is correspondingly simpler: no more sed-rewriting `version.go`, no `release:` commit, no `chore: bump to -dev` follow-up commit. The workflow now only computes the next revision from tag history and creates the tag at `HEAD`. `publish.yml` already injects the tagged version into the release image via the `VERSION` build-arg → ldflags, so nothing on the release side had to change.

## Behaviour

| Build path | `Version` | `BuildVersion` |
| --- | --- | --- |
| Local `docker compose up --build` | `26.4.DEV` | `26.4.DEV 2026-04-19 07:59 EDT` |
| Tagged release (`v26.4.1` → publish.yml) | `26.4.1` | `26.4.1` |

## Test plan

- [x] Local: `docker compose up -d --build api` in `local/`, hit `/health`, confirm `"version":"26.4.DEV 2026-04-19 07:59 EDT"`.
- [x] Release path: `docker build --build-arg VERSION=26.4.1 ...` + run, hit `/health`, confirm `"version":"26.4.1"` with no timestamp.
- [ ] Release workflow dry-run on GitHub Actions (`workflow_dispatch` with `dry-run: true`) to confirm the simplified version-compute step still emits the right tag.