### PR TITLE
feat(m2m): book ↔ library many-to-many refactor

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -146,6 +146,7 @@ func main() {
 	workerBookSvc := service.NewBookService(
 		pool,
 		repository.NewBookRepo(pool),
+		repository.NewLibraryBookRepo(pool),
 		repository.NewContributorRepo(pool),
 		repository.NewEditionRepo(pool),
 		repository.NewTagRepo(pool),
@@ -157,6 +158,7 @@ func main() {
 		pool,
 		repository.NewImportJobRepo(pool),
 		repository.NewBookRepo(pool),
+		repository.NewLibraryBookRepo(pool),
 		repository.NewContributorRepo(pool),
 		repository.NewEditionRepo(pool),
 		repository.NewTagRepo(pool),

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -23,6 +23,78 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/admin/books/{book_id}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Permanently deletes the books row and cascades through all\nlibraries, editions, user interactions, loans, and any other\nreferences. Use with care.",
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Delete a book entirely (admin only)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Book UUID",
+                        "name": "book_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/admin/connections/ai": {
             "get": {
                 "security": [
@@ -4385,17 +4457,83 @@ const docTemplate = `{
                     }
                 }
             },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Inserts the library_books junction row. Idempotent. Used by\nthe suggestions-as-books \"Add to library\" CTA and any other\nflow that wants to attach a floating book to a real library.",
+                "tags": [
+                    "books"
+                ],
+                "summary": "Add an existing book to a library",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Library UUID",
+                        "name": "library_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Book UUID",
+                        "name": "book_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
             "delete": {
                 "security": [
                     {
                         "BearerAuth": []
                     }
                 ],
-                "description": "Permanently deletes a book and all its editions from the library.",
+                "description": "Drops the library_books junction row for this library/book.\nThe book row itself stays (may be held by other libraries or\nreferenced by AI suggestions). Use the admin endpoint to\ndelete a book entirely.",
                 "tags": [
                     "books"
                 ],
-                "summary": "Delete a book",
+                "summary": "Remove a book from a library",
                 "parameters": [
                     {
                         "type": "string",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -17,6 +17,78 @@
     "host": "localhost:8080",
     "basePath": "/api/v1",
     "paths": {
+        "/admin/books/{book_id}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Permanently deletes the books row and cascades through all\nlibraries, editions, user interactions, loans, and any other\nreferences. Use with care.",
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Delete a book entirely (admin only)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Book UUID",
+                        "name": "book_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/admin/connections/ai": {
             "get": {
                 "security": [
@@ -4379,17 +4451,83 @@
                     }
                 }
             },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Inserts the library_books junction row. Idempotent. Used by\nthe suggestions-as-books \"Add to library\" CTA and any other\nflow that wants to attach a floating book to a real library.",
+                "tags": [
+                    "books"
+                ],
+                "summary": "Add an existing book to a library",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Library UUID",
+                        "name": "library_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Book UUID",
+                        "name": "book_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
             "delete": {
                 "security": [
                     {
                         "BearerAuth": []
                     }
                 ],
-                "description": "Permanently deletes a book and all its editions from the library.",
+                "description": "Drops the library_books junction row for this library/book.\nThe book row itself stays (may be held by other libraries or\nreferenced by AI suggestions). Use the admin endpoint to\ndelete a book entirely.",
                 "tags": [
                     "books"
                 ],
-                "summary": "Delete a book",
+                "summary": "Remove a book from a library",
                 "parameters": [
                     {
                         "type": "string",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1132,6 +1132,54 @@ info:
   title: Librarium API
   version: 26.4.0
 paths:
+  /admin/books/{book_id}:
+    delete:
+      description: |-
+        Permanently deletes the books row and cascades through all
+        libraries, editions, user interactions, loans, and any other
+        references. Use with care.
+      parameters:
+      - description: Book UUID
+        in: path
+        name: book_id
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+        "403":
+          description: Forbidden
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Delete a book entirely (admin only)
+      tags:
+      - admin
   /admin/connections/ai:
     get:
       description: Returns provider status, masked config, active flag, and config-field
@@ -3606,7 +3654,11 @@ paths:
       - books
   /libraries/{library_id}/books/{book_id}:
     delete:
-      description: Permanently deletes a book and all its editions from the library.
+      description: |-
+        Drops the library_books junction row for this library/book.
+        The book row itself stays (may be held by other libraries or
+        referenced by AI suggestions). Use the admin endpoint to
+        delete a book entirely.
       parameters:
       - description: Library UUID
         in: path
@@ -3644,7 +3696,7 @@ paths:
             type: object
       security:
       - BearerAuth: []
-      summary: Delete a book
+      summary: Remove a book from a library
       tags:
       - books
     get:
@@ -3692,6 +3744,51 @@ paths:
       security:
       - BearerAuth: []
       summary: Get a book
+      tags:
+      - books
+    post:
+      description: |-
+        Inserts the library_books junction row. Idempotent. Used by
+        the suggestions-as-books "Add to library" CTA and any other
+        flow that wants to attach a floating book to a real library.
+      parameters:
+      - description: Library UUID
+        in: path
+        name: library_id
+        required: true
+        type: string
+      - description: Book UUID
+        in: path
+        name: book_id
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Add an existing book to a library
       tags:
       - books
     put:

--- a/internal/api/handlers/books.go
+++ b/internal/api/handlers/books.go
@@ -447,8 +447,11 @@ func (h *BookHandler) FindByISBN(w http.ResponseWriter, r *http.Request) {
 
 // DeleteBook godoc
 //
-// @Summary     Delete a book
-// @Description Permanently deletes a book and all its editions from the library.
+// @Summary     Remove a book from a library
+// @Description Drops the library_books junction row for this library/book.
+// @Description The book row itself stays (may be held by other libraries or
+// @Description referenced by AI suggestions). Use the admin endpoint to
+// @Description delete a book entirely.
 // @Tags        books
 // @Security    BearerAuth
 // @Param       library_id  path  string  true  "Library UUID"
@@ -459,6 +462,42 @@ func (h *BookHandler) FindByISBN(w http.ResponseWriter, r *http.Request) {
 // @Failure     404  {object}  object{error=string}
 // @Router      /libraries/{library_id}/books/{book_id} [delete]
 func (h *BookHandler) DeleteBook(w http.ResponseWriter, r *http.Request) {
+	libraryID, err := uuid.Parse(r.PathValue("library_id"))
+	if err != nil {
+		respond.Error(w, http.StatusBadRequest, "invalid library id")
+		return
+	}
+	bookID, err := uuid.Parse(r.PathValue("book_id"))
+	if err != nil {
+		respond.Error(w, http.StatusBadRequest, "invalid book id")
+		return
+	}
+	if err := h.svc.RemoveBookFromLibrary(r.Context(), libraryID, bookID); errors.Is(err, repository.ErrNotFound) {
+		respond.Error(w, http.StatusNotFound, "book not found in this library")
+		return
+	} else if err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// AdminDeleteBook godoc
+//
+// @Summary     Delete a book entirely (admin only)
+// @Description Permanently deletes the books row and cascades through all
+// @Description libraries, editions, user interactions, loans, and any other
+// @Description references. Use with care.
+// @Tags        admin
+// @Security    BearerAuth
+// @Param       book_id  path  string  true  "Book UUID"
+// @Success     204
+// @Failure     400  {object}  object{error=string}
+// @Failure     401  {object}  object{error=string}
+// @Failure     403  {object}  object{error=string}
+// @Failure     404  {object}  object{error=string}
+// @Router      /admin/books/{book_id} [delete]
+func (h *BookHandler) AdminDeleteBook(w http.ResponseWriter, r *http.Request) {
 	bookID, err := uuid.Parse(r.PathValue("book_id"))
 	if err != nil {
 		respond.Error(w, http.StatusBadRequest, "invalid book id")
@@ -468,6 +507,44 @@ func (h *BookHandler) DeleteBook(w http.ResponseWriter, r *http.Request) {
 		respond.Error(w, http.StatusNotFound, "book not found")
 		return
 	} else if err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// AddBookToLibrary godoc
+//
+// @Summary     Add an existing book to a library
+// @Description Inserts the library_books junction row. Idempotent. Used by
+// @Description the suggestions-as-books "Add to library" CTA and any other
+// @Description flow that wants to attach a floating book to a real library.
+// @Tags        books
+// @Security    BearerAuth
+// @Param       library_id  path  string  true  "Library UUID"
+// @Param       book_id     path  string  true  "Book UUID"
+// @Success     204
+// @Failure     400  {object}  object{error=string}
+// @Failure     401  {object}  object{error=string}
+// @Failure     404  {object}  object{error=string}
+// @Router      /libraries/{library_id}/books/{book_id} [post]
+func (h *BookHandler) AddBookToLibrary(w http.ResponseWriter, r *http.Request) {
+	libraryID, err := uuid.Parse(r.PathValue("library_id"))
+	if err != nil {
+		respond.Error(w, http.StatusBadRequest, "invalid library id")
+		return
+	}
+	bookID, err := uuid.Parse(r.PathValue("book_id"))
+	if err != nil {
+		respond.Error(w, http.StatusBadRequest, "invalid book id")
+		return
+	}
+	var callerID *uuid.UUID
+	if claims := middleware.ClaimsFromContext(r.Context()); claims != nil {
+		id := claims.UserID
+		callerID = &id
+	}
+	if err := h.svc.AddBookToLibrary(r.Context(), libraryID, bookID, callerID); err != nil {
 		respond.ServerError(w, r, err)
 		return
 	}

--- a/internal/api/handlers/books.go
+++ b/internal/api/handlers/books.go
@@ -558,14 +558,22 @@ func decodeBookRequest(r *http.Request) (*service.BookRequest, error) {
 func bookBody(b *models.Book) map[string]any {
 	var coverURL any
 	if b.HasCover {
-		// Include updated_at as a cache-buster so browsers fetch the new image
-		// when the cover changes rather than serving a stale cached version.
-		coverURL = fmt.Sprintf("/api/v1/libraries/%s/books/%s/cover?v=%d",
-			b.LibraryID, b.ID, b.UpdatedAt.Unix())
+		// Library-agnostic cover URL; a book can now live in multiple libraries
+		// so the cover path is keyed by book id, not library+book. Includes
+		// updated_at as a cache-buster.
+		coverURL = fmt.Sprintf("/api/v1/books/%s/cover?v=%d",
+			b.ID, b.UpdatedAt.Unix())
 	}
-	body := map[string]any{
+	// Preserve the legacy `library_id` field for clients that expect it by
+	// picking the first library this book belongs to. Empty if floating.
+	var primaryLibraryID any
+	if len(b.Libraries) > 0 {
+		primaryLibraryID = b.Libraries[0].ID
+	}
+	return map[string]any{
 		"id":               b.ID,
-		"library_id":       b.LibraryID,
+		"library_id":       primaryLibraryID,
+		"libraries":        b.Libraries,
 		"title":            b.Title,
 		"subtitle":         b.Subtitle,
 		"media_type_id":    b.MediaTypeID,
@@ -584,10 +592,6 @@ func bookBody(b *models.Book) map[string]any {
 		"language":         b.Language,
 		"user_read_status": b.UserReadStatus,
 	}
-	if b.AddedBy != nil {
-		body["added_by"] = b.AddedBy
-	}
-	return body
 }
 
 // parseFlexDate tries several date formats and returns the parsed time.

--- a/internal/api/handlers/editions.go
+++ b/internal/api/handlers/editions.go
@@ -422,7 +422,6 @@ func editionBody(e *models.BookEdition) map[string]any {
 		"publisher":                 e.Publisher,
 		"isbn_10":                   e.ISBN10,
 		"isbn_13":                   e.ISBN13,
-		"copy_count":                e.CopyCount,
 		"description":               e.Description,
 		"is_primary":                e.IsPrimary,
 		"created_at":                e.CreatedAt,
@@ -430,6 +429,9 @@ func editionBody(e *models.BookEdition) map[string]any {
 		"narrator_contributor_name": e.NarratorContributorName,
 		"files":                     files,
 	}
+	// copy_count and acquired_at are now per-library (library_book_editions).
+	// Callers that need those for a specific library should query that
+	// junction directly. Left out of the legacy per-edition body.
 	if e.NarratorContributorID != nil {
 		body["narrator_contributor_id"] = e.NarratorContributorID
 	} else {
@@ -449,11 +451,6 @@ func editionBody(e *models.BookEdition) map[string]any {
 		body["page_count"] = *e.PageCount
 	} else {
 		body["page_count"] = nil
-	}
-	if e.AcquiredAt != nil {
-		body["acquired_at"] = e.AcquiredAt.Format("2006-01-02")
-	} else {
-		body["acquired_at"] = nil
 	}
 	return body
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -48,6 +48,7 @@ func NewRouter(ctx context.Context, db *pgxpool.Pool, cfg *config.Config, riverC
 	membershipRepo := repository.NewMembershipRepo(db)
 	roleRepo := repository.NewRoleRepo(db)
 	bookRepo := repository.NewBookRepo(db)
+	libraryBookRepo := repository.NewLibraryBookRepo(db)
 	contributorRepo := repository.NewContributorRepo(db)
 	editionRepo := repository.NewEditionRepo(db)
 	tagRepo := repository.NewTagRepo(db)
@@ -89,7 +90,7 @@ func NewRouter(ctx context.Context, db *pgxpool.Pool, cfg *config.Config, riverC
 		RegistrationEnabled: cfg.RegistrationEnabled,
 	})
 	libSvc := service.NewLibraryService(db, libraryRepo, membershipRepo, roleRepo, userRepo, shelfRepo)
-	bookSvc := service.NewBookService(db, bookRepo, contributorRepo, editionRepo, tagRepo, genreRepo, coverRepo, cfg.CoverStoragePath)
+	bookSvc := service.NewBookService(db, bookRepo, libraryBookRepo, contributorRepo, editionRepo, tagRepo, genreRepo, coverRepo, cfg.CoverStoragePath)
 	editionFileSvc := service.NewEditionFileService(bookRepo, editionRepo, editionFileRepo, storageLocationRepo, cfg.EbookStoragePath, cfg.AudiobookStoragePath, cfg.EbookPathTemplate, cfg.AudiobookPathTemplate)
 	shelfSvc := service.NewShelfService(shelfRepo, tagRepo)
 	importSvc := service.NewImportService(importJobRepo, riverClient)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -282,9 +282,14 @@ func NewRouter(ctx context.Context, db *pgxpool.Pool, cfg *config.Config, riverC
 	mux.Handle("GET /api/v1/libraries/{library_id}/books/{book_id}", requireLibraryPerm("books:read", http.HandlerFunc(bookHandler.GetBook)))
 	mux.Handle("PUT /api/v1/libraries/{library_id}/books/{book_id}", requireLibraryPerm("books:update", http.HandlerFunc(bookHandler.UpdateBook)))
 	mux.Handle("DELETE /api/v1/libraries/{library_id}/books/{book_id}", requireLibraryPerm("books:delete", http.HandlerFunc(bookHandler.DeleteBook)))
+	mux.Handle("POST /api/v1/libraries/{library_id}/books/{book_id}", requireLibraryPerm("books:create", http.HandlerFunc(bookHandler.AddBookToLibrary)))
+	mux.Handle("DELETE /api/v1/admin/books/{book_id}", requireAdmin(http.HandlerFunc(bookHandler.AdminDeleteBook)))
 
 	// Covers — all operations require library read permission
 	mux.Handle("GET /api/v1/libraries/{library_id}/books/{book_id}/cover", requireLibraryPerm("books:read", http.HandlerFunc(bookHandler.ServeBookCover)))
+	// Library-agnostic cover route for books that may live in multiple
+	// libraries (or none — floating suggestion books). Just needs auth.
+	mux.Handle("GET /api/v1/books/{book_id}/cover", requireAuth(http.HandlerFunc(bookHandler.ServeBookCover)))
 	mux.Handle("POST /api/v1/libraries/{library_id}/books/{book_id}/cover/fetch", requireLibraryPerm("books:update", http.HandlerFunc(bookHandler.FetchBookCover)))
 	mux.Handle("PUT /api/v1/libraries/{library_id}/books/{book_id}/cover", requireLibraryPerm("books:update", http.HandlerFunc(bookHandler.UploadBookCover)))
 	mux.Handle("DELETE /api/v1/libraries/{library_id}/books/{book_id}/cover", requireLibraryPerm("books:update", http.HandlerFunc(bookHandler.DeleteBookCover)))

--- a/internal/db/migrations/000006_book_library_m2m_schema.down.sql
+++ b/internal/db/migrations/000006_book_library_m2m_schema.down.sql
@@ -1,0 +1,68 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Copyright (C) 2026 fireball1725
+
+-- Reverse the M2M schema refactor.
+--
+-- NOTE: this down migration is LOSSY if multi-library membership was actually
+-- used between the upgrade and the downgrade. Each book can only hold one
+-- library_id on the scalar column, so we pick the earliest library_books
+-- entry per book. Restore from a pre-migration backup if that matters.
+--
+-- If any book exists without a library_books row (e.g. a floating suggestion
+-- book created after an upstream feature like suggestions-as-books ships),
+-- the downgrade fails loudly rather than silently dropping those rows.
+
+-- ── Put the scalar columns back ────────────────────────────────────────────
+
+ALTER TABLE books         ADD COLUMN library_id  UUID REFERENCES libraries(id) ON DELETE CASCADE;
+ALTER TABLE books         ADD COLUMN added_by    UUID REFERENCES users(id);
+
+ALTER TABLE book_editions ADD COLUMN copy_count  INTEGER NOT NULL DEFAULT 1;
+ALTER TABLE book_editions ADD COLUMN acquired_at DATE;
+
+-- ── Repopulate from junctions ──────────────────────────────────────────────
+
+-- books.library_id + added_by — pick the earliest-added library_books row
+-- per book. DISTINCT ON respects the ORDER BY to choose one row per book_id.
+UPDATE books
+SET library_id = lb.library_id,
+    added_by   = lb.added_by
+FROM (
+    SELECT DISTINCT ON (book_id) book_id, library_id, added_by
+    FROM library_books
+    ORDER BY book_id, added_at ASC, id ASC
+) lb
+WHERE books.id = lb.book_id;
+
+-- Fail loudly on floating books — we have no library to downgrade them to.
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM books WHERE library_id IS NULL) THEN
+        RAISE EXCEPTION 'Cannot downgrade: some books have no library_books row (likely floating/suggestion books). Restore from pre-migration backup.';
+    END IF;
+END $$;
+
+-- Now the column can be NOT NULL again.
+ALTER TABLE books ALTER COLUMN library_id SET NOT NULL;
+
+-- Restore the library_id index.
+CREATE INDEX idx_books_library_id ON books(library_id);
+
+-- book_editions.copy_count — sum across libraries (total copies owned).
+-- acquired_at — earliest acquisition date across libraries.
+UPDATE book_editions
+SET copy_count  = COALESCE(lbe.total_copies, 1),
+    acquired_at = lbe.earliest_acquired
+FROM (
+    SELECT book_edition_id,
+           SUM(copy_count)   AS total_copies,
+           MIN(acquired_at)  AS earliest_acquired
+    FROM library_book_editions
+    GROUP BY book_edition_id
+) lbe
+WHERE book_editions.id = lbe.book_edition_id;
+
+-- ── Drop junctions ─────────────────────────────────────────────────────────
+
+DROP TABLE library_book_editions;
+DROP TABLE library_books;

--- a/internal/db/migrations/000006_book_library_m2m_schema.up.sql
+++ b/internal/db/migrations/000006_book_library_m2m_schema.up.sql
@@ -1,0 +1,69 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Copyright (C) 2026 fireball1725
+
+-- Book ↔ Library many-to-many refactor: schema phase.
+--
+-- Moves library ownership off the `books` table and onto two junctions:
+--   library_books         — work-level ownership ("does this library hold
+--                            the book at all")
+--   library_book_editions — edition-level copy counts ("this library has
+--                            2 hardbacks and 1 audiobook")
+--
+-- This migration is additive + subtractive: it creates the new structure,
+-- backfills it from the current scalar columns, then drops those columns.
+-- It does NOT dedupe ISBN-duplicate books/editions across libraries — that
+-- is 000007.
+--
+-- `book_editions.is_primary` stays on the edition — it's a property of the
+-- manifestation (e.g. "this is the 1st-print hardback"), not a per-library
+-- preference.
+
+-- ── Junctions ──────────────────────────────────────────────────────────────
+
+CREATE TABLE library_books (
+    id         UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    library_id UUID        NOT NULL REFERENCES libraries(id) ON DELETE CASCADE,
+    book_id    UUID        NOT NULL REFERENCES books(id)     ON DELETE CASCADE,
+    added_by   UUID        REFERENCES users(id),
+    added_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (library_id, book_id)
+);
+
+CREATE INDEX idx_library_books_library_id ON library_books(library_id);
+CREATE INDEX idx_library_books_book_id    ON library_books(book_id);
+
+CREATE TABLE library_book_editions (
+    library_id      UUID        NOT NULL REFERENCES libraries(id)     ON DELETE CASCADE,
+    book_edition_id UUID        NOT NULL REFERENCES book_editions(id) ON DELETE CASCADE,
+    copy_count      INTEGER     NOT NULL DEFAULT 1,
+    acquired_at     DATE,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (library_id, book_edition_id)
+);
+
+CREATE INDEX idx_lbe_book_edition_id ON library_book_editions(book_edition_id);
+
+-- ── Backfill ───────────────────────────────────────────────────────────────
+
+-- One library_books row per existing book, carrying over the current scalar
+-- ownership fields. The book's created_at becomes added_at — close enough,
+-- and we don't have a separate "added to library" timestamp today.
+INSERT INTO library_books (library_id, book_id, added_by, added_at)
+SELECT library_id, id, added_by, created_at
+FROM books;
+
+-- One library_book_editions row per existing edition, scoped to its book's
+-- library. Carries over copy_count and acquired_at.
+INSERT INTO library_book_editions (library_id, book_edition_id, copy_count, acquired_at)
+SELECT b.library_id, e.id, e.copy_count, e.acquired_at
+FROM book_editions e
+JOIN books b ON b.id = e.book_id;
+
+-- ── Drop columns that moved to junctions ───────────────────────────────────
+-- idx_books_library_id drops automatically with the column.
+
+ALTER TABLE books            DROP COLUMN library_id;
+ALTER TABLE books            DROP COLUMN added_by;
+
+ALTER TABLE book_editions    DROP COLUMN copy_count;
+ALTER TABLE book_editions    DROP COLUMN acquired_at;

--- a/internal/db/migrations/000007_dedupe_books_by_isbn.down.sql
+++ b/internal/db/migrations/000007_dedupe_books_by_isbn.down.sql
@@ -1,0 +1,13 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Copyright (C) 2026 fireball1725
+
+-- The dedupe migration is not reversible. Once two book rows have been
+-- merged into one and all FK references repointed, there is no way to
+-- reconstruct the original row identities — the losing UUIDs are gone.
+-- If you need to roll back the dedupe, restore from a pre-migration dump.
+--
+-- This down script is intentionally a no-op so `migrate down` doesn't
+-- error out on the step. 000006's down migration is the reversible piece
+-- of the M2M refactor.
+
+SELECT 1 WHERE FALSE;

--- a/internal/db/migrations/000007_dedupe_books_by_isbn.up.sql
+++ b/internal/db/migrations/000007_dedupe_books_by_isbn.up.sql
@@ -1,0 +1,287 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Copyright (C) 2026 fireball1725
+
+-- Book ↔ Library M2M refactor: dedupe phase.
+--
+-- Before M2M, the same ISBN imported into two libraries created two distinct
+-- `books` rows + two distinct `book_editions` rows. This migration collapses
+-- ISBN-duplicates to single canonical rows and repoints every FK. The
+-- canonical row for any group is always the earliest-created one.
+--
+-- Order of operations matters:
+--   1. Dedupe BOOKS first — for each ISBN shared across multiple books via
+--      their editions, merge the losers into the earliest-created book.
+--      After this, all editions that share an ISBN belong to the same book.
+--   2. Dedupe EDITIONS second — within a single book, collapse editions
+--      that share ISBN-13 or ISBN-10 into the earliest-created edition.
+--
+-- Only strictly well-formed ISBNs participate in the dedupe:
+--   ISBN-13: exactly 13 digits
+--   ISBN-10: exactly 10 characters, trailing check-digit may be 0-9 or X
+-- This guards against corrupt/truncated ISBN fields mis-merging distinct
+-- books — seen in the wild where ISBN-10 got stored as the first 11
+-- characters of an ISBN-13 (two different books in a series shared a
+-- publisher prefix and looked identical under a permissive filter).
+--
+-- Books with no valid ISBN on any edition are not deduped — title/author
+-- matching is too lossy to do automatically. They remain as separate rows;
+-- a hand-curated pass can merge them later if needed.
+
+-- ── Helper: merge a loser book into a canonical book ───────────────────────
+
+CREATE OR REPLACE FUNCTION _m2m_merge_book(canonical_id UUID, loser_id UUID)
+RETURNS VOID AS $$
+BEGIN
+    -- book_series: PK (book_id, series_id).
+    DELETE FROM book_series
+     WHERE book_id = loser_id
+       AND series_id IN (SELECT series_id FROM book_series WHERE book_id = canonical_id);
+    UPDATE book_series SET book_id = canonical_id WHERE book_id = loser_id;
+
+    -- book_contributors: PK (book_id, contributor_id, role).
+    DELETE FROM book_contributors
+     WHERE book_id = loser_id
+       AND (contributor_id, role) IN (
+             SELECT contributor_id, role FROM book_contributors WHERE book_id = canonical_id);
+    UPDATE book_contributors SET book_id = canonical_id WHERE book_id = loser_id;
+
+    -- book_genres: PK (book_id, genre_id).
+    DELETE FROM book_genres
+     WHERE book_id = loser_id
+       AND genre_id IN (SELECT genre_id FROM book_genres WHERE book_id = canonical_id);
+    UPDATE book_genres SET book_id = canonical_id WHERE book_id = loser_id;
+
+    -- book_shelves: PK (book_id, shelf_id).
+    DELETE FROM book_shelves
+     WHERE book_id = loser_id
+       AND shelf_id IN (SELECT shelf_id FROM book_shelves WHERE book_id = canonical_id);
+    UPDATE book_shelves SET book_id = canonical_id WHERE book_id = loser_id;
+
+    -- book_tags: PK (book_id, tag_id).
+    DELETE FROM book_tags
+     WHERE book_id = loser_id
+       AND tag_id IN (SELECT tag_id FROM book_tags WHERE book_id = canonical_id);
+    UPDATE book_tags SET book_id = canonical_id WHERE book_id = loser_id;
+
+    -- book_editions: move over; conflicts (same ISBN) are handled in phase 2.
+    UPDATE book_editions SET book_id = canonical_id WHERE book_id = loser_id;
+
+    -- library_books: UNIQUE(library_id, book_id).
+    DELETE FROM library_books
+     WHERE book_id = loser_id
+       AND library_id IN (SELECT library_id FROM library_books WHERE book_id = canonical_id);
+    UPDATE library_books SET book_id = canonical_id WHERE book_id = loser_id;
+
+    -- loans: no uniqueness on book_id.
+    UPDATE loans SET book_id = canonical_id WHERE book_id = loser_id;
+
+    -- Nullable FK columns — simple repoint, no conflicts.
+    UPDATE wishlist_items         SET book_id = canonical_id WHERE book_id = loser_id;
+    UPDATE import_job_items       SET book_id = canonical_id WHERE book_id = loser_id;
+    UPDATE enrichment_batch_items SET book_id = canonical_id WHERE book_id = loser_id;
+    UPDATE ai_suggestions         SET book_id = canonical_id WHERE book_id = loser_id;
+
+    -- enrichment_batches.book_ids is a JSONB UUID array — swap the loser.
+    UPDATE enrichment_batches
+       SET book_ids = (
+             SELECT to_jsonb(array_agg(DISTINCT v))
+               FROM jsonb_array_elements_text(book_ids) AS t(raw),
+                    LATERAL (SELECT CASE WHEN raw = loser_id::text
+                                         THEN canonical_id::text
+                                         ELSE raw END AS v) s
+           )
+     WHERE book_ids @> to_jsonb(loser_id::text);
+
+    DELETE FROM books WHERE id = loser_id;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ── Helper: merge a loser edition into a canonical edition ─────────────────
+
+CREATE OR REPLACE FUNCTION _m2m_merge_edition(canonical_id UUID, loser_id UUID)
+RETURNS VOID AS $$
+BEGIN
+    -- user_book_interactions: UNIQUE(user_id, book_edition_id). If both
+    -- exist for a user, keep the more-recently-updated side's fields on
+    -- the canonical row, then drop the loser.
+    UPDATE user_book_interactions c
+       SET read_status   = CASE WHEN l.updated_at > c.updated_at THEN l.read_status   ELSE c.read_status   END,
+           rating        = COALESCE(CASE WHEN l.updated_at > c.updated_at THEN l.rating        ELSE c.rating        END, c.rating),
+           notes         = COALESCE(CASE WHEN l.updated_at > c.updated_at THEN l.notes         ELSE c.notes         END, c.notes),
+           review        = COALESCE(CASE WHEN l.updated_at > c.updated_at THEN l.review        ELSE c.review        END, c.review),
+           date_started  = COALESCE(l.date_started,  c.date_started),
+           date_finished = COALESCE(l.date_finished, c.date_finished),
+           progress      = COALESCE(CASE WHEN l.updated_at > c.updated_at THEN l.progress      ELSE c.progress      END, c.progress),
+           is_favorite   = l.is_favorite OR c.is_favorite,
+           reread_count  = GREATEST(l.reread_count, c.reread_count),
+           updated_at    = GREATEST(l.updated_at, c.updated_at)
+      FROM user_book_interactions l
+     WHERE l.book_edition_id = loser_id
+       AND c.book_edition_id = canonical_id
+       AND l.user_id         = c.user_id;
+
+    DELETE FROM user_book_interactions
+     WHERE book_edition_id = loser_id
+       AND user_id IN (SELECT user_id FROM user_book_interactions
+                        WHERE book_edition_id = canonical_id);
+
+    UPDATE user_book_interactions
+       SET book_edition_id = canonical_id
+     WHERE book_edition_id = loser_id;
+
+    -- edition_files: no uniqueness, straight repoint.
+    UPDATE edition_files
+       SET edition_id = canonical_id
+     WHERE edition_id = loser_id;
+
+    -- ai_suggestions.book_edition_id: nullable, no uniqueness, repoint.
+    UPDATE ai_suggestions
+       SET book_edition_id = canonical_id
+     WHERE book_edition_id = loser_id;
+
+    -- library_book_editions: PK (library_id, book_edition_id). Sum copies
+    -- and take the earliest acquired_at when a library held both.
+    UPDATE library_book_editions c
+       SET copy_count  = c.copy_count + l.copy_count,
+           acquired_at = LEAST(c.acquired_at, l.acquired_at)
+      FROM library_book_editions l
+     WHERE l.book_edition_id = loser_id
+       AND c.book_edition_id = canonical_id
+       AND l.library_id      = c.library_id;
+
+    DELETE FROM library_book_editions
+     WHERE book_edition_id = loser_id
+       AND library_id IN (SELECT library_id FROM library_book_editions
+                           WHERE book_edition_id = canonical_id);
+
+    UPDATE library_book_editions
+       SET book_edition_id = canonical_id
+     WHERE book_edition_id = loser_id;
+
+    DELETE FROM book_editions WHERE id = loser_id;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ── Phase 1: dedupe books that share an ISBN via any edition ───────────────
+--
+-- Find every ISBN (13 first, then 10) where editions owned by multiple
+-- books match. Those books are duplicates of the same work — merge them
+-- into the earliest-created row.
+
+DO $$
+DECLARE
+    isbn TEXT;
+    canonical_id UUID;
+    loser RECORD;
+BEGIN
+    -- ISBN-13 pass
+    FOR isbn IN
+        SELECT e.isbn_13
+          FROM book_editions e
+         WHERE e.isbn_13 ~ '^[0-9]{13}$'
+         GROUP BY e.isbn_13
+        HAVING COUNT(DISTINCT e.book_id) > 1
+    LOOP
+        SELECT b.id INTO canonical_id
+          FROM books b
+          JOIN book_editions e ON e.book_id = b.id
+         WHERE e.isbn_13 = isbn
+         ORDER BY b.created_at ASC, b.id ASC
+         LIMIT 1;
+
+        FOR loser IN
+            SELECT DISTINCT b.id
+              FROM books b
+              JOIN book_editions e ON e.book_id = b.id
+             WHERE e.isbn_13 = isbn
+               AND b.id <> canonical_id
+        LOOP
+            PERFORM _m2m_merge_book(canonical_id, loser.id);
+        END LOOP;
+    END LOOP;
+
+    -- ISBN-10 pass on whatever's still duplicated
+    FOR isbn IN
+        SELECT e.isbn_10
+          FROM book_editions e
+         WHERE e.isbn_10 ~ '^[0-9]{9}[0-9Xx]$'
+         GROUP BY e.isbn_10
+        HAVING COUNT(DISTINCT e.book_id) > 1
+    LOOP
+        SELECT b.id INTO canonical_id
+          FROM books b
+          JOIN book_editions e ON e.book_id = b.id
+         WHERE e.isbn_10 = isbn
+         ORDER BY b.created_at ASC, b.id ASC
+         LIMIT 1;
+
+        FOR loser IN
+            SELECT DISTINCT b.id
+              FROM books b
+              JOIN book_editions e ON e.book_id = b.id
+             WHERE e.isbn_10 = isbn
+               AND b.id <> canonical_id
+        LOOP
+            PERFORM _m2m_merge_book(canonical_id, loser.id);
+        END LOOP;
+    END LOOP;
+END $$;
+
+-- ── Phase 2: dedupe editions within a canonical book ───────────────────────
+--
+-- After phase 1, all editions that share an ISBN belong to the same book.
+-- Collapse duplicates: earliest-created edition wins.
+
+DO $$
+DECLARE
+    isbn TEXT;
+    canonical_id UUID;
+    loser RECORD;
+BEGIN
+    FOR isbn IN
+        SELECT isbn_13
+          FROM book_editions
+         WHERE isbn_13 ~ '^[0-9]{13}$'
+         GROUP BY isbn_13
+        HAVING COUNT(*) > 1
+    LOOP
+        SELECT id INTO canonical_id
+          FROM book_editions
+         WHERE isbn_13 = isbn
+         ORDER BY created_at ASC, id ASC
+         LIMIT 1;
+
+        FOR loser IN
+            SELECT id FROM book_editions
+             WHERE isbn_13 = isbn AND id <> canonical_id
+        LOOP
+            PERFORM _m2m_merge_edition(canonical_id, loser.id);
+        END LOOP;
+    END LOOP;
+
+    FOR isbn IN
+        SELECT isbn_10
+          FROM book_editions
+         WHERE isbn_10 ~ '^[0-9]{9}[0-9Xx]$'
+         GROUP BY isbn_10
+        HAVING COUNT(*) > 1
+    LOOP
+        SELECT id INTO canonical_id
+          FROM book_editions
+         WHERE isbn_10 = isbn
+         ORDER BY created_at ASC, id ASC
+         LIMIT 1;
+
+        FOR loser IN
+            SELECT id FROM book_editions
+             WHERE isbn_10 = isbn AND id <> canonical_id
+        LOOP
+            PERFORM _m2m_merge_edition(canonical_id, loser.id);
+        END LOOP;
+    END LOOP;
+END $$;
+
+-- ── Cleanup ────────────────────────────────────────────────────────────────
+
+DROP FUNCTION _m2m_merge_book(UUID, UUID);
+DROP FUNCTION _m2m_merge_edition(UUID, UUID);

--- a/internal/models/book.go
+++ b/internal/models/book.go
@@ -32,15 +32,16 @@ type BookShelfRef struct {
 	Name string    `json:"name"`
 }
 
+// Book represents a work — the abstract creative entity. Library ownership
+// is expressed via the library_books junction (see LibraryBook); a book row
+// no longer carries a single library_id.
 type Book struct {
 	ID           uuid.UUID
-	LibraryID    uuid.UUID
 	Title        string
 	Subtitle     string
 	MediaTypeID  uuid.UUID
 	MediaType    string // display_name from joined media_types row
 	Description  string
-	AddedBy      *uuid.UUID
 	CreatedAt    time.Time
 	UpdatedAt    time.Time
 	Contributors []BookContributor
@@ -53,4 +54,22 @@ type Book struct {
 	PublishYear    *int
 	Language       string
 	UserReadStatus string
+	// Libraries is the set of libraries holding this book (populated by the
+	// service layer on reads that need it; empty when the book is floating).
+	Libraries []BookLibraryRef
+}
+
+// BookLibraryRef is a lightweight reference to a library that holds this book.
+type BookLibraryRef struct {
+	ID   uuid.UUID `json:"id"`
+	Name string    `json:"name"`
+}
+
+// LibraryBook is a row in the library_books junction — "library X holds book Y".
+type LibraryBook struct {
+	ID        uuid.UUID
+	LibraryID uuid.UUID
+	BookID    uuid.UUID
+	AddedBy   *uuid.UUID
+	AddedAt   time.Time
 }

--- a/internal/models/edition.go
+++ b/internal/models/edition.go
@@ -48,18 +48,27 @@ type BookEdition struct {
 	PublishDate            *time.Time
 	ISBN10                 string
 	ISBN13                 string
-	CopyCount              int
 	Description            string
 	DurationSeconds        *int
 	PageCount              *int
 	IsPrimary              bool
-	AcquiredAt             *time.Time
 	CreatedAt              time.Time
 	UpdatedAt              time.Time
 	NarratorContributorID   *uuid.UUID
 	NarratorContributorName string
 	// Files is populated by the service layer — not a DB column on book_editions.
 	Files []*EditionFile
+}
+
+// LibraryBookEdition is a row in the library_book_editions junction — how
+// many copies of a given edition a specific library holds, and when that
+// library acquired them.
+type LibraryBookEdition struct {
+	LibraryID     uuid.UUID
+	BookEditionID uuid.UUID
+	CopyCount     int
+	AcquiredAt    *time.Time
+	CreatedAt     time.Time
 }
 
 type UserBookInteraction struct {

--- a/internal/repository/ai_suggestions.go
+++ b/internal/repository/ai_suggestions.go
@@ -144,7 +144,7 @@ func (r *AISuggestionsRepo) ListLibraryTitles(ctx context.Context, libraryID, us
 	const q = `
 		SELECT
 			b.id,
-			b.library_id,
+			lb.library_id,
 			b.title,
 			COALESCE((
 				SELECT c.name
@@ -193,8 +193,9 @@ func (r *AISuggestionsRepo) ListLibraryTitles(ctx context.Context, libraryID, us
 			) AS has_cover,
 			b.updated_at
 		FROM books b
+		JOIN library_books lb ON lb.book_id = b.id
 		LEFT JOIN media_types mt ON mt.id = b.media_type_id
-		WHERE b.library_id = $1
+		WHERE lb.library_id = $1
 		ORDER BY b.title`
 	rows, err := r.db.Query(ctx, q, libraryID, userID)
 	if err != nil {
@@ -229,7 +230,8 @@ func (r *AISuggestionsRepo) BookExistsInLibrary(ctx context.Context, libraryID u
 			SELECT EXISTS (
 				SELECT 1 FROM book_editions be
 				JOIN books b ON b.id = be.book_id
-				WHERE b.library_id = $1 AND (be.isbn_13 = $2 OR be.isbn_10 = $2)
+				JOIN library_books lb ON lb.book_id = b.id
+				WHERE lb.library_id = $1 AND (be.isbn_13 = $2 OR be.isbn_10 = $2)
 			)`
 		var ok bool
 		if err := r.db.QueryRow(ctx, q, libraryID, isbn).Scan(&ok); err != nil {
@@ -245,7 +247,8 @@ func (r *AISuggestionsRepo) BookExistsInLibrary(ctx context.Context, libraryID u
 	const qTitle = `
 		SELECT EXISTS (
 			SELECT 1 FROM books b
-			WHERE b.library_id = $1 AND lower(b.title) = lower($2)
+			JOIN library_books lb ON lb.book_id = b.id
+			WHERE lb.library_id = $1 AND lower(b.title) = lower($2)
 		)`
 	var ok bool
 	if err := r.db.QueryRow(ctx, qTitle, libraryID, title).Scan(&ok); err != nil {
@@ -492,15 +495,24 @@ func (r *AISuggestionsRepo) ListNewSuggestionKeys(ctx context.Context, userID uu
 // status filter is ignored — scoped views surface every suggestion the run
 // produced, including ones the user later dismissed or saved.
 func (r *AISuggestionsRepo) ListSuggestions(ctx context.Context, userID uuid.UUID, typeFilter, statusFilter string, runID *uuid.UUID) ([]*models.AISuggestionWithLibrary, error) {
-	// LEFT JOIN on books so read_next suggestions (which point into the user's
-	// library) can surface library_id for direct navigation. buy-type rows have
-	// book_id = NULL so the join just returns NULL for them.
+	// For read_next suggestions, surface one library_id the user is a member
+	// of that holds the referenced book — used for direct navigation on the
+	// client. Under M2M a book can be in multiple libraries; we pick the
+	// earliest-added of the user's memberships via a LATERAL subquery. buy
+	// suggestions have book_id NULL so the subquery returns NULL for them.
 	q := `
 		SELECT s.id, s.user_id, s.run_id, s.type, s.book_id, s.book_edition_id,
 		       s.title, COALESCE(s.author,''), COALESCE(s.isbn,''), COALESCE(s.cover_url,''),
-		       COALESCE(s.reasoning,''), s.status, s.created_at, b.library_id
+		       COALESCE(s.reasoning,''), s.status, s.created_at, inlib.library_id
 		FROM ai_suggestions s
-		LEFT JOIN books b ON b.id = s.book_id
+		LEFT JOIN LATERAL (
+		    SELECT lb.library_id
+		    FROM library_books lb
+		    JOIN library_memberships lm ON lm.library_id = lb.library_id AND lm.user_id = s.user_id
+		    WHERE lb.book_id = s.book_id
+		    ORDER BY lb.added_at ASC
+		    LIMIT 1
+		) inlib ON TRUE
 		WHERE s.user_id = $1`
 	args := []any{userID}
 	if typeFilter != "" {

--- a/internal/repository/books.go
+++ b/internal/repository/books.go
@@ -85,9 +85,9 @@ func booksSelect(userStatusArg int) string {
 
 	return `
 	SELECT
-		b.id, b.library_id, b.title, b.subtitle,
+		b.id, b.title, b.subtitle,
 		b.media_type_id, mt.display_name,
-		b.description, b.added_by, b.created_at, b.updated_at,
+		b.description, b.created_at, b.updated_at,
 		(
 			SELECT COALESCE(
 				json_agg(
@@ -179,12 +179,16 @@ func booksSelect(userStatusArg int) string {
 	JOIN media_types mt ON mt.id = b.media_type_id`
 }
 
-func (r *BookRepo) Create(ctx context.Context, tx pgx.Tx, id, libraryID uuid.UUID, title, subtitle string, mediaTypeID uuid.UUID, description string, addedBy uuid.UUID) error {
+// Create inserts a new book (work). Library ownership is a separate concern —
+// call AddToLibrary on the LibraryBookRepo after creating to associate the
+// book with a library. A book with no library_books rows is a floating book
+// (e.g. an un-owned suggestion).
+func (r *BookRepo) Create(ctx context.Context, tx pgx.Tx, id uuid.UUID, title, subtitle string, mediaTypeID uuid.UUID, description string) error {
 	const q = `
-		INSERT INTO books (id, library_id, title, subtitle, media_type_id, description, added_by)
-		VALUES ($1, $2, $3, NULLIF($4,''), $5, NULLIF($6,''), $7)`
+		INSERT INTO books (id, title, subtitle, media_type_id, description)
+		VALUES ($1, $2, NULLIF($3,''), $4, NULLIF($5,''))`
 
-	_, err := tx.Exec(ctx, q, id, libraryID, title, subtitle, mediaTypeID, description, addedBy)
+	_, err := tx.Exec(ctx, q, id, title, subtitle, mediaTypeID, description)
 	if err != nil {
 		return fmt.Errorf("inserting book: %w", err)
 	}
@@ -263,23 +267,19 @@ func (r *BookRepo) FindByID(ctx context.Context, id uuid.UUID) (*models.Book, er
 func (r *BookRepo) ListByContributor(ctx context.Context, libraryID, contributorID, callerID uuid.UUID) ([]*models.Book, error) {
 	var args []any
 	var q string
+	const scope = `
+		JOIN library_books lb ON lb.book_id = b.id
+		WHERE lb.library_id = $1
+		  AND EXISTS (
+		    SELECT 1 FROM book_contributors bc2
+		    WHERE bc2.book_id = b.id AND bc2.contributor_id = $2
+		  )
+		ORDER BY natural_sort_key(b.title)`
 	if callerID != uuid.Nil {
-		q = booksSelect(3) + `
-			WHERE b.library_id = $1
-			  AND EXISTS (
-			    SELECT 1 FROM book_contributors bc2
-			    WHERE bc2.book_id = b.id AND bc2.contributor_id = $2
-			  )
-			ORDER BY natural_sort_key(b.title)`
+		q = booksSelect(3) + scope
 		args = []any{libraryID, contributorID, callerID}
 	} else {
-		q = booksSelect(0) + `
-			WHERE b.library_id = $1
-			  AND EXISTS (
-			    SELECT 1 FROM book_contributors bc2
-			    WHERE bc2.book_id = b.id AND bc2.contributor_id = $2
-			  )
-			ORDER BY natural_sort_key(b.title)`
+		q = booksSelect(0) + scope
 		args = []any{libraryID, contributorID}
 	}
 
@@ -310,7 +310,11 @@ type BookFingerprint struct {
 // Fingerprint returns the total book count and the most recent updated_at
 // (formatted RFC3339) for a library. MaxUpdatedAt is nil when empty.
 func (r *BookRepo) Fingerprint(ctx context.Context, libraryID uuid.UUID) (BookFingerprint, error) {
-	const q = `SELECT COUNT(*), MAX(updated_at) FROM books WHERE library_id = $1`
+	const q = `
+		SELECT COUNT(*), MAX(b.updated_at)
+		FROM books b
+		JOIN library_books lb ON lb.book_id = b.id
+		WHERE lb.library_id = $1`
 	var fp BookFingerprint
 	var maxTS pgtype.Timestamptz
 	if err := r.db.QueryRow(ctx, q, libraryID).Scan(&fp.Total, &maxTS); err != nil {
@@ -329,7 +333,8 @@ func (r *BookRepo) ListBookLetters(ctx context.Context, libraryID uuid.UUID) ([]
 	const q = `
 		SELECT DISTINCT upper(substr(sort_title(b.title), 1, 1)) AS letter
 		FROM books b
-		WHERE b.library_id = $1
+		JOIN library_books lb ON lb.book_id = b.id
+		WHERE lb.library_id = $1
 		  AND sort_title(b.title) ~ '^[A-Za-z]'
 		ORDER BY letter`
 	rows, err := r.db.Query(ctx, q, libraryID)
@@ -644,14 +649,16 @@ func (r *BookRepo) List(ctx context.Context, libraryID uuid.UUID, opts ListBooks
 		}
 	}
 
-	where := "WHERE b.library_id = $1"
+	// Library scope routes through the library_books junction.
+	where := "WHERE lb.library_id = $1"
 	for _, c := range conditions {
 		where += " AND " + c
 	}
+	scopeJoin := " JOIN library_books lb ON lb.book_id = b.id "
 
 	// Count
 	var total int
-	countQ := "SELECT COUNT(*) FROM books b JOIN media_types mt ON mt.id = b.media_type_id " + where
+	countQ := "SELECT COUNT(*) FROM books b JOIN media_types mt ON mt.id = b.media_type_id " + scopeJoin + where
 	if err := r.db.QueryRow(ctx, countQ, args...).Scan(&total); err != nil {
 		return nil, 0, fmt.Errorf("counting books: %w", err)
 	}
@@ -673,7 +680,7 @@ func (r *BookRepo) List(ctx context.Context, libraryID uuid.UUID, opts ListBooks
 	if opts.Sort == "publish_date" {
 		nullsClause = " NULLS LAST"
 	}
-	listQ := selectQuery + " " + where +
+	listQ := selectQuery + scopeJoin + where +
 		fmt.Sprintf(" ORDER BY %s %s%s LIMIT $%d OFFSET $%d", sortCol, sortDir, nullsClause, argIdx, argIdx+1)
 
 	rows, err := r.db.Query(ctx, listQ, args...)
@@ -735,9 +742,7 @@ func (r *BookRepo) Delete(ctx context.Context, id uuid.UUID) error {
 func scanBook(s scanner) (*models.Book, error) {
 	var (
 		pgID           pgtype.UUID
-		pgLibraryID    pgtype.UUID
 		pgMediaTypeID  pgtype.UUID
-		pgAddedBy      pgtype.UUID
 		pgSubtitle     pgtype.Text
 		pgDesc         pgtype.Text
 		mediaTypeName  string
@@ -754,9 +759,9 @@ func scanBook(s scanner) (*models.Book, error) {
 	)
 
 	err := s.Scan(
-		&pgID, &pgLibraryID, &b.Title, &pgSubtitle,
+		&pgID, &b.Title, &pgSubtitle,
 		&pgMediaTypeID, &mediaTypeName,
-		&pgDesc, &pgAddedBy, &b.CreatedAt, &b.UpdatedAt,
+		&pgDesc, &b.CreatedAt, &b.UpdatedAt,
 		&contribJSON, &tagsJSON, &genresJSON, &b.HasCover,
 		&seriesJSON, &shelvesJSON, &publisher, &publishYear, &language,
 		&userReadStatus,
@@ -766,7 +771,6 @@ func scanBook(s scanner) (*models.Book, error) {
 	}
 
 	b.ID = uuid.UUID(pgID.Bytes)
-	b.LibraryID = uuid.UUID(pgLibraryID.Bytes)
 	b.MediaTypeID = uuid.UUID(pgMediaTypeID.Bytes)
 	b.MediaType = mediaTypeName
 	b.Subtitle = pgSubtitle.String
@@ -777,11 +781,6 @@ func scanBook(s scanner) (*models.Book, error) {
 	if publishYear.Valid {
 		y := int(publishYear.Int32)
 		b.PublishYear = &y
-	}
-
-	if pgAddedBy.Valid {
-		id := uuid.UUID(pgAddedBy.Bytes)
-		b.AddedBy = &id
 	}
 
 	b.Contributors = []models.BookContributor{}
@@ -863,9 +862,19 @@ type CurrentlyReadingBook struct {
 // ordered by when the interaction was last updated (most recent first).
 // Spans all libraries the user is a member of.
 func (r *BookRepo) CurrentlyReading(ctx context.Context, userID uuid.UUID, limit int) ([]*CurrentlyReadingBook, error) {
+	// Under M2M a book may live in several libraries the user is a member of.
+	// Pick the earliest-added library as the book's representative (inner
+	// DISTINCT ON), then order the final result by last-interaction time.
 	q := `
+		WITH user_book AS (
+			SELECT DISTINCT ON (lb.book_id)
+				lb.book_id, lb.library_id
+			FROM library_books lb
+			JOIN library_memberships lm ON lm.library_id = lb.library_id AND lm.user_id = $1
+			ORDER BY lb.book_id, lb.added_at ASC
+		)
 		SELECT
-			b.id, b.library_id, l.name,
+			b.id, ub.library_id, l.name,
 			b.title, b.updated_at,
 			EXISTS(
 				SELECT 1 FROM cover_images ci
@@ -878,8 +887,8 @@ func (r *BookRepo) CurrentlyReading(ctx context.Context, userID uuid.UUID, limit
 				WHERE bc.book_id = b.id
 			), '') AS authors
 		FROM books b
-		JOIN libraries l ON l.id = b.library_id
-		JOIN library_memberships lm ON lm.library_id = b.library_id AND lm.user_id = $1
+		JOIN user_book ub ON ub.book_id = b.id
+		JOIN libraries l ON l.id = ub.library_id
 		WHERE EXISTS (
 			SELECT 1 FROM book_editions be
 			JOIN user_book_interactions ubi ON ubi.book_edition_id = be.id
@@ -933,9 +942,16 @@ type RecentlyAddedBook struct {
 // is a member of.
 func (r *BookRepo) RecentlyAdded(ctx context.Context, userID uuid.UUID, limit int) ([]*RecentlyAddedBook, error) {
 	q := `
+		WITH user_book AS (
+			SELECT DISTINCT ON (lb.book_id)
+				lb.book_id, lb.library_id, lb.added_at
+			FROM library_books lb
+			JOIN library_memberships lm ON lm.library_id = lb.library_id AND lm.user_id = $1
+			ORDER BY lb.book_id, lb.added_at ASC
+		)
 		SELECT
-			b.id, b.library_id, l.name,
-			b.title, b.created_at,
+			b.id, ub.library_id, l.name,
+			b.title, ub.added_at,
 			EXISTS(
 				SELECT 1 FROM cover_images ci
 				WHERE ci.entity_type = 'book' AND ci.entity_id = b.id AND ci.is_primary = true
@@ -960,9 +976,9 @@ func (r *BookRepo) RecentlyAdded(ctx context.Context, userID uuid.UUID, limit in
 				LIMIT 1
 			), '') AS read_status
 		FROM books b
-		JOIN libraries l ON l.id = b.library_id
-		JOIN library_memberships lm ON lm.library_id = b.library_id AND lm.user_id = $1
-		ORDER BY b.created_at DESC
+		JOIN user_book ub ON ub.book_id = b.id
+		JOIN libraries l ON l.id = ub.library_id
+		ORDER BY ub.added_at DESC
 		LIMIT $2`
 
 	rows, err := r.db.Query(ctx, q, userID, limit)
@@ -996,9 +1012,16 @@ func (r *BookRepo) RecentlyAdded(ctx context.Context, userID uuid.UUID, limit in
 // mediaTypes is empty, all media types are eligible.
 func (r *BookRepo) PicksOfTheDay(ctx context.Context, userID uuid.UUID, mediaTypes []string, daySeed string, limit int) ([]*RecentlyAddedBook, error) {
 	q := `
+		WITH user_book AS (
+			SELECT DISTINCT ON (lb.book_id)
+				lb.book_id, lb.library_id, lb.added_at
+			FROM library_books lb
+			JOIN library_memberships lm ON lm.library_id = lb.library_id AND lm.user_id = $1
+			ORDER BY lb.book_id, lb.added_at ASC
+		)
 		SELECT
-			b.id, b.library_id, l.name,
-			b.title, b.created_at,
+			b.id, ub.library_id, l.name,
+			b.title, ub.added_at,
 			EXISTS(
 				SELECT 1 FROM cover_images ci
 				WHERE ci.entity_type = 'book' AND ci.entity_id = b.id AND ci.is_primary = true
@@ -1011,8 +1034,8 @@ func (r *BookRepo) PicksOfTheDay(ctx context.Context, userID uuid.UUID, mediaTyp
 			), '') AS authors,
 			'' AS read_status
 		FROM books b
-		JOIN libraries l ON l.id = b.library_id
-		JOIN library_memberships lm ON lm.library_id = b.library_id AND lm.user_id = $1
+		JOIN user_book ub ON ub.book_id = b.id
+		JOIN libraries l ON l.id = ub.library_id
 		JOIN media_types mt ON mt.id = b.media_type_id
 		WHERE (cardinality($2::text[]) = 0 OR mt.name = ANY($2))
 		  AND NOT EXISTS (
@@ -1073,18 +1096,24 @@ type MonthlyReadBucket struct {
 func (r *BookRepo) GetDashboardStats(ctx context.Context, userID uuid.UUID) (*DashboardStats, error) {
 	var s DashboardStats
 	err := r.db.QueryRow(ctx, `
+		WITH user_book AS (
+			SELECT DISTINCT ON (lb.book_id) lb.book_id, lb.added_at
+			FROM library_books lb
+			JOIN library_memberships lm ON lm.library_id = lb.library_id AND lm.user_id = $1
+			ORDER BY lb.book_id, lb.added_at ASC
+		)
 		SELECT
 			COUNT(DISTINCT b.id) AS total_books,
 			COUNT(DISTINCT CASE WHEN ubi.read_status = 'read'    THEN b.id END) AS books_read,
 			COUNT(DISTINCT CASE WHEN ubi.read_status = 'reading' THEN b.id END) AS books_reading,
-			COUNT(DISTINCT CASE WHEN b.created_at >= date_trunc('year', NOW()) THEN b.id END) AS added_this_year,
+			COUNT(DISTINCT CASE WHEN ub.added_at >= date_trunc('year', NOW()) THEN b.id END) AS added_this_year,
 			COUNT(DISTINCT CASE
 				WHEN ubi.read_status = 'read'
 				 AND COALESCE(ubi.date_finished::timestamptz, ubi.updated_at) >= date_trunc('year', NOW())
 				THEN b.id END) AS read_this_year,
 			COUNT(DISTINCT CASE WHEN ubi.is_favorite THEN b.id END) AS favorites_count
 		FROM books b
-		JOIN library_memberships lm ON lm.library_id = b.library_id AND lm.user_id = $1
+		JOIN user_book ub ON ub.book_id = b.id
 		LEFT JOIN book_editions be ON be.book_id = b.id
 		LEFT JOIN user_book_interactions ubi ON ubi.book_edition_id = be.id AND ubi.user_id = $1`,
 		userID,
@@ -1109,7 +1138,8 @@ func (r *BookRepo) GetDashboardStats(ctx context.Context, userID uuid.UUID) (*Da
 				date_trunc('month', COALESCE(ubi.date_finished::timestamptz, ubi.updated_at)) AS m,
 				COUNT(DISTINCT b.id) AS c
 			FROM books b
-			JOIN library_memberships lm ON lm.library_id = b.library_id AND lm.user_id = $1
+			JOIN library_books lb ON lb.book_id = b.id
+			JOIN library_memberships lm ON lm.library_id = lb.library_id AND lm.user_id = $1
 			JOIN book_editions be ON be.book_id = b.id
 			JOIN user_book_interactions ubi ON ubi.book_edition_id = be.id AND ubi.user_id = $1
 			WHERE ubi.read_status = 'read'
@@ -1169,7 +1199,8 @@ func (r *BookRepo) ContinueSeries(ctx context.Context, userID uuid.UUID, limit i
 			SELECT bs.series_id, MAX(bs.position) AS max_pos
 			FROM book_series bs
 			JOIN books b ON b.id = bs.book_id
-			JOIN library_memberships lm ON lm.library_id = b.library_id AND lm.user_id = $1
+			JOIN library_books lb ON lb.book_id = b.id
+			JOIN library_memberships lm ON lm.library_id = lb.library_id AND lm.user_id = $1
 			JOIN book_editions be ON be.book_id = b.id
 			JOIN user_book_interactions ubi ON ubi.book_edition_id = be.id AND ubi.user_id = $1
 			WHERE ubi.read_status = 'read'
@@ -1178,11 +1209,13 @@ func (r *BookRepo) ContinueSeries(ctx context.Context, userID uuid.UUID, limit i
 		next_books AS (
 			-- The lowest position > max_pos that the user has NOT yet marked 'read'
 			SELECT DISTINCT ON (bs.series_id)
-				bs.series_id, bs.book_id, bs.position, urp.max_pos
+				bs.series_id, bs.book_id, bs.position, urp.max_pos,
+				lb.library_id
 			FROM book_series bs
 			JOIN user_read_positions urp ON urp.series_id = bs.series_id
 			JOIN books b ON b.id = bs.book_id
-			JOIN library_memberships lm ON lm.library_id = b.library_id AND lm.user_id = $1
+			JOIN library_books lb ON lb.book_id = b.id
+			JOIN library_memberships lm ON lm.library_id = lb.library_id AND lm.user_id = $1
 			WHERE bs.position > urp.max_pos
 			  AND NOT EXISTS (
 				SELECT 1
@@ -1196,7 +1229,7 @@ func (r *BookRepo) ContinueSeries(ctx context.Context, userID uuid.UUID, limit i
 		)
 		SELECT
 			s.id, s.name, nb.position, nb.max_pos,
-			b.id, b.library_id, l.name, b.title, b.updated_at,
+			b.id, nb.library_id, l.name, b.title, b.updated_at,
 			EXISTS(
 				SELECT 1 FROM cover_images ci
 				WHERE ci.entity_type = 'book' AND ci.entity_id = b.id AND ci.is_primary = true
@@ -1222,7 +1255,7 @@ func (r *BookRepo) ContinueSeries(ctx context.Context, userID uuid.UUID, limit i
 		FROM next_books nb
 		JOIN series s  ON s.id  = nb.series_id
 		JOIN books  b  ON b.id  = nb.book_id
-		JOIN libraries l ON l.id = b.library_id
+		JOIN libraries l ON l.id = nb.library_id
 		ORDER BY nb.position ASC, lower(s.name)
 		LIMIT $2`
 
@@ -1270,16 +1303,22 @@ type FinishedBook struct {
 // De-duplicates by book (multiple editions read collapse to a single row).
 func (r *BookRepo) RecentlyFinished(ctx context.Context, userID uuid.UUID, limit int) ([]*FinishedBook, error) {
 	q := `
-		WITH finished AS (
+		WITH user_book AS (
+			SELECT DISTINCT ON (lb.book_id) lb.book_id, lb.library_id
+			FROM library_books lb
+			JOIN library_memberships lm ON lm.library_id = lb.library_id AND lm.user_id = $1
+			ORDER BY lb.book_id, lb.added_at ASC
+		),
+		finished AS (
 			SELECT DISTINCT ON (b.id)
 				b.id AS book_id,
-				b.library_id,
+				ub.library_id,
 				b.title,
 				COALESCE(ubi.date_finished::timestamptz, ubi.updated_at) AS finished_at,
 				ubi.rating,
 				ubi.is_favorite
 			FROM books b
-			JOIN library_memberships lm ON lm.library_id = b.library_id AND lm.user_id = $1
+			JOIN user_book ub ON ub.book_id = b.id
 			JOIN book_editions be ON be.book_id = b.id
 			JOIN user_book_interactions ubi ON ubi.book_edition_id = be.id AND ubi.user_id = $1
 			WHERE ubi.read_status = 'read'

--- a/internal/repository/contributors.go
+++ b/internal/repository/contributors.go
@@ -113,7 +113,8 @@ func (r *ContributorRepo) ListForLibrary(ctx context.Context, libraryID uuid.UUI
 		FROM contributors c
 		JOIN book_contributors bc ON bc.contributor_id = c.id
 		JOIN books b ON b.id = bc.book_id
-		WHERE b.library_id = $1
+		JOIN library_books lb ON lb.book_id = b.id
+		WHERE lb.library_id = $1
 		GROUP BY c.id
 		ORDER BY c.name`
 
@@ -137,7 +138,7 @@ func (r *ContributorRepo) ListForLibrary(ctx context.Context, libraryID uuid.UUI
 // ListForLibraryPaged returns a paginated, filtered, sorted slice of contributors
 // who have at least one book in the given library.
 func (r *ContributorRepo) ListForLibraryPaged(ctx context.Context, libraryID uuid.UUID, opts ContributorListOpts) ([]*models.Contributor, int, error) {
-	conditions := []string{"b.library_id = $1"}
+	conditions := []string{"lb.library_id = $1"}
 	args := []any{libraryID}
 	idx := 2
 
@@ -159,6 +160,7 @@ func (r *ContributorRepo) ListForLibraryPaged(ctx context.Context, libraryID uui
 		FROM contributors c
 		JOIN book_contributors bc ON bc.contributor_id = c.id
 		JOIN books b ON b.id = bc.book_id
+		JOIN library_books lb ON lb.book_id = b.id
 		` + where
 	if err := r.db.QueryRow(ctx, countQ, args...).Scan(&total); err != nil {
 		return nil, 0, fmt.Errorf("counting contributors: %w", err)
@@ -195,6 +197,7 @@ func (r *ContributorRepo) ListForLibraryPaged(ctx context.Context, libraryID uui
 		FROM contributors c
 		JOIN book_contributors bc ON bc.contributor_id = c.id
 		JOIN books b ON b.id = bc.book_id
+		JOIN library_books lb ON lb.book_id = b.id
 		` + where + `
 		GROUP BY c.id
 		ORDER BY ` + sortCol + ` ` + dir + secondary + `
@@ -225,7 +228,8 @@ func (r *ContributorRepo) LettersForLibrary(ctx context.Context, libraryID uuid.
 		FROM contributors c
 		JOIN book_contributors bc ON bc.contributor_id = c.id
 		JOIN books b ON b.id = bc.book_id
-		WHERE b.library_id = $1
+		JOIN library_books lb ON lb.book_id = b.id
+		WHERE lb.library_id = $1
 		  AND c.name ~ '^[A-Za-z]'
 		ORDER BY letter`
 	rows, err := r.db.Query(ctx, q, libraryID)
@@ -430,19 +434,20 @@ func (r *ContributorRepo) ListWorks(ctx context.Context, contributorID, libraryI
 			SELECT cw.id, cw.contributor_id, cw.title, COALESCE(cw.isbn_13,''),
 			       COALESCE(cw.isbn_10,''), cw.publish_year, COALESCE(cw.cover_url,''),
 			       cw.source, cw.deleted_at, cw.created_at,
-			       (lb.id IS NOT NULL), lb.id
+			       (inlib.id IS NOT NULL), inlib.id
 			FROM contributor_works cw
 			LEFT JOIN LATERAL (
 			    SELECT b.id
 			    FROM books b
 			    JOIN book_editions be ON be.book_id = b.id
-			    WHERE b.library_id = $2
+			    JOIN library_books lbj ON lbj.book_id = b.id
+			    WHERE lbj.library_id = $2
 			      AND (
 			           (cw.isbn_13 <> '' AND be.isbn_13 = cw.isbn_13) OR
 			           (cw.isbn_10 <> '' AND be.isbn_10 = cw.isbn_10)
 			      )
 			    LIMIT 1
-			) lb ON TRUE
+			) inlib ON TRUE
 			WHERE cw.contributor_id = $1 AND cw.deleted_at IS NULL
 			ORDER BY cw.publish_year ASC NULLS LAST, cw.title`
 		args = []any{contributorID, libraryID}

--- a/internal/repository/editions.go
+++ b/internal/repository/editions.go
@@ -28,8 +28,8 @@ func NewEditionRepo(db *pgxpool.Pool) *EditionRepo {
 const editionColumns = `
 	id, book_id, format, COALESCE(language,''), COALESCE(edition_name,''),
 	COALESCE(narrator,''), COALESCE(publisher,''), publish_date,
-	COALESCE(isbn_10,''), COALESCE(isbn_13,''), copy_count, COALESCE(description,''),
-	duration_seconds, page_count, is_primary, acquired_at, created_at, updated_at,
+	COALESCE(isbn_10,''), COALESCE(isbn_13,''), COALESCE(description,''),
+	duration_seconds, page_count, is_primary, created_at, updated_at,
 	narrator_contributor_id,
 	(SELECT name FROM contributors WHERE id = narrator_contributor_id)
 `
@@ -41,8 +41,8 @@ const editionColumns = `
 const beEditionColumns = `
 	be.id, be.book_id, be.format, COALESCE(be.language,''), COALESCE(be.edition_name,''),
 	COALESCE(be.narrator,''), COALESCE(be.publisher,''), be.publish_date,
-	COALESCE(be.isbn_10,''), COALESCE(be.isbn_13,''), be.copy_count, COALESCE(be.description,''),
-	be.duration_seconds, be.page_count, be.is_primary, be.acquired_at, be.created_at, be.updated_at,
+	COALESCE(be.isbn_10,''), COALESCE(be.isbn_13,''), COALESCE(be.description,''),
+	be.duration_seconds, be.page_count, be.is_primary, be.created_at, be.updated_at,
 	be.narrator_contributor_id,
 	(SELECT name FROM contributors WHERE id = be.narrator_contributor_id)
 `
@@ -78,20 +78,20 @@ func (r *EditionRepo) FindByID(ctx context.Context, id uuid.UUID) (*models.BookE
 	return e, nil
 }
 
-func (r *EditionRepo) Create(ctx context.Context, tx pgx.Tx, id, bookID uuid.UUID, format, language, editionName, narrator, publisher string, publishDate any, isbn10, isbn13, description string, durationSeconds, pageCount any, isPrimary bool, acquiredAt any, narratorContributorID any) error {
+func (r *EditionRepo) Create(ctx context.Context, tx pgx.Tx, id, bookID uuid.UUID, format, language, editionName, narrator, publisher string, publishDate any, isbn10, isbn13, description string, durationSeconds, pageCount any, isPrimary bool, narratorContributorID any) error {
 	const q = `
 		INSERT INTO book_editions
-			(id, book_id, format, language, edition_name, narrator, publisher, publish_date, isbn_10, isbn_13, description, duration_seconds, page_count, is_primary, acquired_at, narrator_contributor_id)
+			(id, book_id, format, language, edition_name, narrator, publisher, publish_date, isbn_10, isbn_13, description, duration_seconds, page_count, is_primary, narrator_contributor_id)
 		VALUES
-			($1, $2, $3, NULLIF($4,''), NULLIF($5,''), NULLIF($6,''), NULLIF($7,''), $8, NULLIF($9,''), NULLIF($10,''), NULLIF($11,''), $12, $13, $14, $15, $16)`
-	_, err := tx.Exec(ctx, q, id, bookID, format, language, editionName, narrator, publisher, publishDate, isbn10, isbn13, description, durationSeconds, pageCount, isPrimary, acquiredAt, narratorContributorID)
+			($1, $2, $3, NULLIF($4,''), NULLIF($5,''), NULLIF($6,''), NULLIF($7,''), $8, NULLIF($9,''), NULLIF($10,''), NULLIF($11,''), $12, $13, $14, $15)`
+	_, err := tx.Exec(ctx, q, id, bookID, format, language, editionName, narrator, publisher, publishDate, isbn10, isbn13, description, durationSeconds, pageCount, isPrimary, narratorContributorID)
 	if err != nil {
 		return fmt.Errorf("inserting edition: %w", err)
 	}
 	return nil
 }
 
-func (r *EditionRepo) Update(ctx context.Context, tx pgx.Tx, id uuid.UUID, format, language, editionName, narrator, publisher string, publishDate any, isbn10, isbn13, description string, durationSeconds, pageCount any, copyCount int, isPrimary bool, acquiredAt any, narratorContributorID any) error {
+func (r *EditionRepo) Update(ctx context.Context, tx pgx.Tx, id uuid.UUID, format, language, editionName, narrator, publisher string, publishDate any, isbn10, isbn13, description string, durationSeconds, pageCount any, isPrimary bool, narratorContributorID any) error {
 	const q = `
 		UPDATE book_editions
 		SET format                   = $2,
@@ -105,12 +105,10 @@ func (r *EditionRepo) Update(ctx context.Context, tx pgx.Tx, id uuid.UUID, forma
 		    description              = NULLIF($10, ''),
 		    duration_seconds         = $11,
 		    page_count               = $12,
-		    copy_count               = $13,
-		    is_primary               = $14,
-		    acquired_at              = $15,
-		    narrator_contributor_id  = $16
+		    is_primary               = $13,
+		    narrator_contributor_id  = $14
 		WHERE id = $1`
-	_, err := tx.Exec(ctx, q, id, format, language, editionName, narrator, publisher, publishDate, isbn10, isbn13, description, durationSeconds, pageCount, copyCount, isPrimary, acquiredAt, narratorContributorID)
+	_, err := tx.Exec(ctx, q, id, format, language, editionName, narrator, publisher, publishDate, isbn10, isbn13, description, durationSeconds, pageCount, isPrimary, narratorContributorID)
 	if err != nil {
 		return fmt.Errorf("updating edition: %w", err)
 	}
@@ -135,7 +133,6 @@ func scanEdition(s scanner) (*models.BookEdition, error) {
 		pgPubDate               pgtype.Date
 		pgDuration              pgtype.Int4
 		pgPageCount             pgtype.Int4
-		pgAcquiredAt            pgtype.Date
 		pgNarratorContributorID pgtype.UUID
 		pgNarratorContribName   pgtype.Text
 		e                       models.BookEdition
@@ -143,8 +140,8 @@ func scanEdition(s scanner) (*models.BookEdition, error) {
 	err := s.Scan(
 		&pgID, &pgBookID, &e.Format, &e.Language, &e.EditionName,
 		&e.Narrator, &e.Publisher, &pgPubDate,
-		&e.ISBN10, &e.ISBN13, &e.CopyCount, &e.Description,
-		&pgDuration, &pgPageCount, &e.IsPrimary, &pgAcquiredAt, &e.CreatedAt, &e.UpdatedAt,
+		&e.ISBN10, &e.ISBN13, &e.Description,
+		&pgDuration, &pgPageCount, &e.IsPrimary, &e.CreatedAt, &e.UpdatedAt,
 		&pgNarratorContributorID, &pgNarratorContribName,
 	)
 	if err != nil {
@@ -164,10 +161,6 @@ func scanEdition(s scanner) (*models.BookEdition, error) {
 		v := int(pgPageCount.Int32)
 		e.PageCount = &v
 	}
-	if pgAcquiredAt.Valid {
-		t := pgAcquiredAt.Time
-		e.AcquiredAt = &t
-	}
 	if pgNarratorContributorID.Valid {
 		id := uuid.UUID(pgNarratorContributorID.Bytes)
 		e.NarratorContributorID = &id
@@ -183,7 +176,8 @@ func (r *EditionRepo) ListMissingFiles(ctx context.Context, libraryID uuid.UUID)
 	q := `SELECT ` + beEditionColumns + `
 		FROM book_editions be
 		JOIN books b ON b.id = be.book_id
-		WHERE b.library_id = $1
+		JOIN library_books lb ON lb.book_id = b.id
+		WHERE lb.library_id = $1
 		  AND be.format IN ('ebook','digital','audiobook')
 		  AND NOT EXISTS (SELECT 1 FROM edition_files ef WHERE ef.edition_id = be.id)
 		ORDER BY b.title, be.format`
@@ -203,15 +197,17 @@ func (r *EditionRepo) ListMissingFiles(ctx context.Context, libraryID uuid.UUID)
 	return out, rows.Err()
 }
 
-// FindByISBN returns the first edition in a library whose isbn_10 or isbn_13
-// matches the given value. Returns ErrNotFound if none match.
-func (r *EditionRepo) FindByISBN(ctx context.Context, libraryID uuid.UUID, isbn string) (*models.BookEdition, error) {
-	q := `SELECT ` + beEditionColumns + `
-		FROM book_editions be
-		JOIN books b ON b.id = be.book_id
-		WHERE b.library_id = $1 AND (be.isbn_10 = $2 OR be.isbn_13 = $2)
+// FindByISBN returns the edition (globally, regardless of library) whose
+// isbn_10 or isbn_13 matches the given value. Returns ErrNotFound if none
+// match. Callers that need library scoping can check library_book_editions
+// afterwards.
+func (r *EditionRepo) FindByISBN(ctx context.Context, isbn string) (*models.BookEdition, error) {
+	q := `SELECT ` + editionColumns + `
+		FROM book_editions
+		WHERE isbn_10 = $1 OR isbn_13 = $1
+		ORDER BY created_at ASC
 		LIMIT 1`
-	e, err := scanEdition(r.db.QueryRow(ctx, q, libraryID, isbn))
+	e, err := scanEdition(r.db.QueryRow(ctx, q, isbn))
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, ErrNotFound
 	}
@@ -221,12 +217,35 @@ func (r *EditionRepo) FindByISBN(ctx context.Context, libraryID uuid.UUID, isbn 
 	return e, nil
 }
 
-// IncrementCopyCount atomically increments the copy_count for an edition.
-func (r *EditionRepo) IncrementCopyCount(ctx context.Context, editionID uuid.UUID) error {
-	_, err := r.db.Exec(ctx,
-		`UPDATE book_editions SET copy_count = copy_count + 1 WHERE id = $1`,
-		editionID,
-	)
+// FindByISBNInLibrary returns the edition with the given ISBN, but only if
+// the given library holds it via library_book_editions. Returns ErrNotFound
+// if the edition doesn't exist or isn't held by that library.
+func (r *EditionRepo) FindByISBNInLibrary(ctx context.Context, libraryID uuid.UUID, isbn string) (*models.BookEdition, error) {
+	q := `SELECT ` + beEditionColumns + `
+		FROM book_editions be
+		JOIN library_book_editions lbe ON lbe.book_edition_id = be.id
+		WHERE lbe.library_id = $1 AND (be.isbn_10 = $2 OR be.isbn_13 = $2)
+		LIMIT 1`
+	e, err := scanEdition(r.db.QueryRow(ctx, q, libraryID, isbn))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("finding edition by isbn in library: %w", err)
+	}
+	return e, nil
+}
+
+// IncrementCopyCount bumps the copy count for an edition in a specific
+// library. Upserts — if the (library, edition) row doesn't exist, creates
+// it with copy_count = 1.
+func (r *EditionRepo) IncrementCopyCount(ctx context.Context, libraryID, editionID uuid.UUID) error {
+	const q = `
+		INSERT INTO library_book_editions (library_id, book_edition_id, copy_count)
+		VALUES ($1, $2, 1)
+		ON CONFLICT (library_id, book_edition_id)
+		DO UPDATE SET copy_count = library_book_editions.copy_count + 1`
+	_, err := r.db.Exec(ctx, q, libraryID, editionID)
 	if err != nil {
 		return fmt.Errorf("incrementing copy count: %w", err)
 	}

--- a/internal/repository/library_books.go
+++ b/internal/repository/library_books.go
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725 (Adaléa)
+
+package repository
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/fireball1725/librarium-api/internal/models"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// LibraryBookRepo manages the library_books and library_book_editions
+// junction tables — i.e., which libraries hold which works (and copy
+// counts at the edition level).
+type LibraryBookRepo struct {
+	db *pgxpool.Pool
+}
+
+func NewLibraryBookRepo(db *pgxpool.Pool) *LibraryBookRepo {
+	return &LibraryBookRepo{db: db}
+}
+
+// AddBookToLibrary inserts a library_books row if one doesn't already
+// exist for the (library, book) pair. Idempotent — re-adding a book
+// that's already in the library is a no-op.
+func (r *LibraryBookRepo) AddBookToLibrary(ctx context.Context, tx pgx.Tx, libraryID, bookID uuid.UUID, addedBy *uuid.UUID) error {
+	const q = `
+		INSERT INTO library_books (library_id, book_id, added_by)
+		VALUES ($1, $2, $3)
+		ON CONFLICT (library_id, book_id) DO NOTHING`
+	var err error
+	if tx != nil {
+		_, err = tx.Exec(ctx, q, libraryID, bookID, addedBy)
+	} else {
+		_, err = r.db.Exec(ctx, q, libraryID, bookID, addedBy)
+	}
+	if err != nil {
+		return fmt.Errorf("adding book to library: %w", err)
+	}
+	return nil
+}
+
+// RemoveBookFromLibrary drops the library_books row for the given
+// (library, book). Returns ErrNotFound if no such row exists.
+func (r *LibraryBookRepo) RemoveBookFromLibrary(ctx context.Context, libraryID, bookID uuid.UUID) error {
+	result, err := r.db.Exec(ctx,
+		`DELETE FROM library_books WHERE library_id = $1 AND book_id = $2`,
+		libraryID, bookID,
+	)
+	if err != nil {
+		return fmt.Errorf("removing book from library: %w", err)
+	}
+	if result.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// IsBookInLibrary returns true if the (library, book) pair exists in
+// library_books.
+func (r *LibraryBookRepo) IsBookInLibrary(ctx context.Context, libraryID, bookID uuid.UUID) (bool, error) {
+	var exists bool
+	err := r.db.QueryRow(ctx,
+		`SELECT EXISTS(SELECT 1 FROM library_books WHERE library_id = $1 AND book_id = $2)`,
+		libraryID, bookID,
+	).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("checking book in library: %w", err)
+	}
+	return exists, nil
+}
+
+// LibrariesForBook returns lightweight references to every library that
+// holds the given book (via the library_books junction).
+func (r *LibraryBookRepo) LibrariesForBook(ctx context.Context, bookID uuid.UUID) ([]models.BookLibraryRef, error) {
+	const q = `
+		SELECT l.id, l.name
+		FROM library_books lb
+		JOIN libraries l ON l.id = lb.library_id
+		WHERE lb.book_id = $1
+		ORDER BY lb.added_at ASC`
+	rows, err := r.db.Query(ctx, q, bookID)
+	if err != nil {
+		return nil, fmt.Errorf("listing libraries for book: %w", err)
+	}
+	defer rows.Close()
+
+	var out []models.BookLibraryRef
+	for rows.Next() {
+		var pgID pgtype.UUID
+		var name string
+		if err := rows.Scan(&pgID, &name); err != nil {
+			return nil, fmt.Errorf("scanning library ref: %w", err)
+		}
+		out = append(out, models.BookLibraryRef{ID: uuid.UUID(pgID.Bytes), Name: name})
+	}
+	return out, rows.Err()
+}
+
+// FindLibraryBook returns the junction row for a (library, book) pair,
+// or ErrNotFound.
+func (r *LibraryBookRepo) FindLibraryBook(ctx context.Context, libraryID, bookID uuid.UUID) (*models.LibraryBook, error) {
+	const q = `
+		SELECT id, library_id, book_id, added_by, added_at
+		FROM library_books
+		WHERE library_id = $1 AND book_id = $2`
+	var (
+		lb         models.LibraryBook
+		pgID       pgtype.UUID
+		pgLibID    pgtype.UUID
+		pgBookID   pgtype.UUID
+		pgAddedBy  pgtype.UUID
+	)
+	err := r.db.QueryRow(ctx, q, libraryID, bookID).Scan(&pgID, &pgLibID, &pgBookID, &pgAddedBy, &lb.AddedAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("finding library book: %w", err)
+	}
+	lb.ID = uuid.UUID(pgID.Bytes)
+	lb.LibraryID = uuid.UUID(pgLibID.Bytes)
+	lb.BookID = uuid.UUID(pgBookID.Bytes)
+	if pgAddedBy.Valid {
+		id := uuid.UUID(pgAddedBy.Bytes)
+		lb.AddedBy = &id
+	}
+	return &lb, nil
+}
+
+// SetEditionCopyCount sets the copy count for an edition in a specific
+// library. If copyCount is 0, the junction row is deleted. Upserts
+// otherwise.
+func (r *LibraryBookRepo) SetEditionCopyCount(ctx context.Context, tx pgx.Tx, libraryID, editionID uuid.UUID, copyCount int, acquiredAt *any) error {
+	if copyCount <= 0 {
+		q := `DELETE FROM library_book_editions WHERE library_id = $1 AND book_edition_id = $2`
+		var err error
+		if tx != nil {
+			_, err = tx.Exec(ctx, q, libraryID, editionID)
+		} else {
+			_, err = r.db.Exec(ctx, q, libraryID, editionID)
+		}
+		return err
+	}
+
+	const q = `
+		INSERT INTO library_book_editions (library_id, book_edition_id, copy_count, acquired_at)
+		VALUES ($1, $2, $3, $4)
+		ON CONFLICT (library_id, book_edition_id)
+		DO UPDATE SET copy_count = EXCLUDED.copy_count,
+		              acquired_at = COALESCE(EXCLUDED.acquired_at, library_book_editions.acquired_at)`
+	var acq any
+	if acquiredAt != nil {
+		acq = *acquiredAt
+	}
+	var err error
+	if tx != nil {
+		_, err = tx.Exec(ctx, q, libraryID, editionID, copyCount, acq)
+	} else {
+		_, err = r.db.Exec(ctx, q, libraryID, editionID, copyCount, acq)
+	}
+	if err != nil {
+		return fmt.Errorf("setting edition copy count: %w", err)
+	}
+	return nil
+}
+
+// GetEditionCopyCount returns the copy count for an edition in a
+// specific library. Returns 0 if the junction row doesn't exist.
+func (r *LibraryBookRepo) GetEditionCopyCount(ctx context.Context, libraryID, editionID uuid.UUID) (int, error) {
+	const q = `
+		SELECT COALESCE((
+			SELECT copy_count FROM library_book_editions
+			WHERE library_id = $1 AND book_edition_id = $2
+		), 0)`
+	var count int
+	err := r.db.QueryRow(ctx, q, libraryID, editionID).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("getting edition copy count: %w", err)
+	}
+	return count, nil
+}

--- a/internal/repository/series.go
+++ b/internal/repository/series.go
@@ -231,7 +231,8 @@ func (r *SeriesRepo) ListMatchCandidates(ctx context.Context, libraryID, seriesI
 				'[]'::json
 			) AS other_series
 		FROM books b
-		WHERE b.library_id = $1
+		JOIN library_books lb ON lb.book_id = b.id
+		WHERE lb.library_id = $1
 		  AND NOT EXISTS (
 		      SELECT 1 FROM book_series bs
 		      WHERE bs.book_id = b.id AND bs.series_id = $2
@@ -300,7 +301,8 @@ func (r *SeriesRepo) ListOrphanBooks(ctx context.Context, libraryID uuid.UUID, m
 			) AS has_cover
 		FROM books b
 		JOIN media_types mt ON mt.id = b.media_type_id
-		WHERE b.library_id = $1
+		JOIN library_books lb ON lb.book_id = b.id
+		WHERE lb.library_id = $1
 		  AND (cardinality($2::text[]) = 0 OR mt.name = ANY($2))
 		  AND NOT EXISTS (SELECT 1 FROM book_series bs WHERE bs.book_id = b.id)
 		ORDER BY b.title`

--- a/internal/service/book.go
+++ b/internal/service/book.go
@@ -32,6 +32,7 @@ func (e ErrUpstreamHTTP) Error() string {
 type BookService struct {
 	pool         *pgxpool.Pool
 	books        *repository.BookRepo
+	libraryBooks *repository.LibraryBookRepo
 	contributors *repository.ContributorRepo
 	editions     *repository.EditionRepo
 	tags         *repository.TagRepo
@@ -40,8 +41,8 @@ type BookService struct {
 	coverPath    string
 }
 
-func NewBookService(pool *pgxpool.Pool, books *repository.BookRepo, contributors *repository.ContributorRepo, editions *repository.EditionRepo, tags *repository.TagRepo, genres *repository.GenreRepo, covers *repository.CoverRepo, coverPath string) *BookService {
-	return &BookService{pool: pool, books: books, contributors: contributors, editions: editions, tags: tags, genres: genres, covers: covers, coverPath: coverPath}
+func NewBookService(pool *pgxpool.Pool, books *repository.BookRepo, libraryBooks *repository.LibraryBookRepo, contributors *repository.ContributorRepo, editions *repository.EditionRepo, tags *repository.TagRepo, genres *repository.GenreRepo, covers *repository.CoverRepo, coverPath string) *BookService {
+	return &BookService{pool: pool, books: books, libraryBooks: libraryBooks, contributors: contributors, editions: editions, tags: tags, genres: genres, covers: covers, coverPath: coverPath}
 }
 
 // ─── Media types ──────────────────────────────────────────────────────────────
@@ -78,16 +79,29 @@ type BookRequest struct {
 }
 
 func (s *BookService) CreateBook(ctx context.Context, libraryID, callerID uuid.UUID, req BookRequest) (*models.Book, error) {
-	// If an ISBN is provided and already exists in this library, increment the
-	// copy count on the matching edition and return the existing book.
+	// If an ISBN is provided and already exists globally (in any library or
+	// floating), we reuse the existing book + edition and bump the copy count
+	// for *this* library via the junction. If this library didn't already
+	// hold the book, the library_books junction row gets added too.
 	if req.Edition != nil {
 		isbn := req.Edition.ISBN13
 		if isbn == "" {
 			isbn = req.Edition.ISBN10
 		}
 		if isbn != "" {
-			if existing, err := s.editions.FindByISBN(ctx, libraryID, isbn); err == nil && existing != nil {
-				if incrErr := s.editions.IncrementCopyCount(ctx, existing.ID); incrErr != nil {
+			if existing, err := s.editions.FindByISBN(ctx, isbn); err == nil && existing != nil {
+				tx, txErr := s.pool.Begin(ctx)
+				if txErr != nil {
+					return nil, fmt.Errorf("beginning transaction: %w", txErr)
+				}
+				defer tx.Rollback(ctx)
+				if err := s.libraryBooks.AddBookToLibrary(ctx, tx, libraryID, existing.BookID, &callerID); err != nil {
+					return nil, err
+				}
+				if err := tx.Commit(ctx); err != nil {
+					return nil, fmt.Errorf("committing transaction: %w", err)
+				}
+				if incrErr := s.editions.IncrementCopyCount(ctx, libraryID, existing.ID); incrErr != nil {
 					return nil, fmt.Errorf("incrementing copy count: %w", incrErr)
 				}
 				return s.books.FindByID(ctx, existing.BookID)
@@ -103,10 +117,14 @@ func (s *BookService) CreateBook(ctx context.Context, libraryID, callerID uuid.U
 	}
 	defer tx.Rollback(ctx)
 
-	if err := s.books.Create(ctx, tx, bookID, libraryID,
+	if err := s.books.Create(ctx, tx, bookID,
 		req.Title, req.Subtitle, req.MediaTypeID,
-		req.Description, callerID,
+		req.Description,
 	); err != nil {
+		return nil, err
+	}
+
+	if err := s.libraryBooks.AddBookToLibrary(ctx, tx, libraryID, bookID, &callerID); err != nil {
 		return nil, err
 	}
 
@@ -126,12 +144,22 @@ func (s *BookService) CreateBook(ctx context.Context, libraryID, callerID uuid.U
 
 	if req.Edition != nil {
 		e := req.Edition
-		if err := s.editions.Create(ctx, tx, uuid.New(), bookID,
+		editionID := uuid.New()
+		if err := s.editions.Create(ctx, tx, editionID, bookID,
 			e.Format, e.Language, e.EditionName, e.Narrator, e.Publisher,
 			e.PublishDate, e.ISBN10, e.ISBN13, e.Description,
-			e.DurationSeconds, e.PageCount, e.IsPrimary, e.AcquiredAt,
+			e.DurationSeconds, e.PageCount, e.IsPrimary,
 			e.NarratorContributorID,
 		); err != nil {
+			return nil, err
+		}
+		// Record that this library holds 1 copy of this new edition.
+		var acq *any
+		if e.AcquiredAt != nil {
+			v := any(*e.AcquiredAt)
+			acq = &v
+		}
+		if err := s.libraryBooks.SetEditionCopyCount(ctx, tx, libraryID, editionID, 1, acq); err != nil {
 			return nil, err
 		}
 	}
@@ -144,11 +172,33 @@ func (s *BookService) CreateBook(ctx context.Context, libraryID, callerID uuid.U
 }
 
 func (s *BookService) GetBook(ctx context.Context, id uuid.UUID) (*models.Book, error) {
-	return s.books.FindByID(ctx, id)
+	b, err := s.books.FindByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	libs, err := s.libraryBooks.LibrariesForBook(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("loading libraries for book: %w", err)
+	}
+	b.Libraries = libs
+	return b, nil
+}
+
+// hydrateLibraries loads the library membership list for each of the given
+// books. Used by list paths so client UI can render "in libraries X, Y".
+func (s *BookService) hydrateLibraries(ctx context.Context, books []*models.Book) error {
+	for _, b := range books {
+		libs, err := s.libraryBooks.LibrariesForBook(ctx, b.ID)
+		if err != nil {
+			return fmt.Errorf("loading libraries for book %s: %w", b.ID, err)
+		}
+		b.Libraries = libs
+	}
+	return nil
 }
 
 func (s *BookService) FindBookByISBN(ctx context.Context, libraryID uuid.UUID, isbn string) (*models.Book, error) {
-	edition, err := s.editions.FindByISBN(ctx, libraryID, isbn)
+	edition, err := s.editions.FindByISBNInLibrary(ctx, libraryID, isbn)
 	if err != nil {
 		return nil, err
 	}
@@ -156,7 +206,14 @@ func (s *BookService) FindBookByISBN(ctx context.Context, libraryID uuid.UUID, i
 }
 
 func (s *BookService) ListBooks(ctx context.Context, libraryID uuid.UUID, opts repository.ListBooksOpts) ([]*models.Book, int, error) {
-	return s.books.List(ctx, libraryID, opts)
+	books, total, err := s.books.List(ctx, libraryID, opts)
+	if err != nil {
+		return nil, 0, err
+	}
+	if err := s.hydrateLibraries(ctx, books); err != nil {
+		return nil, 0, err
+	}
+	return books, total, nil
 }
 
 func (s *BookService) ListBookLetters(ctx context.Context, libraryID uuid.UUID) ([]string, error) {
@@ -244,7 +301,7 @@ func (s *BookService) CreateEdition(ctx context.Context, bookID uuid.UUID, req E
 	if err := s.editions.Create(ctx, tx, editionID, bookID,
 		req.Format, req.Language, req.EditionName, req.Narrator, req.Publisher,
 		req.PublishDate, req.ISBN10, req.ISBN13, req.Description,
-		req.DurationSeconds, req.PageCount, req.IsPrimary, req.AcquiredAt,
+		req.DurationSeconds, req.PageCount, req.IsPrimary,
 		req.NarratorContributorID,
 	); err != nil {
 		return nil, err
@@ -273,11 +330,13 @@ func (s *BookService) UpdateEdition(ctx context.Context, id uuid.UUID, req Editi
 	if err := s.editions.Update(ctx, tx, id,
 		req.Format, req.Language, req.EditionName, req.Narrator, req.Publisher,
 		req.PublishDate, req.ISBN10, req.ISBN13, req.Description,
-		req.DurationSeconds, req.PageCount, req.CopyCount, req.IsPrimary, req.AcquiredAt,
+		req.DurationSeconds, req.PageCount, req.IsPrimary,
 		req.NarratorContributorID,
 	); err != nil {
 		return nil, err
 	}
+	// CopyCount and AcquiredAt are per-library now and not managed on this
+	// generic Update path; use library-scoped endpoints for those.
 
 	if req.NarratorContributorID != nil {
 		// Look up the book_id from the edition to link the contributor.

--- a/internal/service/book.go
+++ b/internal/service/book.go
@@ -257,8 +257,24 @@ func (s *BookService) UpdateBook(ctx context.Context, id uuid.UUID, req BookRequ
 	return s.books.FindByID(ctx, id)
 }
 
+// DeleteBook permanently deletes a book. Cascades through library_books,
+// book_editions, user_book_interactions, loans, ai_suggestions, and every
+// other FK that references the book. Admin-only at the handler layer.
 func (s *BookService) DeleteBook(ctx context.Context, id uuid.UUID) error {
 	return s.books.Delete(ctx, id)
+}
+
+// AddBookToLibrary attaches an existing book to a library via the
+// library_books junction. Idempotent — re-adding a book already in the
+// library is a no-op.
+func (s *BookService) AddBookToLibrary(ctx context.Context, libraryID, bookID uuid.UUID, addedBy *uuid.UUID) error {
+	return s.libraryBooks.AddBookToLibrary(ctx, nil, libraryID, bookID, addedBy)
+}
+
+// RemoveBookFromLibrary drops the library_books junction row for this
+// (library, book). The book row itself stays.
+func (s *BookService) RemoveBookFromLibrary(ctx context.Context, libraryID, bookID uuid.UUID) error {
+	return s.libraryBooks.RemoveBookFromLibrary(ctx, libraryID, bookID)
 }
 
 // ─── Editions ─────────────────────────────────────────────────────────────────

--- a/internal/workers/import_worker.go
+++ b/internal/workers/import_worker.go
@@ -33,6 +33,7 @@ type ImportWorker struct {
 	pool         *pgxpool.Pool
 	importJobs   *repository.ImportJobRepo
 	books        *repository.BookRepo
+	libraryBooks *repository.LibraryBookRepo
 	contributors *repository.ContributorRepo
 	editions     *repository.EditionRepo
 	tags         *repository.TagRepo
@@ -45,6 +46,7 @@ func NewImportWorker(
 	pool *pgxpool.Pool,
 	importJobs *repository.ImportJobRepo,
 	books *repository.BookRepo,
+	libraryBooks *repository.LibraryBookRepo,
 	contributors *repository.ContributorRepo,
 	editions *repository.EditionRepo,
 	tags *repository.TagRepo,
@@ -56,6 +58,7 @@ func NewImportWorker(
 		pool:         pool,
 		importJobs:   importJobs,
 		books:        books,
+		libraryBooks: libraryBooks,
 		contributors: contributors,
 		editions:     editions,
 		tags:         tags,
@@ -232,10 +235,16 @@ func (w *ImportWorker) processItem(
 	}
 
 	// ── Duplicate check (ISBN deduplication at edition level) ─────────────────
+	// Under M2M, an edition with a given ISBN exists globally at most once.
+	// If we already have one, add this library to its junction and bump the
+	// copy count there — no duplicate book/edition rows created.
 	if isbn != "" {
-		existing, err := w.editions.FindByISBN(ctx, job.LibraryID, isbn)
+		existing, err := w.editions.FindByISBN(ctx, isbn)
 		if err == nil && existing != nil {
-			if incrErr := w.editions.IncrementCopyCount(ctx, existing.ID); incrErr != nil {
+			if addErr := w.libraryBooks.AddBookToLibrary(ctx, nil, job.LibraryID, existing.BookID, &job.CreatedBy); addErr != nil {
+				return models.ImportItemFailed, fmt.Sprintf("adding book to library: %v", addErr), nil
+			}
+			if incrErr := w.editions.IncrementCopyCount(ctx, job.LibraryID, existing.ID); incrErr != nil {
 				return models.ImportItemFailed, fmt.Sprintf("increment copy count: %v", incrErr), nil
 			}
 			bookID := existing.BookID
@@ -347,11 +356,15 @@ func (w *ImportWorker) processItem(
 	}
 	defer tx.Rollback(ctx)
 
-	if err := w.books.Create(ctx, tx, bookID, job.LibraryID,
+	if err := w.books.Create(ctx, tx, bookID,
 		finalTitle, finalSubtitle, mediaTypeID,
-		finalDescription, job.CreatedBy,
+		finalDescription,
 	); err != nil {
 		return models.ImportItemFailed, fmt.Sprintf("creating book: %v", err), nil
+	}
+
+	if err := w.libraryBooks.AddBookToLibrary(ctx, tx, job.LibraryID, bookID, &job.CreatedBy); err != nil {
+		return models.ImportItemFailed, fmt.Sprintf("adding book to library: %v", err), nil
 	}
 
 	if len(contribs) > 0 {
@@ -388,12 +401,22 @@ func (w *ImportWorker) processItem(
 		}
 	}
 
-	if err := w.editions.Create(ctx, tx, uuid.New(), bookID,
+	editionID := uuid.New()
+	if err := w.editions.Create(ctx, tx, editionID, bookID,
 		format, editionLang, "", "", finalPublisher,
 		publishDate, finalISBN10, finalISBN13, finalDescription,
-		nil, pageCount, true, acquiredAt, nil,
+		nil, pageCount, true, nil,
 	); err != nil {
 		return models.ImportItemFailed, fmt.Sprintf("creating edition: %v", err), nil
+	}
+	// Record this library's copy of the new edition.
+	var acq *any
+	if acquiredAt != nil {
+		v := any(*acquiredAt)
+		acq = &v
+	}
+	if err := w.libraryBooks.SetEditionCopyCount(ctx, tx, job.LibraryID, editionID, 1, acq); err != nil {
+		return models.ImportItemFailed, fmt.Sprintf("setting library copy count: %v", err), nil
 	}
 
 	if err := tx.Commit(ctx); err != nil {

--- a/internal/workers/metadata_worker.go
+++ b/internal/workers/metadata_worker.go
@@ -297,9 +297,7 @@ func (w *MetadataWorker) applyMerged(
 		Description:     primary.Description,
 		DurationSeconds: primary.DurationSeconds,
 		PageCount:       newPageCount,
-		CopyCount:       primary.CopyCount,
 		IsPrimary:       primary.IsPrimary,
-		AcquiredAt:      primary.AcquiredAt,
 	}); err != nil {
 		return fmt.Errorf("updating edition: %w", err)
 	}


### PR DESCRIPTION
- Moves library ownership off \`books\`/\`book_editions\` onto new \`library_books\` and \`library_book_editions\` junction tables. Unifies what used to be duplicate rows when the same ISBN was imported into multiple libraries.
- Adds add/remove-from-library endpoints, an admin-only delete-book-entirely endpoint, and a library-agnostic book cover route. Prerequisite for suggestions-as-books (floating books = books with zero junction rows). See [plans/book-library-m2m.md](../plans/book-library-m2m.md).