### PR TITLE
feat(ai): steered suggestions

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -124,6 +124,86 @@ const docTemplate = `{
                 }
             }
         },
+        "/admin/connections/ai/ollama/models": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Proxies the configured Ollama host's /api/tags endpoint. Used by the provider-config UI to render a model dropdown instead of a free-text input. Returns 503 when the host is unreachable so the UI can fall back to the text input.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin",
+                    "ai"
+                ],
+                "summary": "List locally-pulled Ollama models (admin)",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_api_handlers.ollamaModelsResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                },
+                                "reachable": {
+                                    "type": "boolean"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/connections/ai/osaurus/models": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Proxies the configured Osaurus host's /v1/models endpoint (OpenAI shape). Used by the provider-config UI to render a model dropdown instead of a free-text input. Returns 503 when the host is unreachable so the UI can fall back to the text input.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin",
+                    "ai"
+                ],
+                "summary": "List models available on the configured Osaurus host (admin)",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_api_handlers.osaurusModelsResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                },
+                                "reachable": {
+                                    "type": "boolean"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/admin/connections/ai/permissions": {
             "get": {
                 "security": [
@@ -9196,6 +9276,53 @@ const docTemplate = `{
                 }
             }
         },
+        "/me/series": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns series from every library the caller can access, filtered by an optional case-insensitive substring in ` + "`" + `q` + "`" + `. Results are capped at 20.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "me"
+                ],
+                "summary": "Search series across my libraries",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Name substring",
+                        "name": "q",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/internal_api_handlers.MeSeriesResult"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/me/suggestions": {
             "get": {
                 "security": [
@@ -9203,7 +9330,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Returns the current AI-generated recommendations for the caller. Filter by type (buy | read_next) and status.",
+                "description": "Returns the current AI-generated recommendations for the caller. Filter by type (buy | read_next) and status, or scope to a specific run via ` + "`" + `run_id` + "`" + `. When ` + "`" + `run_id` + "`" + ` is set the status filter is ignored — the scoped view returns every suggestion that run produced.",
                 "produces": [
                     "application/json"
                 ],
@@ -9224,6 +9351,12 @@ const docTemplate = `{
                         "description": "Filter by status: new | dismissed | interested | added_to_library",
                         "name": "status",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Scope to a specific run ID",
+                        "name": "run_id",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -9233,6 +9366,28 @@ const docTemplate = `{
                             "type": "array",
                             "items": {
                                 "$ref": "#/definitions/internal_api_handlers.SuggestionView"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
                             }
                         }
                     }
@@ -9272,7 +9427,10 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Enqueues a background job to regenerate suggestions. Rate-limited by admin config.",
+                "description": "Enqueues a background job to regenerate suggestions. Accepts an optional ` + "`" + `steering` + "`" + ` body to bias this run toward specific authors, series, genres, tags, and/or free-form notes. Rate-limited by admin config.",
+                "consumes": [
+                    "application/json"
+                ],
                 "produces": [
                     "application/json"
                 ],
@@ -9281,9 +9439,35 @@ const docTemplate = `{
                     "ai"
                 ],
                 "summary": "Trigger a suggestions run for the caller",
+                "parameters": [
+                    {
+                        "description": "Optional steering payload",
+                        "name": "body",
+                        "in": "body",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "steering": {
+                                    "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_models.SuggestionSteering"
+                                }
+                            }
+                        }
+                    }
+                ],
                 "responses": {
                     "202": {
                         "description": "Accepted"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
                     },
                     "429": {
                         "description": "Too Many Requests",
@@ -9504,6 +9688,53 @@ const docTemplate = `{
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/me/tags": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns tags from every library the caller can access, filtered by an optional case-insensitive substring in ` + "`" + `q` + "`" + `. Tags are per-library; the response marks names as ambiguous when the same name exists in multiple libraries so the UI can disambiguate. Results are capped at 20.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "me"
+                ],
+                "summary": "Search tags across my libraries",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Name substring",
+                        "name": "q",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/internal_api_handlers.MeTagResult"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
                         "schema": {
                             "type": "object",
                             "properties": {
@@ -10074,6 +10305,46 @@ const docTemplate = `{
         }
     },
     "definitions": {
+        "github_com_fireball1725_librarium-api_internal_ai.OllamaModel": {
+            "type": "object",
+            "properties": {
+                "digest": {
+                    "type": "string"
+                },
+                "family": {
+                    "type": "string"
+                },
+                "modified": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "parameter_size": {
+                    "type": "string"
+                },
+                "quantization": {
+                    "type": "string"
+                },
+                "size": {
+                    "type": "integer"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_ai.OsaurusModel": {
+            "type": "object",
+            "properties": {
+                "created": {
+                    "type": "integer"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "owned_by": {
+                    "type": "string"
+                }
+            }
+        },
         "github_com_fireball1725_librarium-api_internal_models.EnrichmentBatch": {
             "type": "object",
             "properties": {
@@ -10342,6 +10613,38 @@ const docTemplate = `{
                 },
                 "skip_duplicates": {
                     "type": "boolean"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_models.SuggestionSteering": {
+            "type": "object",
+            "properties": {
+                "author_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "genre_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "notes": {
+                    "type": "string"
+                },
+                "series_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "tag_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         },
@@ -10788,13 +11091,82 @@ const docTemplate = `{
                 }
             }
         },
+        "internal_api_handlers.MeSeriesResult": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "library_id": {
+                    "type": "string"
+                },
+                "library_name": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api_handlers.MeTagResult": {
+            "type": "object",
+            "properties": {
+                "ambiguous": {
+                    "description": "Ambiguous is true when another accessible library has a tag with the\nsame (case-insensitive) name. The client appends \" · \u003clibrary\u003e\" in\nthat case.",
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "library_id": {
+                    "type": "string"
+                },
+                "library_name": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api_handlers.NamedRef": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api_handlers.NamedTagRef": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "library_id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
         "internal_api_handlers.QuotaView": {
             "type": "object",
             "properties": {
+                "available": {
+                    "type": "boolean"
+                },
                 "limit": {
                     "type": "integer"
                 },
                 "resets_at": {
+                    "type": "string"
+                },
+                "unavailable_reason": {
                     "type": "string"
                 },
                 "unlimited": {
@@ -10832,6 +11204,9 @@ const docTemplate = `{
                 "status": {
                     "type": "string"
                 },
+                "steering": {
+                    "$ref": "#/definitions/internal_api_handlers.SteeringView"
+                },
                 "tokens_in": {
                     "type": "integer"
                 },
@@ -10843,6 +11218,38 @@ const docTemplate = `{
                 },
                 "user_id": {
                     "type": "string"
+                }
+            }
+        },
+        "internal_api_handlers.SteeringView": {
+            "type": "object",
+            "properties": {
+                "authors": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/internal_api_handlers.NamedRef"
+                    }
+                },
+                "genres": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/internal_api_handlers.NamedRef"
+                    }
+                },
+                "notes": {
+                    "type": "string"
+                },
+                "series": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/internal_api_handlers.NamedRef"
+                    }
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/internal_api_handlers.NamedTagRef"
+                    }
                 }
             }
         },
@@ -10884,6 +11291,28 @@ const docTemplate = `{
                 },
                 "type": {
                     "type": "string"
+                }
+            }
+        },
+        "internal_api_handlers.ollamaModelsResponse": {
+            "type": "object",
+            "properties": {
+                "models": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_ai.OllamaModel"
+                    }
+                }
+            }
+        },
+        "internal_api_handlers.osaurusModelsResponse": {
+            "type": "object",
+            "properties": {
+                "models": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_ai.OsaurusModel"
+                    }
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -118,6 +118,86 @@
                 }
             }
         },
+        "/admin/connections/ai/ollama/models": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Proxies the configured Ollama host's /api/tags endpoint. Used by the provider-config UI to render a model dropdown instead of a free-text input. Returns 503 when the host is unreachable so the UI can fall back to the text input.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin",
+                    "ai"
+                ],
+                "summary": "List locally-pulled Ollama models (admin)",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_api_handlers.ollamaModelsResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                },
+                                "reachable": {
+                                    "type": "boolean"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/connections/ai/osaurus/models": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Proxies the configured Osaurus host's /v1/models endpoint (OpenAI shape). Used by the provider-config UI to render a model dropdown instead of a free-text input. Returns 503 when the host is unreachable so the UI can fall back to the text input.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin",
+                    "ai"
+                ],
+                "summary": "List models available on the configured Osaurus host (admin)",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_api_handlers.osaurusModelsResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                },
+                                "reachable": {
+                                    "type": "boolean"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/admin/connections/ai/permissions": {
             "get": {
                 "security": [
@@ -9190,6 +9270,53 @@
                 }
             }
         },
+        "/me/series": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns series from every library the caller can access, filtered by an optional case-insensitive substring in `q`. Results are capped at 20.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "me"
+                ],
+                "summary": "Search series across my libraries",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Name substring",
+                        "name": "q",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/internal_api_handlers.MeSeriesResult"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/me/suggestions": {
             "get": {
                 "security": [
@@ -9197,7 +9324,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Returns the current AI-generated recommendations for the caller. Filter by type (buy | read_next) and status.",
+                "description": "Returns the current AI-generated recommendations for the caller. Filter by type (buy | read_next) and status, or scope to a specific run via `run_id`. When `run_id` is set the status filter is ignored — the scoped view returns every suggestion that run produced.",
                 "produces": [
                     "application/json"
                 ],
@@ -9218,6 +9345,12 @@
                         "description": "Filter by status: new | dismissed | interested | added_to_library",
                         "name": "status",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Scope to a specific run ID",
+                        "name": "run_id",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -9227,6 +9360,28 @@
                             "type": "array",
                             "items": {
                                 "$ref": "#/definitions/internal_api_handlers.SuggestionView"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
                             }
                         }
                     }
@@ -9266,7 +9421,10 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Enqueues a background job to regenerate suggestions. Rate-limited by admin config.",
+                "description": "Enqueues a background job to regenerate suggestions. Accepts an optional `steering` body to bias this run toward specific authors, series, genres, tags, and/or free-form notes. Rate-limited by admin config.",
+                "consumes": [
+                    "application/json"
+                ],
                 "produces": [
                     "application/json"
                 ],
@@ -9275,9 +9433,35 @@
                     "ai"
                 ],
                 "summary": "Trigger a suggestions run for the caller",
+                "parameters": [
+                    {
+                        "description": "Optional steering payload",
+                        "name": "body",
+                        "in": "body",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "steering": {
+                                    "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_models.SuggestionSteering"
+                                }
+                            }
+                        }
+                    }
+                ],
                 "responses": {
                     "202": {
                         "description": "Accepted"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
                     },
                     "429": {
                         "description": "Too Many Requests",
@@ -9498,6 +9682,53 @@
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/me/tags": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns tags from every library the caller can access, filtered by an optional case-insensitive substring in `q`. Tags are per-library; the response marks names as ambiguous when the same name exists in multiple libraries so the UI can disambiguate. Results are capped at 20.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "me"
+                ],
+                "summary": "Search tags across my libraries",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Name substring",
+                        "name": "q",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/internal_api_handlers.MeTagResult"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
                         "schema": {
                             "type": "object",
                             "properties": {
@@ -10068,6 +10299,46 @@
         }
     },
     "definitions": {
+        "github_com_fireball1725_librarium-api_internal_ai.OllamaModel": {
+            "type": "object",
+            "properties": {
+                "digest": {
+                    "type": "string"
+                },
+                "family": {
+                    "type": "string"
+                },
+                "modified": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "parameter_size": {
+                    "type": "string"
+                },
+                "quantization": {
+                    "type": "string"
+                },
+                "size": {
+                    "type": "integer"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_ai.OsaurusModel": {
+            "type": "object",
+            "properties": {
+                "created": {
+                    "type": "integer"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "owned_by": {
+                    "type": "string"
+                }
+            }
+        },
         "github_com_fireball1725_librarium-api_internal_models.EnrichmentBatch": {
             "type": "object",
             "properties": {
@@ -10336,6 +10607,38 @@
                 },
                 "skip_duplicates": {
                     "type": "boolean"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_models.SuggestionSteering": {
+            "type": "object",
+            "properties": {
+                "author_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "genre_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "notes": {
+                    "type": "string"
+                },
+                "series_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "tag_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         },
@@ -10782,13 +11085,82 @@
                 }
             }
         },
+        "internal_api_handlers.MeSeriesResult": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "library_id": {
+                    "type": "string"
+                },
+                "library_name": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api_handlers.MeTagResult": {
+            "type": "object",
+            "properties": {
+                "ambiguous": {
+                    "description": "Ambiguous is true when another accessible library has a tag with the\nsame (case-insensitive) name. The client appends \" · \u003clibrary\u003e\" in\nthat case.",
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "library_id": {
+                    "type": "string"
+                },
+                "library_name": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api_handlers.NamedRef": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api_handlers.NamedTagRef": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "library_id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
         "internal_api_handlers.QuotaView": {
             "type": "object",
             "properties": {
+                "available": {
+                    "type": "boolean"
+                },
                 "limit": {
                     "type": "integer"
                 },
                 "resets_at": {
+                    "type": "string"
+                },
+                "unavailable_reason": {
                     "type": "string"
                 },
                 "unlimited": {
@@ -10826,6 +11198,9 @@
                 "status": {
                     "type": "string"
                 },
+                "steering": {
+                    "$ref": "#/definitions/internal_api_handlers.SteeringView"
+                },
                 "tokens_in": {
                     "type": "integer"
                 },
@@ -10837,6 +11212,38 @@
                 },
                 "user_id": {
                     "type": "string"
+                }
+            }
+        },
+        "internal_api_handlers.SteeringView": {
+            "type": "object",
+            "properties": {
+                "authors": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/internal_api_handlers.NamedRef"
+                    }
+                },
+                "genres": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/internal_api_handlers.NamedRef"
+                    }
+                },
+                "notes": {
+                    "type": "string"
+                },
+                "series": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/internal_api_handlers.NamedRef"
+                    }
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/internal_api_handlers.NamedTagRef"
+                    }
                 }
             }
         },
@@ -10878,6 +11285,28 @@
                 },
                 "type": {
                     "type": "string"
+                }
+            }
+        },
+        "internal_api_handlers.ollamaModelsResponse": {
+            "type": "object",
+            "properties": {
+                "models": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_ai.OllamaModel"
+                    }
+                }
+            }
+        },
+        "internal_api_handlers.osaurusModelsResponse": {
+            "type": "object",
+            "properties": {
+                "models": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_ai.OsaurusModel"
+                    }
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,5 +1,31 @@
 basePath: /api/v1
 definitions:
+  github_com_fireball1725_librarium-api_internal_ai.OllamaModel:
+    properties:
+      digest:
+        type: string
+      family:
+        type: string
+      modified:
+        type: string
+      name:
+        type: string
+      parameter_size:
+        type: string
+      quantization:
+        type: string
+      size:
+        type: integer
+    type: object
+  github_com_fireball1725_librarium-api_internal_ai.OsaurusModel:
+    properties:
+      created:
+        type: integer
+      id:
+        type: string
+      owned_by:
+        type: string
+    type: object
   github_com_fireball1725_librarium-api_internal_models.EnrichmentBatch:
     properties:
       book_ids:
@@ -188,6 +214,27 @@ definitions:
         type: object
       skip_duplicates:
         type: boolean
+    type: object
+  github_com_fireball1725_librarium-api_internal_models.SuggestionSteering:
+    properties:
+      author_ids:
+        items:
+          type: string
+        type: array
+      genre_ids:
+        items:
+          type: string
+        type: array
+      notes:
+        type: string
+      series_ids:
+        items:
+          type: string
+        type: array
+      tag_ids:
+        items:
+          type: string
+        type: array
     type: object
   github_com_fireball1725_librarium-api_internal_providers.BookResult:
     properties:
@@ -494,11 +541,59 @@ definitions:
       type:
         type: string
     type: object
+  internal_api_handlers.MeSeriesResult:
+    properties:
+      id:
+        type: string
+      library_id:
+        type: string
+      library_name:
+        type: string
+      name:
+        type: string
+    type: object
+  internal_api_handlers.MeTagResult:
+    properties:
+      ambiguous:
+        description: |-
+          Ambiguous is true when another accessible library has a tag with the
+          same (case-insensitive) name. The client appends " · <library>" in
+          that case.
+        type: boolean
+      id:
+        type: string
+      library_id:
+        type: string
+      library_name:
+        type: string
+      name:
+        type: string
+    type: object
+  internal_api_handlers.NamedRef:
+    properties:
+      id:
+        type: string
+      name:
+        type: string
+    type: object
+  internal_api_handlers.NamedTagRef:
+    properties:
+      id:
+        type: string
+      library_id:
+        type: string
+      name:
+        type: string
+    type: object
   internal_api_handlers.QuotaView:
     properties:
+      available:
+        type: boolean
       limit:
         type: integer
       resets_at:
+        type: string
+      unavailable_reason:
         type: string
       unlimited:
         type: boolean
@@ -523,6 +618,8 @@ definitions:
         type: string
       status:
         type: string
+      steering:
+        $ref: '#/definitions/internal_api_handlers.SteeringView'
       tokens_in:
         type: integer
       tokens_out:
@@ -531,6 +628,27 @@ definitions:
         type: string
       user_id:
         type: string
+    type: object
+  internal_api_handlers.SteeringView:
+    properties:
+      authors:
+        items:
+          $ref: '#/definitions/internal_api_handlers.NamedRef'
+        type: array
+      genres:
+        items:
+          $ref: '#/definitions/internal_api_handlers.NamedRef'
+        type: array
+      notes:
+        type: string
+      series:
+        items:
+          $ref: '#/definitions/internal_api_handlers.NamedRef'
+        type: array
+      tags:
+        items:
+          $ref: '#/definitions/internal_api_handlers.NamedTagRef'
+        type: array
     type: object
   internal_api_handlers.SuggestionView:
     properties:
@@ -558,6 +676,20 @@ definitions:
         type: string
       type:
         type: string
+    type: object
+  internal_api_handlers.ollamaModelsResponse:
+    properties:
+      models:
+        items:
+          $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_ai.OllamaModel'
+        type: array
+    type: object
+  internal_api_handlers.osaurusModelsResponse:
+    properties:
+      models:
+        items:
+          $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_ai.OsaurusModel'
+        type: array
     type: object
   responses.BookResponse:
     properties:
@@ -1132,6 +1264,62 @@ paths:
       security:
       - BearerAuth: []
       summary: Set the active AI provider (admin)
+      tags:
+      - admin
+      - ai
+  /admin/connections/ai/ollama/models:
+    get:
+      description: Proxies the configured Ollama host's /api/tags endpoint. Used by
+        the provider-config UI to render a model dropdown instead of a free-text input.
+        Returns 503 when the host is unreachable so the UI can fall back to the text
+        input.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/internal_api_handlers.ollamaModelsResponse'
+        "503":
+          description: Service Unavailable
+          schema:
+            properties:
+              error:
+                type: string
+              reachable:
+                type: boolean
+            type: object
+      security:
+      - BearerAuth: []
+      summary: List locally-pulled Ollama models (admin)
+      tags:
+      - admin
+      - ai
+  /admin/connections/ai/osaurus/models:
+    get:
+      description: Proxies the configured Osaurus host's /v1/models endpoint (OpenAI
+        shape). Used by the provider-config UI to render a model dropdown instead
+        of a free-text input. Returns 503 when the host is unreachable so the UI can
+        fall back to the text input.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/internal_api_handlers.osaurusModelsResponse'
+        "503":
+          description: Service Unavailable
+          schema:
+            properties:
+              error:
+                type: string
+              reachable:
+                type: boolean
+            type: object
+      security:
+      - BearerAuth: []
+      summary: List models available on the configured Osaurus host (admin)
       tags:
       - admin
       - ai
@@ -6873,10 +7061,42 @@ paths:
       tags:
       - me
       - ai
+  /me/series:
+    get:
+      description: Returns series from every library the caller can access, filtered
+        by an optional case-insensitive substring in `q`. Results are capped at 20.
+      parameters:
+      - description: Name substring
+        in: query
+        name: q
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/internal_api_handlers.MeSeriesResult'
+            type: array
+        "401":
+          description: Unauthorized
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Search series across my libraries
+      tags:
+      - me
   /me/suggestions:
     get:
       description: Returns the current AI-generated recommendations for the caller.
-        Filter by type (buy | read_next) and status.
+        Filter by type (buy | read_next) and status, or scope to a specific run via
+        `run_id`. When `run_id` is set the status filter is ignored — the scoped view
+        returns every suggestion that run produced.
       parameters:
       - description: 'Filter by type: buy | read_next'
         in: query
@@ -6885,6 +7105,10 @@ paths:
       - description: 'Filter by status: new | dismissed | interested | added_to_library'
         in: query
         name: status
+        type: string
+      - description: Scope to a specific run ID
+        in: query
+        name: run_id
         type: string
       produces:
       - application/json
@@ -6895,6 +7119,20 @@ paths:
             items:
               $ref: '#/definitions/internal_api_handlers.SuggestionView'
             type: array
+        "400":
+          description: Bad Request
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
       security:
       - BearerAuth: []
       summary: List my AI suggestions
@@ -7004,13 +7242,32 @@ paths:
       - ai
   /me/suggestions/run:
     post:
-      description: Enqueues a background job to regenerate suggestions. Rate-limited
-        by admin config.
+      consumes:
+      - application/json
+      description: Enqueues a background job to regenerate suggestions. Accepts an
+        optional `steering` body to bias this run toward specific authors, series,
+        genres, tags, and/or free-form notes. Rate-limited by admin config.
+      parameters:
+      - description: Optional steering payload
+        in: body
+        name: body
+        schema:
+          properties:
+            steering:
+              $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_models.SuggestionSteering'
+          type: object
       produces:
       - application/json
       responses:
         "202":
           description: Accepted
+        "400":
+          description: Bad Request
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
         "429":
           description: Too Many Requests
           schema:
@@ -7081,6 +7338,38 @@ paths:
       tags:
       - me
       - ai
+  /me/tags:
+    get:
+      description: Returns tags from every library the caller can access, filtered
+        by an optional case-insensitive substring in `q`. Tags are per-library; the
+        response marks names as ambiguous when the same name exists in multiple libraries
+        so the UI can disambiguate. Results are capped at 20.
+      parameters:
+      - description: Name substring
+        in: query
+        name: q
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/internal_api_handlers.MeTagResult'
+            type: array
+        "401":
+          description: Unauthorized
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Search tags across my libraries
+      tags:
+      - me
   /me/taste-profile:
     get:
       description: Returns the JSON taste profile the user has saved. Empty object

--- a/internal/api/handlers/ai.go
+++ b/internal/api/handlers/ai.go
@@ -7,10 +7,23 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/fireball1725/librarium-api/internal/ai"
 	"github.com/fireball1725/librarium-api/internal/api/middleware"
 	"github.com/fireball1725/librarium-api/internal/api/respond"
 	"github.com/fireball1725/librarium-api/internal/service"
 )
+
+// ollamaModelsResponse wraps the Ollama /api/tags models list. Named for
+// swag — inline object{models=[]ai.OllamaModel} can't resolve the package.
+type ollamaModelsResponse struct {
+	Models []ai.OllamaModel `json:"models"`
+}
+
+// osaurusModelsResponse wraps the Osaurus /v1/models list. Same rationale
+// as ollamaModelsResponse.
+type osaurusModelsResponse struct {
+	Models []ai.OsaurusModel `json:"models"`
+}
 
 // AIHandler groups admin-side AI endpoints: provider CRUD, test, active
 // selection, and permissions policy. User-scoped endpoints (opt-in, taste
@@ -178,7 +191,7 @@ func (h *AIHandler) SetPermissions(w http.ResponseWriter, r *http.Request) {
 //	@Tags        admin,ai
 //	@Produce     json
 //	@Security    BearerAuth
-//	@Success     200  {object}  object{models=[]ai.OllamaModel}
+//	@Success     200  {object}  ollamaModelsResponse
 //	@Failure     503  {object}  object{error=string,reachable=boolean}
 //	@Router      /admin/connections/ai/ollama/models [get]
 func (h *AIHandler) ListOllamaModels(w http.ResponseWriter, r *http.Request) {
@@ -200,7 +213,7 @@ func (h *AIHandler) ListOllamaModels(w http.ResponseWriter, r *http.Request) {
 //	@Tags        admin,ai
 //	@Produce     json
 //	@Security    BearerAuth
-//	@Success     200  {object}  object{models=[]ai.OsaurusModel}
+//	@Success     200  {object}  osaurusModelsResponse
 //	@Failure     503  {object}  object{error=string,reachable=boolean}
 //	@Router      /admin/connections/ai/osaurus/models [get]
 func (h *AIHandler) ListOsaurusModels(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handlers/ai_suggestions.go
+++ b/internal/api/handlers/ai_suggestions.go
@@ -4,6 +4,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -20,15 +21,19 @@ import (
 )
 
 // AISuggestionsHandler groups user-facing suggestion endpoints: list, change
-// status (dismiss / interested / added_to_library), block, and run-now.
+// status (dismiss / interested / added_to_library), block, and run-now. aiSvc
+// is consulted by the quota endpoint to surface feature availability; it
+// provides the live registry so we can tell "no provider configured" apart
+// from "job disabled by admin" without duplicating the registry's state.
 type AISuggestionsHandler struct {
 	repo        *repository.AISuggestionsRepo
 	riverClient *river.Client[pgx.Tx]
 	jobSvc      *service.JobService
+	aiSvc       *service.AIService
 }
 
-func NewAISuggestionsHandler(repo *repository.AISuggestionsRepo, riverClient *river.Client[pgx.Tx], jobSvc *service.JobService) *AISuggestionsHandler {
-	return &AISuggestionsHandler{repo: repo, riverClient: riverClient, jobSvc: jobSvc}
+func NewAISuggestionsHandler(repo *repository.AISuggestionsRepo, riverClient *river.Client[pgx.Tx], jobSvc *service.JobService, aiSvc *service.AIService) *AISuggestionsHandler {
+	return &AISuggestionsHandler{repo: repo, riverClient: riverClient, jobSvc: jobSvc, aiSvc: aiSvc}
 }
 
 // SuggestionView is the JSON shape the UI consumes. Nullable pointer IDs are
@@ -75,13 +80,16 @@ func toView(s *models.AISuggestionWithLibrary) SuggestionView {
 // ListSuggestions godoc
 //
 //	@Summary     List my AI suggestions
-//	@Description Returns the current AI-generated recommendations for the caller. Filter by type (buy | read_next) and status.
+//	@Description Returns the current AI-generated recommendations for the caller. Filter by type (buy | read_next) and status, or scope to a specific run via `run_id`. When `run_id` is set the status filter is ignored — the scoped view returns every suggestion that run produced.
 //	@Tags        me,ai
 //	@Produce     json
 //	@Security    BearerAuth
 //	@Param       type    query     string  false  "Filter by type: buy | read_next"
 //	@Param       status  query     string  false  "Filter by status: new | dismissed | interested | added_to_library"
+//	@Param       run_id  query     string  false  "Scope to a specific run ID"
 //	@Success     200     {array}   handlers.SuggestionView
+//	@Failure     400     {object}  object{error=string}
+//	@Failure     404     {object}  object{error=string}
 //	@Router      /me/suggestions [get]
 func (h *AISuggestionsHandler) ListSuggestions(w http.ResponseWriter, r *http.Request) {
 	claims := middleware.ClaimsFromContext(r.Context())
@@ -91,10 +99,36 @@ func (h *AISuggestionsHandler) ListSuggestions(w http.ResponseWriter, r *http.Re
 	}
 	typeFilter := r.URL.Query().Get("type")
 	statusFilter := r.URL.Query().Get("status")
-	if statusFilter == "" {
+
+	var runIDPtr *uuid.UUID
+	if s := r.URL.Query().Get("run_id"); s != "" {
+		runID, err := uuid.Parse(s)
+		if err != nil {
+			respond.Error(w, http.StatusBadRequest, "invalid run_id")
+			return
+		}
+		// Confirm the run belongs to the caller before we let them peek at it.
+		// Without this, a user could enumerate anyone's suggestions by guessing
+		// run IDs (admittedly 128-bit UUIDs, but still not a boundary to lean on).
+		run, err := h.repo.GetRun(r.Context(), runID)
+		if err != nil {
+			if errors.Is(err, repository.ErrNotFound) {
+				respond.Error(w, http.StatusNotFound, "run not found")
+				return
+			}
+			respond.ServerError(w, r, err)
+			return
+		}
+		if run.UserID != claims.UserID {
+			respond.Error(w, http.StatusNotFound, "run not found")
+			return
+		}
+		runIDPtr = &runID
+	} else if statusFilter == "" {
 		statusFilter = "new"
 	}
-	items, err := h.repo.ListSuggestions(r.Context(), claims.UserID, typeFilter, statusFilter)
+
+	items, err := h.repo.ListSuggestions(r.Context(), claims.UserID, typeFilter, statusFilter, runIDPtr)
 	if err != nil {
 		respond.ServerError(w, r, err)
 		return
@@ -229,11 +263,14 @@ func (h *AISuggestionsHandler) BlockSuggestion(w http.ResponseWriter, r *http.Re
 // RunNow godoc
 //
 //	@Summary     Trigger a suggestions run for the caller
-//	@Description Enqueues a background job to regenerate suggestions. Rate-limited by admin config.
+//	@Description Enqueues a background job to regenerate suggestions. Accepts an optional `steering` body to bias this run toward specific authors, series, genres, tags, and/or free-form notes. Rate-limited by admin config.
 //	@Tags        me,ai
+//	@Accept      json
 //	@Produce     json
 //	@Security    BearerAuth
+//	@Param       body  body      object{steering=models.SuggestionSteering}  false  "Optional steering payload"
 //	@Success     202
+//	@Failure     400  {object}  object{error=string}
 //	@Failure     429  {object}  object{error=string}
 //	@Router      /me/suggestions/run [post]
 func (h *AISuggestionsHandler) RunNow(w http.ResponseWriter, r *http.Request) {
@@ -241,6 +278,24 @@ func (h *AISuggestionsHandler) RunNow(w http.ResponseWriter, r *http.Request) {
 	if claims == nil {
 		respond.Error(w, http.StatusUnauthorized, "unauthenticated")
 		return
+	}
+	// Body is optional — legacy clients that POST with no body still get a
+	// normal unsteered run. We only decode if Content-Length suggests content
+	// so an empty body doesn't surface a decode error.
+	var body struct {
+		Steering *models.SuggestionSteering `json:"steering,omitempty"`
+	}
+	if r.ContentLength > 0 {
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			respond.Error(w, http.StatusBadRequest, "invalid request body")
+			return
+		}
+	}
+	// Collapse a wholly-empty steering object to nil so the worker treats it
+	// as an unsteered run — avoids persisting '{}' on the row and simplifies
+	// the prompt branch.
+	if body.Steering != nil && body.Steering.IsEmpty() {
+		body.Steering = nil
 	}
 	// Enforce the per-user rate limit up front so the user gets immediate
 	// feedback instead of silently queued jobs that the worker would bounce.
@@ -272,7 +327,7 @@ func (h *AISuggestionsHandler) RunNow(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if _, err := h.riverClient.Insert(r.Context(),
-		models.AISuggestionsJobArgs{UserID: claims.UserID, TriggeredBy: "user"}, nil); err != nil {
+		models.AISuggestionsJobArgs{UserID: claims.UserID, TriggeredBy: "user", Steering: body.Steering}, nil); err != nil {
 		respond.ServerError(w, r, err)
 		return
 	}
@@ -280,12 +335,21 @@ func (h *AISuggestionsHandler) RunNow(w http.ResponseWriter, r *http.Request) {
 }
 
 // QuotaView is the JSON shape for the caller's daily run quota. Limit = 0
-// means unlimited.
+// means unlimited. Available=false means the feature can't be used right now
+// regardless of quota — UnavailableReason explains why so clients can render
+// the right inline hint (and decide whether to hide the sidebar entry).
+//
+// Unavailable reasons, in the order the server resolves them:
+//   - "job_disabled"  → admin disabled the AI suggestions job instance-wide
+//   - "no_provider"   → no active AI provider configured on the instance
+//   - "not_opted_in"  → user hasn't opted in under Profile → AI Privacy
 type QuotaView struct {
-	Used      int    `json:"used"`
-	Limit     int    `json:"limit"`
-	ResetsAt  string `json:"resets_at,omitempty"`
-	Unlimited bool   `json:"unlimited"`
+	Used              int    `json:"used"`
+	Limit             int    `json:"limit"`
+	ResetsAt          string `json:"resets_at,omitempty"`
+	Unlimited         bool   `json:"unlimited"`
+	Available         bool   `json:"available"`
+	UnavailableReason string `json:"unavailable_reason,omitempty"`
 }
 
 // GetMyQuota godoc
@@ -313,13 +377,37 @@ func (h *AISuggestionsHandler) GetMyQuota(w http.ResponseWriter, r *http.Request
 		respond.ServerError(w, r, err)
 		return
 	}
+
+	// Feature-availability resolution — order is deliberate. Admin-wide
+	// disables win over per-user state: if the admin turned the job off, we
+	// shouldn't prompt the user to toggle their opt-in as if that would help.
+	available := true
+	reason := ""
+	switch {
+	case !cfg.Enabled:
+		available, reason = false, "job_disabled"
+	case h.aiSvc == nil || h.aiSvc.Registry().Active() == nil:
+		available, reason = false, "no_provider"
+	default:
+		optedIn, err := h.repo.IsOptedIn(r.Context(), claims.UserID)
+		if err != nil {
+			respond.ServerError(w, r, err)
+			return
+		}
+		if !optedIn {
+			available, reason = false, "not_opted_in"
+		}
+	}
+
 	// -1 = unlimited, 0 = disabled, positive = cap. The UI renders "unlimited"
 	// copy when the flag is set and hides the counter; limit=0 surfaces as
 	// 0 remaining, which correctly blocks user-triggered runs.
 	out := QuotaView{
-		Used:      used,
-		Limit:     cfg.UserRunRateLimitPerDay,
-		Unlimited: cfg.UserRunRateLimitPerDay < 0,
+		Used:              used,
+		Limit:             cfg.UserRunRateLimitPerDay,
+		Unlimited:         cfg.UserRunRateLimitPerDay < 0,
+		Available:         available,
+		UnavailableReason: reason,
 	}
 	// resets_at = earliest-in-window + 24h — when the oldest run falls out of
 	// the rolling window and the user gets a slot back. Only meaningful when a
@@ -341,19 +429,44 @@ func (h *AISuggestionsHandler) GetMyQuota(w http.ResponseWriter, r *http.Request
 
 // RunView is the JSON shape for a single suggestions run — shared by user and
 // admin endpoints. UserID is only populated for admin-scoped responses.
+// Steering is present only on runs the user triggered with a custom ask and
+// comes back with display names resolved, so the UI doesn't need a second
+// round-trip to render the steering summary banner.
 type RunView struct {
-	ID               uuid.UUID `json:"id"`
-	UserID           string    `json:"user_id,omitempty"`
-	TriggeredBy      string    `json:"triggered_by"`
-	ProviderType     string    `json:"provider_type"`
-	ModelID          string    `json:"model_id,omitempty"`
-	Status           string    `json:"status"`
-	Error            string    `json:"error,omitempty"`
-	TokensIn         int       `json:"tokens_in"`
-	TokensOut        int       `json:"tokens_out"`
-	EstimatedCostUSD float64   `json:"estimated_cost_usd"`
-	StartedAt        string    `json:"started_at"`
-	FinishedAt       string    `json:"finished_at,omitempty"`
+	ID               uuid.UUID     `json:"id"`
+	UserID           string        `json:"user_id,omitempty"`
+	TriggeredBy      string        `json:"triggered_by"`
+	ProviderType     string        `json:"provider_type"`
+	ModelID          string        `json:"model_id,omitempty"`
+	Status           string        `json:"status"`
+	Error            string        `json:"error,omitempty"`
+	TokensIn         int           `json:"tokens_in"`
+	TokensOut        int           `json:"tokens_out"`
+	EstimatedCostUSD float64       `json:"estimated_cost_usd"`
+	StartedAt        string        `json:"started_at"`
+	FinishedAt       string        `json:"finished_at,omitempty"`
+	Steering         *SteeringView `json:"steering,omitempty"`
+}
+
+// SteeringView hydrates stored steering IDs to {id, name} objects for direct
+// UI consumption. Notes is free-form text and flows through unchanged.
+type SteeringView struct {
+	Authors []NamedRef        `json:"authors,omitempty"`
+	Series  []NamedRef        `json:"series,omitempty"`
+	Genres  []NamedRef        `json:"genres,omitempty"`
+	Tags    []NamedTagRef     `json:"tags,omitempty"`
+	Notes   string            `json:"notes,omitempty"`
+}
+
+type NamedRef struct {
+	ID   uuid.UUID `json:"id"`
+	Name string    `json:"name"`
+}
+
+type NamedTagRef struct {
+	ID        uuid.UUID `json:"id"`
+	Name      string    `json:"name"`
+	LibraryID uuid.UUID `json:"library_id"`
 }
 
 // EventView is the JSON shape for one pipeline event. Content is emitted as
@@ -387,6 +500,101 @@ func runToView(r *models.AISuggestionRun, includeUser bool) RunView {
 	return v
 }
 
+// hydrateSteeringViews fills RunView.Steering for every run with a non-null
+// steering column. Batches lookups per taxonomy so N runs cost at most 4 SQL
+// queries instead of 4N. Stale IDs (entities deleted after the ask) are
+// quietly dropped; the notes field always survives intact.
+func (h *AISuggestionsHandler) hydrateSteeringViews(ctx context.Context, runs []*models.AISuggestionRun, views []RunView) error {
+	if len(views) == 0 {
+		return nil
+	}
+	var authorIDs, seriesIDs, genreIDs, tagIDs []uuid.UUID
+	decoded := make([]*models.SuggestionSteering, len(runs))
+	for i, r := range runs {
+		if len(r.Steering) == 0 {
+			continue
+		}
+		var s models.SuggestionSteering
+		if err := json.Unmarshal(r.Steering, &s); err != nil {
+			// A row with malformed steering shouldn't poison the whole list —
+			// log-and-skip so the rest of the timeline renders. Empty stays nil.
+			continue
+		}
+		decoded[i] = &s
+		authorIDs = append(authorIDs, s.AuthorIDs...)
+		seriesIDs = append(seriesIDs, s.SeriesIDs...)
+		genreIDs = append(genreIDs, s.GenreIDs...)
+		tagIDs = append(tagIDs, s.TagIDs...)
+	}
+
+	authorNames, err := h.repo.ResolveNames(ctx, "contributors", dedupeUUIDs(authorIDs))
+	if err != nil {
+		return err
+	}
+	seriesNames, err := h.repo.ResolveNames(ctx, "series", dedupeUUIDs(seriesIDs))
+	if err != nil {
+		return err
+	}
+	genreNames, err := h.repo.ResolveNames(ctx, "genres", dedupeUUIDs(genreIDs))
+	if err != nil {
+		return err
+	}
+	tagRefs, err := h.repo.ResolveTags(ctx, dedupeUUIDs(tagIDs))
+	if err != nil {
+		return err
+	}
+
+	for i, s := range decoded {
+		if s == nil {
+			continue
+		}
+		sv := &SteeringView{Notes: s.Notes}
+		for _, id := range s.AuthorIDs {
+			if name, ok := authorNames[id]; ok {
+				sv.Authors = append(sv.Authors, NamedRef{ID: id, Name: name})
+			}
+		}
+		for _, id := range s.SeriesIDs {
+			if name, ok := seriesNames[id]; ok {
+				sv.Series = append(sv.Series, NamedRef{ID: id, Name: name})
+			}
+		}
+		for _, id := range s.GenreIDs {
+			if name, ok := genreNames[id]; ok {
+				sv.Genres = append(sv.Genres, NamedRef{ID: id, Name: name})
+			}
+		}
+		for _, id := range s.TagIDs {
+			if t, ok := tagRefs[id]; ok {
+				sv.Tags = append(sv.Tags, NamedTagRef{ID: id, Name: t.Name, LibraryID: t.LibraryID})
+			}
+		}
+		// Wholly-stale payloads with no notes collapse to omitted — same signal
+		// as an unsteered run, which is the right read once nothing's left.
+		if len(sv.Authors) == 0 && len(sv.Series) == 0 && len(sv.Genres) == 0 && len(sv.Tags) == 0 && sv.Notes == "" {
+			continue
+		}
+		views[i].Steering = sv
+	}
+	return nil
+}
+
+func dedupeUUIDs(ids []uuid.UUID) []uuid.UUID {
+	if len(ids) < 2 {
+		return ids
+	}
+	seen := make(map[uuid.UUID]struct{}, len(ids))
+	out := make([]uuid.UUID, 0, len(ids))
+	for _, id := range ids {
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	return out
+}
+
 // ListMyRuns godoc
 //
 //	@Summary     List my recent AI suggestion runs
@@ -407,9 +615,13 @@ func (h *AISuggestionsHandler) ListMyRuns(w http.ResponseWriter, r *http.Request
 		respond.ServerError(w, r, err)
 		return
 	}
-	out := make([]RunView, 0, len(runs))
-	for _, run := range runs {
-		out = append(out, runToView(run, false))
+	out := make([]RunView, len(runs))
+	for i, run := range runs {
+		out[i] = runToView(run, false)
+	}
+	if err := h.hydrateSteeringViews(r.Context(), runs, out); err != nil {
+		respond.ServerError(w, r, err)
+		return
 	}
 	respond.JSON(w, http.StatusOK, out)
 }
@@ -454,8 +666,13 @@ func (h *AISuggestionsHandler) GetMyRun(w http.ResponseWriter, r *http.Request) 
 		respond.ServerError(w, r, err)
 		return
 	}
+	views := []RunView{runToView(run, false)}
+	if err := h.hydrateSteeringViews(r.Context(), []*models.AISuggestionRun{run}, views); err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
 	respond.JSON(w, http.StatusOK, map[string]any{
-		"run":    runToView(run, false),
+		"run":    views[0],
 		"events": toEventViews(events),
 	})
 }
@@ -475,9 +692,13 @@ func (h *AISuggestionsHandler) AdminListRuns(w http.ResponseWriter, r *http.Requ
 		respond.ServerError(w, r, err)
 		return
 	}
-	out := make([]RunView, 0, len(runs))
-	for _, run := range runs {
-		out = append(out, runToView(run, true))
+	out := make([]RunView, len(runs))
+	for i, run := range runs {
+		out[i] = runToView(run, true)
+	}
+	if err := h.hydrateSteeringViews(r.Context(), runs, out); err != nil {
+		respond.ServerError(w, r, err)
+		return
 	}
 	respond.JSON(w, http.StatusOK, out)
 }
@@ -513,8 +734,13 @@ func (h *AISuggestionsHandler) AdminGetRun(w http.ResponseWriter, r *http.Reques
 		respond.ServerError(w, r, err)
 		return
 	}
+	views := []RunView{runToView(run, true)}
+	if err := h.hydrateSteeringViews(r.Context(), []*models.AISuggestionRun{run}, views); err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
 	respond.JSON(w, http.StatusOK, map[string]any{
-		"run":    runToView(run, true),
+		"run":    views[0],
 		"events": toEventViews(events),
 	})
 }

--- a/internal/api/handlers/me_lookup.go
+++ b/internal/api/handlers/me_lookup.go
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725 (Adaléa)
+
+package handlers
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/fireball1725/librarium-api/internal/api/middleware"
+	"github.com/fireball1725/librarium-api/internal/api/respond"
+	"github.com/fireball1725/librarium-api/internal/repository"
+	"github.com/fireball1725/librarium-api/internal/service"
+	"github.com/google/uuid"
+)
+
+// MeLookupHandler powers user-scoped search endpoints used by the Steered
+// Suggestions modal. Results are aggregated across every library the caller
+// has access to, deduped, and filtered by the `?q=` query term.
+type MeLookupHandler struct {
+	libSvc     *service.LibraryService
+	seriesRepo *repository.SeriesRepo
+	tagRepo    *repository.TagRepo
+}
+
+func NewMeLookupHandler(libSvc *service.LibraryService, seriesRepo *repository.SeriesRepo, tagRepo *repository.TagRepo) *MeLookupHandler {
+	return &MeLookupHandler{libSvc: libSvc, seriesRepo: seriesRepo, tagRepo: tagRepo}
+}
+
+// MeSeriesResult is the lightweight shape returned by GET /me/series.
+type MeSeriesResult struct {
+	ID          uuid.UUID `json:"id"`
+	Name        string    `json:"name"`
+	LibraryID   uuid.UUID `json:"library_id"`
+	LibraryName string    `json:"library_name"`
+}
+
+// MeTagResult is the lightweight shape returned by GET /me/tags. When the
+// same tag name exists in multiple accessible libraries, library_name is
+// set so the UI can disambiguate.
+type MeTagResult struct {
+	ID          uuid.UUID `json:"id"`
+	Name        string    `json:"name"`
+	LibraryID   uuid.UUID `json:"library_id"`
+	LibraryName string    `json:"library_name"`
+	// Ambiguous is true when another accessible library has a tag with the
+	// same (case-insensitive) name. The client appends " · <library>" in
+	// that case.
+	Ambiguous bool `json:"ambiguous"`
+}
+
+// SearchSeries godoc
+//
+//	@Summary     Search series across my libraries
+//	@Description Returns series from every library the caller can access, filtered by an optional case-insensitive substring in `q`. Results are capped at 20.
+//	@Tags        me
+//	@Produce     json
+//	@Security    BearerAuth
+//	@Param       q  query     string  false  "Name substring"
+//	@Success     200  {array}   handlers.MeSeriesResult
+//	@Failure     401  {object}  object{error=string}
+//	@Router      /me/series [get]
+func (h *MeLookupHandler) SearchSeries(w http.ResponseWriter, r *http.Request) {
+	claims := middleware.ClaimsFromContext(r.Context())
+	if claims == nil {
+		respond.Error(w, http.StatusUnauthorized, "unauthenticated")
+		return
+	}
+	q := strings.TrimSpace(r.URL.Query().Get("q"))
+
+	libs, err := h.libSvc.ListLibraries(r.Context(), claims.UserID, claims.IsInstanceAdmin)
+	if err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
+
+	results := make([]MeSeriesResult, 0, 32)
+	for _, lib := range libs {
+		ss, err := h.seriesRepo.List(r.Context(), lib.ID, q, "")
+		if err != nil {
+			respond.ServerError(w, r, err)
+			return
+		}
+		for _, s := range ss {
+			results = append(results, MeSeriesResult{
+				ID:          s.ID,
+				Name:        s.Name,
+				LibraryID:   lib.ID,
+				LibraryName: lib.Name,
+			})
+		}
+	}
+
+	sort.SliceStable(results, func(i, j int) bool {
+		return strings.ToLower(results[i].Name) < strings.ToLower(results[j].Name)
+	})
+	if len(results) > 20 {
+		results = results[:20]
+	}
+	respond.JSON(w, http.StatusOK, results)
+}
+
+// SearchTags godoc
+//
+//	@Summary     Search tags across my libraries
+//	@Description Returns tags from every library the caller can access, filtered by an optional case-insensitive substring in `q`. Tags are per-library; the response marks names as ambiguous when the same name exists in multiple libraries so the UI can disambiguate. Results are capped at 20.
+//	@Tags        me
+//	@Produce     json
+//	@Security    BearerAuth
+//	@Param       q  query     string  false  "Name substring"
+//	@Success     200  {array}   handlers.MeTagResult
+//	@Failure     401  {object}  object{error=string}
+//	@Router      /me/tags [get]
+func (h *MeLookupHandler) SearchTags(w http.ResponseWriter, r *http.Request) {
+	claims := middleware.ClaimsFromContext(r.Context())
+	if claims == nil {
+		respond.Error(w, http.StatusUnauthorized, "unauthenticated")
+		return
+	}
+	q := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("q")))
+
+	libs, err := h.libSvc.ListLibraries(r.Context(), claims.UserID, claims.IsInstanceAdmin)
+	if err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
+
+	type row struct {
+		MeTagResult
+		lowerName string
+	}
+	rows := make([]row, 0, 32)
+	nameCounts := map[string]int{}
+	for _, lib := range libs {
+		ts, err := h.tagRepo.List(r.Context(), lib.ID)
+		if err != nil {
+			respond.ServerError(w, r, err)
+			return
+		}
+		for _, t := range ts {
+			lower := strings.ToLower(t.Name)
+			if q != "" && !strings.Contains(lower, q) {
+				continue
+			}
+			rows = append(rows, row{
+				MeTagResult: MeTagResult{
+					ID:          t.ID,
+					Name:        t.Name,
+					LibraryID:   lib.ID,
+					LibraryName: lib.Name,
+				},
+				lowerName: lower,
+			})
+			nameCounts[lower]++
+		}
+	}
+
+	results := make([]MeTagResult, 0, len(rows))
+	for _, r := range rows {
+		r.Ambiguous = nameCounts[r.lowerName] > 1
+		results = append(results, r.MeTagResult)
+	}
+
+	sort.SliceStable(results, func(i, j int) bool {
+		li, lj := strings.ToLower(results[i].Name), strings.ToLower(results[j].Name)
+		if li != lj {
+			return li < lj
+		}
+		return results[i].LibraryName < results[j].LibraryName
+	})
+	if len(results) > 20 {
+		results = results[:20]
+	}
+	respond.JSON(w, http.StatusOK, results)
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -99,7 +99,7 @@ func NewRouter(ctx context.Context, db *pgxpool.Pool, cfg *config.Config, riverC
 	aiHandler := handlers.NewAIHandler(aiSvc)
 	aiUserHandler := handlers.NewAIUserHandler(aiUserSvc)
 	jobsHandler := handlers.NewJobsHandler(jobSvc)
-	aiSuggestionsHandler := handlers.NewAISuggestionsHandler(aiSuggestionsRepo, riverClient, jobSvc)
+	aiSuggestionsHandler := handlers.NewAISuggestionsHandler(aiSuggestionsRepo, riverClient, jobSvc, aiSvc)
 
 	authHandler := handlers.NewAuthHandler(authSvc, preferencesRepo)
 	setupHandler := handlers.NewSetupHandler(authSvc, userRepo)
@@ -117,6 +117,7 @@ func NewRouter(ctx context.Context, db *pgxpool.Pool, cfg *config.Config, riverC
 	storageLocationHandler := handlers.NewStorageLocationHandler(editionFileSvc)
 	contributorHandler := handlers.NewContributorHandler(contributorSvc)
 	dashboardHandler := handlers.NewDashboardHandler(bookRepo)
+	meLookupHandler := handlers.NewMeLookupHandler(libSvc, seriesRepo, tagRepo)
 
 	releaseChecker := background.NewReleaseChecker(releaseSyncSvc, 24*time.Hour)
 	go releaseChecker.Start(ctx)
@@ -212,6 +213,10 @@ func NewRouter(ctx context.Context, db *pgxpool.Pool, cfg *config.Config, riverC
 	mux.Handle("PUT /api/v1/me/ai-prefs", requireAuth(http.HandlerFunc(aiUserHandler.UpdatePrefs)))
 	mux.Handle("GET /api/v1/me/taste-profile", requireAuth(http.HandlerFunc(aiUserHandler.GetTasteProfile)))
 	mux.Handle("PUT /api/v1/me/taste-profile", requireAuth(http.HandlerFunc(aiUserHandler.UpdateTasteProfile)))
+
+	// User-scoped lookup endpoints (aggregated across the caller's libraries)
+	mux.Handle("GET /api/v1/me/series", requireAuth(http.HandlerFunc(meLookupHandler.SearchSeries)))
+	mux.Handle("GET /api/v1/me/tags", requireAuth(http.HandlerFunc(meLookupHandler.SearchTags)))
 
 	// User-scoped AI suggestions
 	// More specific paths (/run, /runs, /runs/{id}) must come before the {id}

--- a/internal/db/migrations/000005_ai_suggestions_steering.down.sql
+++ b/internal/db/migrations/000005_ai_suggestions_steering.down.sql
@@ -1,0 +1,4 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Copyright (C) 2026 fireball1725
+
+ALTER TABLE ai_suggestion_runs DROP COLUMN IF EXISTS steering;

--- a/internal/db/migrations/000005_ai_suggestions_steering.up.sql
+++ b/internal/db/migrations/000005_ai_suggestions_steering.up.sql
@@ -1,0 +1,14 @@
+-- Steered suggestions: per-run user steering payload
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Copyright (C) 2026 fireball1725
+
+-- JSONB shape (all fields optional):
+--   {
+--     "author_ids": ["uuid", ...],
+--     "series_ids": ["uuid", ...],
+--     "genre_ids":  ["uuid", ...],
+--     "tag_ids":    ["uuid", ...],
+--     "notes":      "free-form text"
+--   }
+-- NULL means "no steering" — scheduled runs and unsteered manual runs.
+ALTER TABLE ai_suggestion_runs ADD COLUMN steering JSONB;

--- a/internal/models/ai_suggestion.go
+++ b/internal/models/ai_suggestion.go
@@ -4,10 +4,35 @@
 package models
 
 import (
+	"encoding/json"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
 )
+
+// SuggestionSteering is the user-provided per-run steering payload — IDs reference
+// live taxonomy rows at ask time; display names are hydrated on read. Notes is a
+// free-form hint ("cozy autumn reads"). All fields optional; callers must reject
+// wholly-empty payloads before persisting.
+type SuggestionSteering struct {
+	AuthorIDs []uuid.UUID `json:"author_ids,omitempty"`
+	SeriesIDs []uuid.UUID `json:"series_ids,omitempty"`
+	GenreIDs  []uuid.UUID `json:"genre_ids,omitempty"`
+	TagIDs    []uuid.UUID `json:"tag_ids,omitempty"`
+	Notes     string      `json:"notes,omitempty"`
+}
+
+// IsEmpty reports whether no steering field is set. An empty steering payload
+// should be persisted as SQL NULL rather than '{}' so the "unsteered run" check
+// stays a single IS NULL test.
+func (s SuggestionSteering) IsEmpty() bool {
+	return len(s.AuthorIDs) == 0 &&
+		len(s.SeriesIDs) == 0 &&
+		len(s.GenreIDs) == 0 &&
+		len(s.TagIDs) == 0 &&
+		strings.TrimSpace(s.Notes) == ""
+}
 
 // AISuggestionRun is one execution of the suggestions pipeline for one user.
 // Runs are persisted even on failure so the admin can audit cost and errors.
@@ -24,6 +49,10 @@ type AISuggestionRun struct {
 	EstimatedCostUSD float64
 	StartedAt        time.Time
 	FinishedAt       *time.Time
+	// Steering is the user's per-run ask as raw JSONB, or nil for unsteered
+	// runs. Handlers decode into SuggestionSteering and hydrate the IDs to
+	// display names on the way out.
+	Steering json.RawMessage
 }
 
 // AISuggestion is one rendered recommendation — either a book to buy (not in
@@ -87,9 +116,12 @@ type AIRunEvent struct {
 
 // AISuggestionsJobArgs is the River job payload for a per-user suggestions run.
 // TriggeredBy distinguishes scheduler/admin/user for cost-attribution display.
+// Steering carries the user's per-run ask for manual runs; omitted for
+// scheduled / admin-broadcast runs.
 type AISuggestionsJobArgs struct {
-	UserID      uuid.UUID `json:"user_id"`
-	TriggeredBy string    `json:"triggered_by"`
+	UserID      uuid.UUID           `json:"user_id"`
+	TriggeredBy string              `json:"triggered_by"`
+	Steering    *SuggestionSteering `json:"steering,omitempty"`
 }
 
 func (AISuggestionsJobArgs) Kind() string { return "ai_suggestions" }

--- a/internal/repository/ai_suggestions.go
+++ b/internal/repository/ai_suggestions.go
@@ -74,6 +74,19 @@ func (r *AISuggestionsRepo) ListOptedInUsers(ctx context.Context) ([]*OptedInUse
 	return out, rows.Err()
 }
 
+// IsOptedIn reports whether the user has opted into AI features. Distinct
+// from GetOptedInUser: this one doesn't require the user to have any library,
+// because the quota endpoint wants to separate "not opted in" from "no
+// library yet" when reporting availability.
+func (r *AISuggestionsRepo) IsOptedIn(ctx context.Context, userID uuid.UUID) (bool, error) {
+	const q = `SELECT COALESCE((SELECT opt_in FROM user_ai_settings WHERE user_id = $1), FALSE)`
+	var ok bool
+	if err := r.db.QueryRow(ctx, q, userID).Scan(&ok); err != nil {
+		return false, fmt.Errorf("check opt-in: %w", err)
+	}
+	return ok, nil
+}
+
 // GetOptedInUser returns a single user's opt-in row + library if present.
 // Returns nil (no error) if the user isn't opted in or has no library.
 func (r *AISuggestionsRepo) GetOptedInUser(ctx context.Context, userID uuid.UUID) (*OptedInUser, error) {
@@ -243,13 +256,19 @@ func (r *AISuggestionsRepo) BookExistsInLibrary(ctx context.Context, libraryID u
 
 // ─── Runs ─────────────────────────────────────────────────────────────────────
 
-// CreateRun inserts a run row in 'running' state and returns its ID.
-func (r *AISuggestionsRepo) CreateRun(ctx context.Context, userID uuid.UUID, triggeredBy, providerType, modelID string) (uuid.UUID, error) {
+// CreateRun inserts a run row in 'running' state and returns its ID. steering
+// is the raw JSON payload persisted on the row (nil for unsteered runs); pass
+// it pre-marshalled so this helper stays taxonomy-agnostic.
+func (r *AISuggestionsRepo) CreateRun(ctx context.Context, userID uuid.UUID, triggeredBy, providerType, modelID string, steering []byte) (uuid.UUID, error) {
 	const q = `
-		INSERT INTO ai_suggestion_runs (user_id, triggered_by, provider_type, model_id, status)
-		VALUES ($1, $2, $3, $4, 'running') RETURNING id`
+		INSERT INTO ai_suggestion_runs (user_id, triggered_by, provider_type, model_id, status, steering)
+		VALUES ($1, $2, $3, $4, 'running', $5) RETURNING id`
 	var id uuid.UUID
-	if err := r.db.QueryRow(ctx, q, userID, triggeredBy, providerType, modelID).Scan(&id); err != nil {
+	var steeringArg any
+	if len(steering) > 0 {
+		steeringArg = steering
+	}
+	if err := r.db.QueryRow(ctx, q, userID, triggeredBy, providerType, modelID, steeringArg).Scan(&id); err != nil {
 		return uuid.Nil, fmt.Errorf("create run: %w", err)
 	}
 	return id, nil
@@ -468,8 +487,11 @@ func (r *AISuggestionsRepo) ListNewSuggestionKeys(ctx context.Context, userID uu
 }
 
 // ListSuggestions returns the caller's current suggestions. Filter by type
-// ('buy' | 'read_next' | '' for all) and by status ('new' | '' for all).
-func (r *AISuggestionsRepo) ListSuggestions(ctx context.Context, userID uuid.UUID, typeFilter, statusFilter string) ([]*models.AISuggestionWithLibrary, error) {
+// ('buy' | 'read_next' | '' for all), status ('new' | '' for all), and
+// optionally scope to a specific run (non-nil runID). When runID is set, the
+// status filter is ignored — scoped views surface every suggestion the run
+// produced, including ones the user later dismissed or saved.
+func (r *AISuggestionsRepo) ListSuggestions(ctx context.Context, userID uuid.UUID, typeFilter, statusFilter string, runID *uuid.UUID) ([]*models.AISuggestionWithLibrary, error) {
 	// LEFT JOIN on books so read_next suggestions (which point into the user's
 	// library) can surface library_id for direct navigation. buy-type rows have
 	// book_id = NULL so the join just returns NULL for them.
@@ -485,7 +507,10 @@ func (r *AISuggestionsRepo) ListSuggestions(ctx context.Context, userID uuid.UUI
 		q += fmt.Sprintf(" AND s.type = $%d", len(args)+1)
 		args = append(args, typeFilter)
 	}
-	if statusFilter != "" {
+	if runID != nil {
+		q += fmt.Sprintf(" AND s.run_id = $%d", len(args)+1)
+		args = append(args, *runID)
+	} else if statusFilter != "" {
 		q += fmt.Sprintf(" AND s.status = $%d", len(args)+1)
 		args = append(args, statusFilter)
 	}
@@ -605,13 +630,13 @@ func (r *AISuggestionsRepo) GetRun(ctx context.Context, runID uuid.UUID) (*model
 	const q = `
 		SELECT id, user_id, triggered_by, provider_type, model_id, status,
 		       COALESCE(error,''), tokens_in, tokens_out, estimated_cost_usd,
-		       started_at, finished_at
+		       started_at, finished_at, steering
 		FROM ai_suggestion_runs WHERE id = $1`
 	run := &models.AISuggestionRun{}
 	err := r.db.QueryRow(ctx, q, runID).Scan(
 		&run.ID, &run.UserID, &run.TriggeredBy, &run.ProviderType, &run.ModelID,
 		&run.Status, &run.Error, &run.TokensIn, &run.TokensOut, &run.EstimatedCostUSD,
-		&run.StartedAt, &run.FinishedAt,
+		&run.StartedAt, &run.FinishedAt, &run.Steering,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, ErrNotFound
@@ -630,7 +655,7 @@ func (r *AISuggestionsRepo) ListRunsByUser(ctx context.Context, userID uuid.UUID
 	const q = `
 		SELECT id, user_id, triggered_by, provider_type, model_id, status,
 		       COALESCE(error,''), tokens_in, tokens_out, estimated_cost_usd,
-		       started_at, finished_at
+		       started_at, finished_at, steering
 		FROM ai_suggestion_runs WHERE user_id = $1
 		ORDER BY started_at DESC LIMIT $2`
 	return scanRuns(r.db.Query(ctx, q, userID, limit))
@@ -645,7 +670,7 @@ func (r *AISuggestionsRepo) ListRecentRuns(ctx context.Context, limit int) ([]*m
 	const q = `
 		SELECT id, user_id, triggered_by, provider_type, model_id, status,
 		       COALESCE(error,''), tokens_in, tokens_out, estimated_cost_usd,
-		       started_at, finished_at
+		       started_at, finished_at, steering
 		FROM ai_suggestion_runs
 		ORDER BY started_at DESC LIMIT $1`
 	return scanRuns(r.db.Query(ctx, q, limit))
@@ -662,7 +687,7 @@ func scanRuns(rows pgx.Rows, err error) ([]*models.AISuggestionRun, error) {
 		if err := rows.Scan(
 			&run.ID, &run.UserID, &run.TriggeredBy, &run.ProviderType, &run.ModelID,
 			&run.Status, &run.Error, &run.TokensIn, &run.TokensOut, &run.EstimatedCostUSD,
-			&run.StartedAt, &run.FinishedAt,
+			&run.StartedAt, &run.FinishedAt, &run.Steering,
 		); err != nil {
 			return nil, err
 		}
@@ -711,6 +736,166 @@ func (r *AISuggestionsRepo) ListBlocks(ctx context.Context, userID uuid.UUID) ([
 			return nil, err
 		}
 		out = append(out, b)
+	}
+	return out, rows.Err()
+}
+
+// ─── Steering hydration ──────────────────────────────────────────────────────
+
+// NamedEntity is one hydrated {id, name} pair — used for author/series/genre
+// names rendered into prompts and API responses for steered runs.
+type NamedEntity struct {
+	ID   uuid.UUID
+	Name string
+}
+
+// NamedTag is a hydrated tag, including its owning library for UI grouping
+// (tags are library-scoped, so two tags can share a name across libraries).
+type NamedTag struct {
+	ID        uuid.UUID
+	Name      string
+	LibraryID uuid.UUID
+}
+
+// HydratedSteering is a SuggestionSteering with display names filled in,
+// ready to render into a prompt or return from a handler. An ID that no
+// longer resolves (e.g. the author was deleted after the ask) is simply
+// dropped — the ask survives in the JSONB column but we only surface what
+// still exists.
+type HydratedSteering struct {
+	Authors []NamedEntity
+	Series  []NamedEntity
+	Genres  []NamedEntity
+	Tags    []NamedTag
+	Notes   string
+}
+
+// IsEmpty reports whether nothing at all resolved (every ID was stale and no
+// notes were set). Callers can short-circuit rendering in that case.
+func (h *HydratedSteering) IsEmpty() bool {
+	return h == nil ||
+		(len(h.Authors) == 0 && len(h.Series) == 0 && len(h.Genres) == 0 && len(h.Tags) == 0 && h.Notes == "")
+}
+
+// HydrateSteering looks up display names for every ID in the steering payload.
+// Returns nil (no error) when the input is nil or entirely empty.
+func (r *AISuggestionsRepo) HydrateSteering(ctx context.Context, s *models.SuggestionSteering) (*HydratedSteering, error) {
+	if s == nil || s.IsEmpty() {
+		return nil, nil
+	}
+	out := &HydratedSteering{Notes: s.Notes}
+	if len(s.AuthorIDs) > 0 {
+		named, err := r.resolveNamed(ctx, `SELECT id, name FROM contributors WHERE id = ANY($1)`, s.AuthorIDs)
+		if err != nil {
+			return nil, fmt.Errorf("hydrate author names: %w", err)
+		}
+		out.Authors = named
+	}
+	if len(s.SeriesIDs) > 0 {
+		named, err := r.resolveNamed(ctx, `SELECT id, name FROM series WHERE id = ANY($1)`, s.SeriesIDs)
+		if err != nil {
+			return nil, fmt.Errorf("hydrate series names: %w", err)
+		}
+		out.Series = named
+	}
+	if len(s.GenreIDs) > 0 {
+		named, err := r.resolveNamed(ctx, `SELECT id, name FROM genres WHERE id = ANY($1)`, s.GenreIDs)
+		if err != nil {
+			return nil, fmt.Errorf("hydrate genre names: %w", err)
+		}
+		out.Genres = named
+	}
+	if len(s.TagIDs) > 0 {
+		rows, err := r.db.Query(ctx, `SELECT id, name, library_id FROM tags WHERE id = ANY($1)`, s.TagIDs)
+		if err != nil {
+			return nil, fmt.Errorf("hydrate tag names: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var t NamedTag
+			if err := rows.Scan(&t.ID, &t.Name, &t.LibraryID); err != nil {
+				return nil, err
+			}
+			out.Tags = append(out.Tags, t)
+		}
+		if err := rows.Err(); err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+func (r *AISuggestionsRepo) resolveNamed(ctx context.Context, query string, ids []uuid.UUID) ([]NamedEntity, error) {
+	rows, err := r.db.Query(ctx, query, ids)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []NamedEntity
+	for rows.Next() {
+		var n NamedEntity
+		if err := rows.Scan(&n.ID, &n.Name); err != nil {
+			return nil, err
+		}
+		out = append(out, n)
+	}
+	return out, rows.Err()
+}
+
+// ResolveNames returns an id→name map for a single {id, name}-shaped table.
+// table must be one of the known taxonomy tables — we gate it in code because
+// Postgres can't parameterise identifiers. Unknown tables return an error.
+// An empty ids slice returns an empty map with no query.
+func (r *AISuggestionsRepo) ResolveNames(ctx context.Context, table string, ids []uuid.UUID) (map[uuid.UUID]string, error) {
+	out := make(map[uuid.UUID]string, len(ids))
+	if len(ids) == 0 {
+		return out, nil
+	}
+	var query string
+	switch table {
+	case "contributors":
+		query = `SELECT id, name FROM contributors WHERE id = ANY($1)`
+	case "series":
+		query = `SELECT id, name FROM series WHERE id = ANY($1)`
+	case "genres":
+		query = `SELECT id, name FROM genres WHERE id = ANY($1)`
+	default:
+		return nil, fmt.Errorf("resolve names: unsupported table %q", table)
+	}
+	rows, err := r.db.Query(ctx, query, ids)
+	if err != nil {
+		return nil, fmt.Errorf("resolve %s names: %w", table, err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id uuid.UUID
+		var name string
+		if err := rows.Scan(&id, &name); err != nil {
+			return nil, err
+		}
+		out[id] = name
+	}
+	return out, rows.Err()
+}
+
+// ResolveTags returns an id→tag map; tags need their owning library alongside
+// the name because the UI groups tags per library.
+func (r *AISuggestionsRepo) ResolveTags(ctx context.Context, ids []uuid.UUID) (map[uuid.UUID]NamedTag, error) {
+	out := make(map[uuid.UUID]NamedTag, len(ids))
+	if len(ids) == 0 {
+		return out, nil
+	}
+	rows, err := r.db.Query(ctx, `SELECT id, name, library_id FROM tags WHERE id = ANY($1)`, ids)
+	if err != nil {
+		return nil, fmt.Errorf("resolve tags: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var t NamedTag
+		if err := rows.Scan(&t.ID, &t.Name, &t.LibraryID); err != nil {
+			return nil, err
+		}
+		out[t.ID] = t
 	}
 	return out, rows.Err()
 }

--- a/internal/service/ai_suggestions.go
+++ b/internal/service/ai_suggestions.go
@@ -5,6 +5,7 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -79,8 +80,10 @@ func NewSuggestionsService(
 
 // RunForUser executes the full pipeline for a single user and returns the
 // persisted run record. Safe to call directly from a River worker or an HTTP
-// handler. triggeredBy is one of "scheduler" | "admin" | "user".
-func (s *SuggestionsService) RunForUser(ctx context.Context, userID uuid.UUID, triggeredBy string) (*models.AISuggestionRun, error) {
+// handler. triggeredBy is one of "scheduler" | "admin" | "user". steering is
+// nil for scheduled / admin runs and for unsteered manual runs; when present
+// it's persisted on the run row and rendered into the prompt.
+func (s *SuggestionsService) RunForUser(ctx context.Context, userID uuid.UUID, triggeredBy string, steering *models.SuggestionSteering) (*models.AISuggestionRun, error) {
 	// ── Precondition checks ──────────────────────────────────────────────────
 	user, err := s.repo.GetOptedInUser(ctx, userID)
 	if err != nil {
@@ -154,7 +157,7 @@ func (s *SuggestionsService) RunForUser(ctx context.Context, userID uuid.UUID, t
 	// the model to pick different titles this run. Without this the model
 	// deterministically regenerates the same picks every time, the unique index
 	// silently drops them, and the user sees no growth in the lists.
-	existing, err := s.repo.ListSuggestions(ctx, userID, "", "new")
+	existing, err := s.repo.ListSuggestions(ctx, userID, "", "new", nil)
 	if err != nil {
 		return nil, fmt.Errorf("load existing suggestions: %w", err)
 	}
@@ -168,9 +171,31 @@ func (s *SuggestionsService) RunForUser(ctx context.Context, userID uuid.UUID, t
 		}
 	}
 
+	// ── Hydrate steering (if any) ────────────────────────────────────────────
+	// Names drive both the prompt copy and the row we persist, so the same
+	// lookup serves both needs. An entirely-stale payload (every ID deleted
+	// since the ask) collapses to nil here and flows through as an unsteered
+	// run rather than silently weighting nothing.
+	var hydrated *repository.HydratedSteering
+	var steeringJSON []byte
+	if steering != nil && !steering.IsEmpty() {
+		h, err := s.repo.HydrateSteering(ctx, steering)
+		if err != nil {
+			return nil, fmt.Errorf("hydrate steering: %w", err)
+		}
+		if !h.IsEmpty() {
+			hydrated = h
+			b, err := json.Marshal(steering)
+			if err != nil {
+				return nil, fmt.Errorf("marshal steering: %w", err)
+			}
+			steeringJSON = b
+		}
+	}
+
 	// ── Build prompt ─────────────────────────────────────────────────────────
 	info := provider.Info()
-	prompt := buildSuggestionsPrompt(titles, user.TasteProfile, blocks, perms, cfg, existingBuy, existingReadNext)
+	prompt := buildSuggestionsPrompt(titles, user.TasteProfile, blocks, perms, cfg, existingBuy, existingReadNext, hydrated)
 
 	// ── Record run starting ──────────────────────────────────────────────────
 	// Stamping the configured model on the run row (and pipeline_start event)
@@ -178,7 +203,7 @@ func (s *SuggestionsService) RunForUser(ctx context.Context, userID uuid.UUID, t
 	// output — useful when comparing Ollama model choices or spotting a silent
 	// config drift.
 	modelID := provider.ConfiguredModel()
-	runID, err := s.repo.CreateRun(ctx, userID, triggeredBy, info.Name, modelID)
+	runID, err := s.repo.CreateRun(ctx, userID, triggeredBy, info.Name, modelID, steeringJSON)
 	if err != nil {
 		return nil, err
 	}
@@ -736,10 +761,58 @@ For "buy" picks, suggest real published books with valid ISBN-13 numbers you are
 Keep reasoning to one sentence focused on why THIS user would enjoy THIS book.`
 
 // buildSuggestionsPrompt assembles the pass-1 prompt. Respects admin
-// permissions by only including the data categories they've enabled.
-func buildSuggestionsPrompt(titles []*repository.LibraryTitle, taste []byte, blocks []*models.AIBlockedItem, perms AIPermissions, cfg AISuggestionsJobConfig, alreadyBuy, alreadyReadNext []string) string {
+// permissions by only including the data categories they've enabled. When
+// steering is non-nil, an explicit "user's ask for THIS run" block is rendered
+// up top so the model treats the request as primary signal rather than just
+// hints blended into the taste profile.
+func buildSuggestionsPrompt(titles []*repository.LibraryTitle, taste []byte, blocks []*models.AIBlockedItem, perms AIPermissions, cfg AISuggestionsJobConfig, alreadyBuy, alreadyReadNext []string, steering *repository.HydratedSteering) string {
 	var b strings.Builder
 	b.WriteString("I have a personal library and want two kinds of book recommendations.\n\n")
+
+	// ── User request for this run (steered only) ────────────────────────────
+	// Rendered first so the model weights this above the passive taste
+	// profile. We list only the dimensions the user actually filled in —
+	// missing ones aren't mentioned at all rather than shown as empty.
+	if !steering.IsEmpty() {
+		b.WriteString("## User request for THIS run\n")
+		b.WriteString("The user has specifically asked for suggestions weighted toward:\n")
+		if len(steering.Authors) > 0 {
+			names := make([]string, 0, len(steering.Authors))
+			for _, a := range steering.Authors {
+				names = append(names, a.Name)
+			}
+			fmt.Fprintf(&b, "  - Authors: %s\n", strings.Join(names, ", "))
+		}
+		if len(steering.Series) > 0 {
+			names := make([]string, 0, len(steering.Series))
+			for _, sr := range steering.Series {
+				names = append(names, sr.Name)
+			}
+			fmt.Fprintf(&b, "  - Series: %s\n", strings.Join(names, ", "))
+		}
+		if len(steering.Genres) > 0 {
+			names := make([]string, 0, len(steering.Genres))
+			for _, g := range steering.Genres {
+				names = append(names, g.Name)
+			}
+			fmt.Fprintf(&b, "  - Genres: %s\n", strings.Join(names, ", "))
+		}
+		if len(steering.Tags) > 0 {
+			names := make([]string, 0, len(steering.Tags))
+			for _, t := range steering.Tags {
+				names = append(names, t.Name)
+			}
+			fmt.Fprintf(&b, "  - Tags: %s\n", strings.Join(names, ", "))
+		}
+		if steering.Notes != "" {
+			fmt.Fprintf(&b, "  - Notes: %s\n", steering.Notes)
+		}
+		b.WriteString("\nPrioritise books that match this request. You may still draw on the\n")
+		b.WriteString("reading history and taste profile below as secondary signal, but when\n")
+		b.WriteString("those conflict with the request above, the request wins. For each\n")
+		b.WriteString("suggestion, briefly cite which part of the request it satisfies in\n")
+		b.WriteString("the reasoning sentence.\n\n")
+	}
 
 	// ── Library summary (high signal, always included when permitted) ───────
 	if perms.FullLibrary && len(titles) > 0 {

--- a/internal/workers/ai_suggestions_worker.go
+++ b/internal/workers/ai_suggestions_worker.go
@@ -37,7 +37,7 @@ func (w *AISuggestionsWorker) Timeout(*river.Job[models.AISuggestionsJobArgs]) t
 func (w *AISuggestionsWorker) Work(ctx context.Context, job *river.Job[models.AISuggestionsJobArgs]) error {
 	args := job.Args
 	slog.Info("ai suggestions job started", "user_id", args.UserID, "triggered_by", args.TriggeredBy)
-	_, err := w.svc.RunForUser(ctx, args.UserID, args.TriggeredBy)
+	_, err := w.svc.RunForUser(ctx, args.UserID, args.TriggeredBy, args.Steering)
 	switch {
 	case errors.Is(err, service.ErrAIDisabled):
 		// Soft skip — don't retry. Nothing to do for this user right now.


### PR DESCRIPTION
- Adds a JSONB `steering` column on `ai_suggestion_runs` for per-run user steering (author/series/genre/tag IDs + free-form notes) and wires it through handler, repo, service, and worker.
- New `/me/lookup` endpoint resolves steering IDs to display names for the client UI.