### PR TITLE
Railway deploy support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ This project uses **`YY.MM.revision`** (e.g. `26.4.0`, `26.4.1`):
 
 Versions `0.1.0` → `0.13.0` predate this scheme. `26.4.0` is the first release cut under the new format and the first release of `librarium-api` as an independent repository.
 
+## [26.4.2] — Railway deploy support
+
+Deployment-infrastructure release: adds a first-class "run Librarium on Railway" path so self-hosters who'd rather pay $5/month than manage a VPS have an on-ramp.
+
+### Added
+
+- `railway.toml` at the repo root — Railway picks up the Dockerfile build, `/health` healthcheck, and restart policy without any extra dashboard config.
+- `deploy/railway/README.md` walkthrough covering the full three-service project (api + web + managed Postgres), custom domains, upgrades, and rollback.
+- README section under Deployment linking to the Railway guide alongside the existing Docker Compose and Kubernetes paths.
+
 ## [26.4.1] — AI-powered book suggestions
 
 End-to-end suggestions feature that recommends books to buy (not in the library) and books to read next (owned but unread). All AI access is opt-in at both the admin (data-category permissions) and user (master toggle) level — restrictive-wins.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,11 @@ Release history in [CHANGELOG.md](./CHANGELOG.md).
 
 ## Deployment
 
-Two supported paths for self-hosting. Both use the multi-arch images published to GHCR — no local build required.
+Three supported paths for self-hosting. Docker Compose and Kubernetes pull the multi-arch images published to GHCR; Railway builds from source on their platform.
+
+### Railway (managed, one-click-ish)
+
+Want Librarium running at `library.example.com` without managing a VPS? [`deploy/railway/`](./deploy/railway/) walks through a three-service Railway project (api + web + managed Postgres) for ~$5-10/month on the Hobby plan. The repo ships a `railway.toml` so Railway picks up the right build and healthcheck without extra config.
 
 ### Docker Compose (whole stack)
 

--- a/deploy/railway/README.md
+++ b/deploy/railway/README.md
@@ -1,0 +1,76 @@
+# Deploy Librarium on Railway
+
+Railway is a PaaS that handles Postgres provisioning, HTTPS, and custom domains for you — nice if you want Librarium running at `library.example.com` in under 10 minutes without managing a VPS. Floor is ~$5/month on the Hobby plan.
+
+> ⚠️ Not a pre-built "Deploy on Railway" template yet. Follow the manual steps below; the button will land once the template is published to the Railway marketplace.
+
+## What you'll end up with
+
+Three Railway services in one project:
+
+- **api** — this repo (`librarium-api`), running the Go binary
+- **web** — [`librarium-web`](https://github.com/FireBall1725/librarium-web), serving the React SPA through nginx and proxying `/api` back to the api service
+- **Postgres** — Railway's managed Postgres add-on
+
+There's no Meilisearch — the api falls back to Postgres full-text search when `MEILI_URL` is unset.
+
+## Prerequisites
+
+- A Railway account with a Hobby plan or higher (Trial works to try, but spins down and doesn't support custom domains).
+- A (custom) domain you control, if you want prettier URLs than `*.up.railway.app`.
+
+## Steps
+
+### 1. Create the project and Postgres
+
+1. From Railway's dashboard: **New Project → Empty Project**.
+2. Inside the new project: **+ New → Database → Add PostgreSQL**. Wait for it to provision.
+
+### 2. Deploy the api service
+
+1. **+ New → GitHub Repo → FireBall1725/librarium-api**.
+2. Railway auto-detects `railway.toml` in the repo root. The build uses the repo `Dockerfile`; healthcheck is `/health`.
+3. Open the service's **Variables** tab and set:
+   - `DATABASE_URL` = `${{Postgres.DATABASE_URL}}?sslmode=require` (click "Add Reference" and pick the Postgres plugin, then append `?sslmode=require`)
+   - `JWT_SECRET` = a long random string. Generate with `openssl rand -hex 32`.
+   - `REGISTRATION_ENABLED` = `false` if you want to lock down signups after creating the first admin (optional — default is `true`).
+4. Under **Settings → Networking**, click **Generate Domain**. Railway gives you a `*.up.railway.app` URL. Custom domains can be added here later.
+
+### 3. Deploy the web service
+
+1. **+ New → GitHub Repo → FireBall1725/librarium-web**.
+2. Again, Railway picks up `railway.toml` and uses the repo Dockerfile (multi-stage: Vite build → nginx).
+3. Set Variables:
+   - `API_UPSTREAM` = `${{api.RAILWAY_PRIVATE_DOMAIN}}` (reference the api service you just created)
+   - `API_UPSTREAM_PORT` = `8080`
+4. **Settings → Networking → Generate Domain** — this one is the URL you'll actually visit.
+
+### 4. First-run setup
+
+Open the web service's URL. You'll be redirected to `/setup`. Create the first admin account. Done.
+
+## Custom domain
+
+In either service's **Settings → Networking**, add your domain and copy the CNAME target Railway gives you into your DNS. Propagation usually takes <5 minutes. Railway provisions a Let's Encrypt cert automatically.
+
+## Upgrading
+
+Railway watches the tracked branch (default: `main`) and redeploys on push. If you want to pin a release tag instead, change the service's deployment branch to the tag in **Settings → Source**.
+
+## Cost expectation
+
+Hobby plan is $5/month *credit*; actual usage:
+
+- api service: idle ~0.05 vCPU / 100 MB — a few dollars a month at idle
+- web service: negligible — nginx serving a static bundle
+- Postgres plugin: ~$5/month for the 1 GB tier, which is plenty for a personal library
+
+Total: $5–10/month on the Hobby plan. Scales up as your library grows.
+
+## Rollback
+
+In Railway's service dashboard, each deploy has a **Redeploy** action. Pick any previous successful deploy to roll back.
+
+## Alternatives
+
+If Railway isn't for you, see [`deploy/docker-compose/`](../docker-compose/) for the reference self-hosted stack, or the Helm chart in [`deploy/helm/`](../helm/).

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,27 @@
+# Railway build/deploy config for librarium-api.
+#
+# Build: uses the repo Dockerfile (multi-stage: Go build → distroless).
+# The binary listens on :8080 and exposes /health for the platform probe.
+#
+# Required env vars on Railway:
+#   DATABASE_URL  — reference the provisioned Postgres plugin, e.g.
+#                   ${{Postgres.DATABASE_URL}}. Append ?sslmode=require
+#                   for Railway's managed Postgres.
+#   JWT_SECRET    — long random string. No default; the server won't boot
+#                   without one in production.
+#
+# Optional:
+#   LOG_LEVEL (default info)
+#   REGISTRATION_ENABLED (default true — set false to lock down new signups
+#                         after you've created the first admin via /setup)
+#   OAUTH_*, GOOGLE_BOOKS_API_KEY — see docs/deploy/railway.md
+
+[build]
+builder = "DOCKERFILE"
+dockerfilePath = "Dockerfile"
+
+[deploy]
+healthcheckPath = "/health"
+healthcheckTimeout = 30
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 10


### PR DESCRIPTION
## Summary
- `railway.toml` so Railway picks up the Dockerfile build + `/health` healthcheck with zero dashboard config
- `deploy/railway/README.md` — full walkthrough for a three-service project (api + web + managed Postgres) including custom domains, upgrades, and rollback
- README Deployment section links the Railway path alongside Docker Compose and Kubernetes

## Test plan
- [ ] Deploy `feat/railway-deploy` (both repos) to a Railway account end-to-end per the walkthrough
- [ ] Confirm `/health` returns 200 on the api service
- [ ] Confirm web service reaches api via `API_UPSTREAM=${{api.RAILWAY_PRIVATE_DOMAIN}}`
- [ ] Confirm Postgres migrations run on first boot
- [ ] Log in through the web UI and exercise one authenticated endpoint