### PR TITLE
feat(suggestions): suggestions-as-books phase 1

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -156,6 +156,7 @@ func main() {
 		repository.NewTagRepo(pool),
 		repository.NewGenreRepo(pool),
 		repository.NewCoverRepo(pool),
+		aiSuggestionsRepo,
 		cfg.CoverStoragePath,
 	)
 	importWorker := workers.NewImportWorker(

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -139,13 +139,9 @@ func main() {
 	aiUserSvc := service.NewAIUserService(repository.NewUserAISettingsRepo(pool))
 	jobSvc := service.NewJobService(settingsRepo)
 	aiSuggestionsRepo := repository.NewAISuggestionsRepo(pool)
-	suggestionsSvc := service.NewSuggestionsService(
-		pool,
-		aiSuggestionsRepo,
-		repository.NewBookRepo(pool),
-		repository.NewEditionRepo(pool),
-		aiRegistry, aiSvc, jobSvc, aiUserSvc, providerSvc,
-	)
+	// workerBookSvc is constructed immediately below; the suggestions worker
+	// needs it to fetch floating-book covers after creation. Build workerBookSvc
+	// first so we can pass it through.
 
 	workerBookSvc := service.NewBookService(
 		pool,
@@ -158,6 +154,14 @@ func main() {
 		repository.NewCoverRepo(pool),
 		aiSuggestionsRepo,
 		cfg.CoverStoragePath,
+	)
+	suggestionsSvc := service.NewSuggestionsService(
+		pool,
+		aiSuggestionsRepo,
+		repository.NewBookRepo(pool),
+		repository.NewEditionRepo(pool),
+		workerBookSvc,
+		aiRegistry, aiSvc, jobSvc, aiUserSvc, providerSvc,
 	)
 	importWorker := workers.NewImportWorker(
 		pool,

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -140,7 +140,11 @@ func main() {
 	jobSvc := service.NewJobService(settingsRepo)
 	aiSuggestionsRepo := repository.NewAISuggestionsRepo(pool)
 	suggestionsSvc := service.NewSuggestionsService(
-		aiSuggestionsRepo, aiRegistry, aiSvc, jobSvc, aiUserSvc, providerSvc,
+		pool,
+		aiSuggestionsRepo,
+		repository.NewBookRepo(pool),
+		repository.NewEditionRepo(pool),
+		aiRegistry, aiSvc, jobSvc, aiUserSvc, providerSvc,
 	)
 
 	workerBookSvc := service.NewBookService(

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -90,7 +90,7 @@ func NewRouter(ctx context.Context, db *pgxpool.Pool, cfg *config.Config, riverC
 		RegistrationEnabled: cfg.RegistrationEnabled,
 	})
 	libSvc := service.NewLibraryService(db, libraryRepo, membershipRepo, roleRepo, userRepo, shelfRepo)
-	bookSvc := service.NewBookService(db, bookRepo, libraryBookRepo, contributorRepo, editionRepo, tagRepo, genreRepo, coverRepo, cfg.CoverStoragePath)
+	bookSvc := service.NewBookService(db, bookRepo, libraryBookRepo, contributorRepo, editionRepo, tagRepo, genreRepo, coverRepo, aiSuggestionsRepo, cfg.CoverStoragePath)
 	editionFileSvc := service.NewEditionFileService(bookRepo, editionRepo, editionFileRepo, storageLocationRepo, cfg.EbookStoragePath, cfg.AudiobookStoragePath, cfg.EbookPathTemplate, cfg.AudiobookPathTemplate)
 	shelfSvc := service.NewShelfService(shelfRepo, tagRepo)
 	importSvc := service.NewImportService(importJobRepo, riverClient)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -290,6 +290,16 @@ func NewRouter(ctx context.Context, db *pgxpool.Pool, cfg *config.Config, riverC
 	// Library-agnostic cover route for books that may live in multiple
 	// libraries (or none — floating suggestion books). Just needs auth.
 	mux.Handle("GET /api/v1/books/{book_id}/cover", requireAuth(http.HandlerFunc(bookHandler.ServeBookCover)))
+	// Library-agnostic book reads for BookDetailPage on floating suggestion
+	// books. Same handlers as their library-scoped counterparts — those only
+	// consume book_id.
+	mux.Handle("GET /api/v1/books/{book_id}", requireAuth(http.HandlerFunc(bookHandler.GetBook)))
+	mux.Handle("GET /api/v1/books/{book_id}/editions", requireAuth(http.HandlerFunc(bookHandler.ListEditions)))
+	// Per-book re-enrichment against a floating book still needs a library
+	// context (enrichment_batches.library_id is non-null today). Add that
+	// endpoint in a follow-up when either (a) we make library_id nullable on
+	// the batch, or (b) we decide on a picker UX. For now, users can
+	// re-enrich after adding the book to a library.
 	mux.Handle("POST /api/v1/libraries/{library_id}/books/{book_id}/cover/fetch", requireLibraryPerm("books:update", http.HandlerFunc(bookHandler.FetchBookCover)))
 	mux.Handle("PUT /api/v1/libraries/{library_id}/books/{book_id}/cover", requireLibraryPerm("books:update", http.HandlerFunc(bookHandler.UploadBookCover)))
 	mux.Handle("DELETE /api/v1/libraries/{library_id}/books/{book_id}/cover", requireLibraryPerm("books:update", http.HandlerFunc(bookHandler.DeleteBookCover)))

--- a/internal/db/migrations/000008_suggestions_require_book_id.down.sql
+++ b/internal/db/migrations/000008_suggestions_require_book_id.down.sql
@@ -1,0 +1,57 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Copyright (C) 2026 fireball1725
+
+-- Reverses 000008: drops the NOT NULL + CASCADE on ai_suggestions.book_id,
+-- re-adds the denormalised title/author/isbn/cover_url columns, and copies
+-- data back from the joined books + editions rows where possible.
+--
+-- NOTE: this down-migration will copy title from the current books.title
+-- (which may have been edited/enriched since the suggestion was made) and
+-- pick the first edition's ISBN. Cover URL is not restored (it was a
+-- transient external URL at suggestion time and we no longer store it).
+-- If exact historical fidelity matters, restore from a pre-migration dump.
+
+-- Restore the FK to the pre-000008 ON DELETE SET NULL behaviour.
+ALTER TABLE ai_suggestions
+    DROP CONSTRAINT ai_suggestions_book_id_fkey,
+    ADD CONSTRAINT ai_suggestions_book_id_fkey
+      FOREIGN KEY (book_id) REFERENCES books(id) ON DELETE SET NULL;
+
+ALTER TABLE ai_suggestions
+    ALTER COLUMN book_id DROP NOT NULL;
+
+-- Re-add the denorm columns (all nullable, as they were originally).
+ALTER TABLE ai_suggestions
+    ADD COLUMN title     TEXT NOT NULL DEFAULT '',
+    ADD COLUMN author    TEXT,
+    ADD COLUMN isbn      TEXT,
+    ADD COLUMN cover_url TEXT;
+
+-- Drop the book_id-based unique index and restore the title-based one.
+DROP INDEX IF EXISTS idx_ai_suggestions_unique_new;
+
+-- Best-effort repopulation from the joined book/edition rows.
+UPDATE ai_suggestions s
+   SET title  = b.title,
+       author = COALESCE(
+                  (SELECT c.name
+                     FROM book_contributors bc
+                     JOIN contributors c ON c.id = bc.contributor_id
+                    WHERE bc.book_id = b.id AND bc.role = 'author'
+                    ORDER BY bc.display_order
+                    LIMIT 1),
+                  NULL),
+       isbn   = COALESCE(
+                  (SELECT COALESCE(NULLIF(e.isbn_13,''), NULLIF(e.isbn_10,''))
+                     FROM book_editions e
+                    WHERE e.book_id = b.id
+                    ORDER BY e.is_primary DESC, e.created_at ASC
+                    LIMIT 1),
+                  NULL)
+  FROM books b
+ WHERE s.book_id = b.id;
+
+-- Restore the title-based unique index.
+CREATE UNIQUE INDEX idx_ai_suggestions_unique_new
+    ON ai_suggestions (user_id, type, lower(title))
+    WHERE status = 'new';

--- a/internal/db/migrations/000008_suggestions_require_book_id.up.sql
+++ b/internal/db/migrations/000008_suggestions_require_book_id.up.sql
@@ -1,0 +1,123 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Copyright (C) 2026 fireball1725
+
+-- Suggestions-as-Books: ai_suggestions always references a real book.
+--
+-- Backfills every buy-type suggestion that's missing a book_id with either
+-- an existing edition's book_id (ISBN match, post-M2M dedupe) or a newly
+-- created floating book + edition derived from the suggestion's denormalised
+-- title/author/isbn/cover_url fields. Then drops those denorm columns and
+-- makes book_id NOT NULL so the worker can't insert a dangling suggestion.
+--
+-- read_next suggestions already have book_id populated (they reference a
+-- book the user owns); they're untouched here.
+--
+-- This is not reversible in any meaningful way — once the denorm columns
+-- are dropped, down-migrating just re-adds them empty. See down.sql.
+
+-- ── Backfill step 1: reuse existing editions where the ISBN matches ────────
+-- A buy suggestion whose ISBN already resolves to an edition in the catalog
+-- (possibly because another user was suggested the same book, or because
+-- the book got imported into some library after the suggestion was made)
+-- gets wired up to that edition's book_id.
+
+UPDATE ai_suggestions s
+   SET book_id         = e.book_id,
+       book_edition_id = e.id
+  FROM book_editions e
+ WHERE s.type = 'buy'
+   AND s.book_id IS NULL
+   AND s.isbn IS NOT NULL
+   AND s.isbn <> ''
+   AND (e.isbn_13 = s.isbn OR e.isbn_10 = s.isbn);
+
+-- ── Backfill step 2: create floating books for everything else ─────────────
+-- Pick a default media_type_id (prefer "novel", fall back to the first one).
+
+DO $$
+DECLARE
+    default_media_type_id UUID;
+    sugg RECORD;
+    new_book_id UUID;
+    new_edition_id UUID;
+BEGIN
+    SELECT id INTO default_media_type_id
+      FROM media_types
+     WHERE name = 'novel'
+     LIMIT 1;
+    IF default_media_type_id IS NULL THEN
+        SELECT id INTO default_media_type_id FROM media_types ORDER BY name LIMIT 1;
+    END IF;
+    IF default_media_type_id IS NULL THEN
+        RAISE EXCEPTION 'No media types defined; cannot backfill floating books';
+    END IF;
+
+    FOR sugg IN
+        SELECT id, title, COALESCE(NULLIF(isbn,''),'') AS isbn
+          FROM ai_suggestions
+         WHERE type = 'buy' AND book_id IS NULL
+    LOOP
+        new_book_id := gen_random_uuid();
+        new_edition_id := gen_random_uuid();
+
+        INSERT INTO books (id, title, media_type_id)
+        VALUES (new_book_id, sugg.title, default_media_type_id);
+
+        INSERT INTO book_editions (id, book_id, format, isbn_13, is_primary)
+        VALUES (
+            new_edition_id,
+            new_book_id,
+            'paperback',
+            NULLIF(sugg.isbn, ''),
+            TRUE
+        );
+
+        UPDATE ai_suggestions
+           SET book_id = new_book_id,
+               book_edition_id = new_edition_id
+         WHERE id = sugg.id;
+    END LOOP;
+END $$;
+
+-- ── Lock it in ─────────────────────────────────────────────────────────────
+-- At this point every suggestion should have a book_id. Anything left over
+-- is a bug — fail loudly rather than silently dropping rows.
+
+DO $$
+DECLARE
+    orphan_count INT;
+BEGIN
+    SELECT COUNT(*) INTO orphan_count FROM ai_suggestions WHERE book_id IS NULL;
+    IF orphan_count > 0 THEN
+        RAISE EXCEPTION
+          'Backfill left % ai_suggestions rows with null book_id; refusing to make column NOT NULL',
+          orphan_count;
+    END IF;
+END $$;
+
+ALTER TABLE ai_suggestions
+    ALTER COLUMN book_id SET NOT NULL;
+
+-- Book deletion should cascade through suggestions — previously SET NULL,
+-- which left dangling denormalised rows around. With book_id NOT NULL that's
+-- no longer an option. Swap to CASCADE.
+ALTER TABLE ai_suggestions
+    DROP CONSTRAINT ai_suggestions_book_id_fkey,
+    ADD CONSTRAINT ai_suggestions_book_id_fkey
+      FOREIGN KEY (book_id) REFERENCES books(id) ON DELETE CASCADE;
+
+-- ── Drop the denormalised columns ──────────────────────────────────────────
+-- Responses now hydrate from the joined books row. The partial unique index
+-- on (user_id, type, lower(title)) auto-drops with the title column.
+
+ALTER TABLE ai_suggestions
+    DROP COLUMN title,
+    DROP COLUMN author,
+    DROP COLUMN isbn,
+    DROP COLUMN cover_url;
+
+-- Replace the dropped unique index with one keyed on book_id — same
+-- "one 'new' suggestion per (user, type, book)" semantic.
+CREATE UNIQUE INDEX idx_ai_suggestions_unique_new
+    ON ai_suggestions (user_id, type, book_id)
+    WHERE status = 'new';

--- a/internal/repository/ai_suggestions.go
+++ b/internal/repository/ai_suggestions.go
@@ -473,8 +473,15 @@ func (r *AISuggestionsRepo) AppendSuggestions(ctx context.Context, userID, runID
 // 'new' suggestions. Used by the service to dedupe a new run's candidates
 // against what's already in the pool, so a backfill pass doesn't churn on a
 // title the unique index would silently drop anyway.
+//
+// Post-000008 the title lives on the joined books row, not on the suggestion
+// itself.
 func (r *AISuggestionsRepo) ListNewSuggestionKeys(ctx context.Context, userID uuid.UUID) (map[string]struct{}, error) {
-	const q = `SELECT lower(title) FROM ai_suggestions WHERE user_id = $1 AND status = 'new'`
+	const q = `
+		SELECT lower(b.title)
+		  FROM ai_suggestions s
+		  JOIN books b ON b.id = s.book_id
+		 WHERE s.user_id = $1 AND s.status = 'new'`
 	rows, err := r.db.Query(ctx, q, userID)
 	if err != nil {
 		return nil, fmt.Errorf("list new keys: %w", err)

--- a/internal/repository/ai_suggestions.go
+++ b/internal/repository/ai_suggestions.go
@@ -575,6 +575,23 @@ func (r *AISuggestionsRepo) ListSuggestions(ctx context.Context, userID uuid.UUI
 	return out, rows.Err()
 }
 
+// DeleteForActionTaken removes all ai_suggestions rows for (user, type, book)
+// regardless of their current status. Used for the "remove on action" rules:
+//   - type="read_next" when the user logs a read on any edition of the book
+//   - type="buy"       when the user adds the book to a library
+//
+// Returns the number of suggestion rows deleted (0 if none matched — safe to
+// call unconditionally from a hook that fires on every interaction upsert).
+func (r *AISuggestionsRepo) DeleteForActionTaken(ctx context.Context, userID, bookID uuid.UUID, suggestionType string) (int64, error) {
+	const q = `DELETE FROM ai_suggestions
+	            WHERE user_id = $1 AND book_id = $2 AND type = $3`
+	tag, err := r.db.Exec(ctx, q, userID, bookID, suggestionType)
+	if err != nil {
+		return 0, fmt.Errorf("delete suggestions on action: %w", err)
+	}
+	return tag.RowsAffected(), nil
+}
+
 // UpdateSuggestionStatus changes the user-visible status flag. Returns
 // ErrNotFound if the row doesn't exist or doesn't belong to the caller.
 func (r *AISuggestionsRepo) UpdateSuggestionStatus(ctx context.Context, id, userID uuid.UUID, status string) error {

--- a/internal/repository/ai_suggestions.go
+++ b/internal/repository/ai_suggestions.go
@@ -432,14 +432,16 @@ func (r *AISuggestionsRepo) AppendSuggestions(ctx context.Context, userID, runID
 	// would lose AI output order inside a single run.
 	const ins = `
 		INSERT INTO ai_suggestions (user_id, run_id, type, book_id, book_edition_id,
-			title, author, isbn, cover_url, reasoning, status, created_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, 'new', clock_timestamp())
+			reasoning, status, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6, 'new', clock_timestamp())
 		ON CONFLICT DO NOTHING`
 	for _, it := range items {
+		if it.BookID == nil {
+			return fmt.Errorf("insert suggestion: book_id required (type=%s title=%q)", it.Type, it.Title)
+		}
 		if _, err := tx.Exec(ctx, ins, userID, runID, it.Type,
 			it.BookID, it.BookEditionID,
-			it.Title, nilIfEmpty(it.Author), nilIfEmpty(it.ISBN),
-			nilIfEmpty(it.CoverURL), nilIfEmpty(it.Reasoning),
+			nilIfEmpty(it.Reasoning),
 		); err != nil {
 			return fmt.Errorf("insert suggestion: %w", err)
 		}
@@ -500,11 +502,36 @@ func (r *AISuggestionsRepo) ListSuggestions(ctx context.Context, userID uuid.UUI
 	// client. Under M2M a book can be in multiple libraries; we pick the
 	// earliest-added of the user's memberships via a LATERAL subquery. buy
 	// suggestions have book_id NULL so the subquery returns NULL for them.
+	// Book metadata comes from the joined books row now (denorm columns
+	// dropped in 000008). title/author/isbn/cover_url on the suggestion
+	// are derived: title from books.title, author from the book's first
+	// author contributor, isbn from the book's primary edition.
 	q := `
 		SELECT s.id, s.user_id, s.run_id, s.type, s.book_id, s.book_edition_id,
-		       s.title, COALESCE(s.author,''), COALESCE(s.isbn,''), COALESCE(s.cover_url,''),
+		       b.title,
+		       COALESCE((
+		           SELECT c.name
+		             FROM book_contributors bc
+		             JOIN contributors c ON c.id = bc.contributor_id
+		            WHERE bc.book_id = b.id AND bc.role = 'author'
+		            ORDER BY bc.display_order
+		            LIMIT 1
+		       ), '') AS author,
+		       COALESCE((
+		           SELECT COALESCE(NULLIF(e.isbn_13,''), NULLIF(e.isbn_10,''))
+		             FROM book_editions e
+		            WHERE e.book_id = b.id
+		            ORDER BY e.is_primary DESC, e.created_at ASC
+		            LIMIT 1
+		       ), '') AS isbn,
+		       CASE WHEN EXISTS(
+		           SELECT 1 FROM cover_images ci
+		            WHERE ci.entity_type = 'book' AND ci.entity_id = b.id AND ci.is_primary = true
+		       ) THEN '/api/v1/books/' || b.id::text || '/cover?v=' || EXTRACT(EPOCH FROM b.updated_at)::bigint::text
+		            ELSE '' END AS cover_url,
 		       COALESCE(s.reasoning,''), s.status, s.created_at, inlib.library_id
 		FROM ai_suggestions s
+		JOIN books b ON b.id = s.book_id
 		LEFT JOIN LATERAL (
 		    SELECT lb.library_id
 		    FROM library_books lb
@@ -563,13 +590,37 @@ func (r *AISuggestionsRepo) UpdateSuggestionStatus(ctx context.Context, id, user
 }
 
 // GetSuggestion fetches one suggestion scoped to a user (for the block flow,
-// which needs title/author/isbn to persist).
+// which needs title/author/isbn to persist). Title/author/isbn are hydrated
+// from the joined books + editions rows now that the denorm columns are
+// gone.
 func (r *AISuggestionsRepo) GetSuggestion(ctx context.Context, id, userID uuid.UUID) (*models.AISuggestion, error) {
 	const q = `
-		SELECT id, user_id, run_id, type, book_id, book_edition_id,
-		       title, COALESCE(author,''), COALESCE(isbn,''), COALESCE(cover_url,''),
-		       COALESCE(reasoning,''), status, created_at
-		FROM ai_suggestions WHERE id = $1 AND user_id = $2`
+		SELECT s.id, s.user_id, s.run_id, s.type, s.book_id, s.book_edition_id,
+		       b.title,
+		       COALESCE((
+		           SELECT c.name
+		             FROM book_contributors bc
+		             JOIN contributors c ON c.id = bc.contributor_id
+		            WHERE bc.book_id = b.id AND bc.role = 'author'
+		            ORDER BY bc.display_order
+		            LIMIT 1
+		       ), '') AS author,
+		       COALESCE((
+		           SELECT COALESCE(NULLIF(e.isbn_13,''), NULLIF(e.isbn_10,''))
+		             FROM book_editions e
+		            WHERE e.book_id = b.id
+		            ORDER BY e.is_primary DESC, e.created_at ASC
+		            LIMIT 1
+		       ), '') AS isbn,
+		       CASE WHEN EXISTS(
+		           SELECT 1 FROM cover_images ci
+		            WHERE ci.entity_type = 'book' AND ci.entity_id = b.id AND ci.is_primary = true
+		       ) THEN '/api/v1/books/' || b.id::text || '/cover?v=' || EXTRACT(EPOCH FROM b.updated_at)::bigint::text
+		            ELSE '' END AS cover_url,
+		       COALESCE(s.reasoning,''), s.status, s.created_at
+		FROM ai_suggestions s
+		JOIN books b ON b.id = s.book_id
+		WHERE s.id = $1 AND s.user_id = $2`
 	s := &models.AISuggestion{}
 	err := r.db.QueryRow(ctx, q, id, userID).Scan(
 		&s.ID, &s.UserID, &s.RunID, &s.Type,

--- a/internal/service/ai_suggestions.go
+++ b/internal/service/ai_suggestions.go
@@ -311,7 +311,7 @@ func (s *SuggestionsService) RunForUser(ctx context.Context, userID uuid.UUID, t
 	}
 
 	// ── Pass 2: enrich & filter ──────────────────────────────────────────────
-	buyItems, rejectedBuyTitles := s.enrichBuy(ctx, runID, user.LibraryID, buyParsed, cfg.MaxBuyPerUser, existingKeys)
+	buyItems, rejectedBuyTitles := s.enrichBuy(ctx, runID, userID, user.LibraryID, buyParsed, cfg.MaxBuyPerUser, existingKeys)
 	readNextItems := s.resolveReadNext(ctx, runID, user.LibraryID, titles, readNextParsed, cfg.MaxReadNextPerUser, existingKeys)
 
 	// ── Pass 3: backfill if buy fell short ───────────────────────────────────
@@ -374,7 +374,7 @@ func (s *SuggestionsService) RunForUser(ctx context.Context, userID uuid.UUID, t
 		for _, it := range buyItems {
 			existingKeys[normalizeTitle(it.Title)] = struct{}{}
 		}
-		bfItems, bfRejected := s.enrichBuy(ctx, runID, user.LibraryID, bfParsed, cfg.MaxBuyPerUser-len(buyItems), existingKeys)
+		bfItems, bfRejected := s.enrichBuy(ctx, runID, userID, user.LibraryID, bfParsed, cfg.MaxBuyPerUser-len(buyItems), existingKeys)
 		buyItems = append(buyItems, bfItems...)
 		rejectedBuyTitles = append(rejectedBuyTitles, bfRejected...)
 	}
@@ -430,7 +430,7 @@ func (s *SuggestionsService) RunForUser(ctx context.Context, userID uuid.UUID, t
 // book) are applied here too. Emits an enrichment_decision event per candidate.
 // `seen` is mutated to include every accepted title's normalized key so the
 // caller can feed the same set into a subsequent backfill without redos.
-func (s *SuggestionsService) enrichBuy(ctx context.Context, runID uuid.UUID, libraryID uuid.UUID, parsed []ParsedSuggestion, max int, seen map[string]struct{}) ([]repository.SuggestionInput, []string) {
+func (s *SuggestionsService) enrichBuy(ctx context.Context, runID, userID uuid.UUID, libraryID uuid.UUID, parsed []ParsedSuggestion, max int, seen map[string]struct{}) ([]repository.SuggestionInput, []string) {
 	var accepted []repository.SuggestionInput
 	var rejected []string
 	for _, p := range parsed {
@@ -594,7 +594,7 @@ func (s *SuggestionsService) enrichBuy(ctx context.Context, runID uuid.UUID, lib
 		// (post-000008 schema change). Populates the full metadata from the
 		// provider result so the BookDetailPage renders with author,
 		// description, publisher, etc. immediately.
-		bookID, editionID, bookErr := s.resolveFloatingBook(ctx, itemMeta)
+		bookID, editionID, bookErr := s.resolveFloatingBook(ctx, userID, itemMeta)
 		if bookErr != nil {
 			rejected = append(rejected, p.Title)
 			decision["outcome"] = "rejected"
@@ -651,7 +651,7 @@ type floatingBookMetadata struct {
 // owned by the metadata enrichment worker. Floating books render with
 // their title-initial fallback until a library acquisition triggers a
 // full enrichment pass.
-func (s *SuggestionsService) resolveFloatingBook(ctx context.Context, meta floatingBookMetadata) (uuid.UUID, uuid.UUID, error) {
+func (s *SuggestionsService) resolveFloatingBook(ctx context.Context, callerID uuid.UUID, meta floatingBookMetadata) (uuid.UUID, uuid.UUID, error) {
 	// Prefer ISBN-13, fall back to ISBN-10 for the global lookup.
 	lookupISBN := meta.ISBN13
 	if lookupISBN == "" {
@@ -741,11 +741,11 @@ func (s *SuggestionsService) resolveFloatingBook(ctx context.Context, meta float
 	}
 
 	// Fetch the cover after the book row exists. Non-fatal on failure —
-	// users can re-enrich later when they add the book to a library. Uses
-	// uuid.Nil as caller because this isn't a user-triggered per-cover
-	// action; the cover_images row records the source URL for provenance.
+	// users can re-enrich later when they add the book to a library.
+	// cover_images.created_by FKs to users(id), so we attribute to the user
+	// whose suggestion this is rather than uuid.Nil.
 	if meta.CoverURL != "" && s.bookSvc != nil {
-		if ferr := s.bookSvc.FetchCoverFromURL(ctx, bookID, uuid.Nil, meta.CoverURL); ferr != nil {
+		if ferr := s.bookSvc.FetchCoverFromURL(ctx, bookID, callerID, meta.CoverURL); ferr != nil {
 			slog.Warn("fetching floating-book cover",
 				"book_id", bookID, "url", meta.CoverURL, "error", ferr)
 		}

--- a/internal/service/ai_suggestions.go
+++ b/internal/service/ai_suggestions.go
@@ -55,6 +55,7 @@ type SuggestionsService struct {
 	repo       *repository.AISuggestionsRepo
 	books      *repository.BookRepo
 	editions   *repository.EditionRepo
+	bookSvc    *BookService
 	aiRegistry *ai.Registry
 	aiSvc      *AIService
 	jobSvc     *JobService
@@ -68,6 +69,7 @@ func NewSuggestionsService(
 	repo *repository.AISuggestionsRepo,
 	books *repository.BookRepo,
 	editions *repository.EditionRepo,
+	bookSvc *BookService,
 	aiRegistry *ai.Registry,
 	aiSvc *AIService,
 	jobSvc *JobService,
@@ -79,6 +81,7 @@ func NewSuggestionsService(
 		repo:       repo,
 		books:      books,
 		editions:   editions,
+		bookSvc:    bookSvc,
 		aiRegistry: aiRegistry,
 		aiSvc:      aiSvc,
 		jobSvc:     jobSvc,
@@ -505,6 +508,9 @@ func (s *SuggestionsService) enrichBuy(ctx context.Context, runID uuid.UUID, lib
 					Language:    fieldValue(merged.Language),
 					PageCount:   fieldValuePageCount(merged.PageCount),
 				}
+				if len(merged.Covers) > 0 {
+					itemMeta.CoverURL = merged.Covers[0].CoverURL
+				}
 				if merged.Subtitle != nil {
 					itemMeta.Subtitle = merged.Subtitle.Value
 				}
@@ -578,6 +584,7 @@ func (s *SuggestionsService) enrichBuy(ctx context.Context, runID uuid.UUID, lib
 				PublishDate: fallback.PublishDate,
 				Language:    fallback.Language,
 				PageCount:   fallback.PageCount,
+				CoverURL:    fallback.CoverURL,
 			}
 		}
 
@@ -623,6 +630,7 @@ type floatingBookMetadata struct {
 	PageCount   *int
 	ISBN10      string
 	ISBN13      string
+	CoverURL    string // external URL; downloaded and stored after the book row exists
 }
 
 // resolveFloatingBook looks up an existing book + edition by ISBN (global,
@@ -731,6 +739,18 @@ func (s *SuggestionsService) resolveFloatingBook(ctx context.Context, meta float
 	if err := tx.Commit(ctx); err != nil {
 		return uuid.Nil, uuid.Nil, fmt.Errorf("commit: %w", err)
 	}
+
+	// Fetch the cover after the book row exists. Non-fatal on failure —
+	// users can re-enrich later when they add the book to a library. Uses
+	// uuid.Nil as caller because this isn't a user-triggered per-cover
+	// action; the cover_images row records the source URL for provenance.
+	if meta.CoverURL != "" && s.bookSvc != nil {
+		if ferr := s.bookSvc.FetchCoverFromURL(ctx, bookID, uuid.Nil, meta.CoverURL); ferr != nil {
+			slog.Warn("fetching floating-book cover",
+				"book_id", bookID, "url", meta.CoverURL, "error", ferr)
+		}
+	}
+
 	return bookID, editionID, nil
 }
 

--- a/internal/service/ai_suggestions.go
+++ b/internal/service/ai_suggestions.go
@@ -18,6 +18,7 @@ import (
 	"github.com/fireball1725/librarium-api/internal/providers"
 	"github.com/fireball1725/librarium-api/internal/repository"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 // ErrAIDisabled signals that a suggestions run was skipped because the AI
@@ -52,16 +53,21 @@ const (
 // providers, backfill if buy candidates fell short, persist the batch.
 type SuggestionsService struct {
 	repo       *repository.AISuggestionsRepo
+	books      *repository.BookRepo
+	editions   *repository.EditionRepo
 	aiRegistry *ai.Registry
 	aiSvc      *AIService
 	jobSvc     *JobService
 	userSvc    *AIUserService
 	providers  *ProviderService
-	pool       any // retained if we need transactions later
+	pool       *pgxpool.Pool
 }
 
 func NewSuggestionsService(
+	pool *pgxpool.Pool,
 	repo *repository.AISuggestionsRepo,
+	books *repository.BookRepo,
+	editions *repository.EditionRepo,
 	aiRegistry *ai.Registry,
 	aiSvc *AIService,
 	jobSvc *JobService,
@@ -69,7 +75,10 @@ func NewSuggestionsService(
 	providers *ProviderService,
 ) *SuggestionsService {
 	return &SuggestionsService{
+		pool:       pool,
 		repo:       repo,
+		books:      books,
+		editions:   editions,
 		aiRegistry: aiRegistry,
 		aiSvc:      aiSvc,
 		jobSvc:     jobSvc,
@@ -540,12 +549,110 @@ func (s *SuggestionsService) enrichBuy(ctx context.Context, runID uuid.UUID, lib
 			}
 		}
 
+		// Resolve or create a floating book + edition for this buy suggestion
+		// so the suggestion has a stable book_id clients can use for detail
+		// views. A buy suggestion without a book_id now fails to persist
+		// (post-000008 schema change).
+		bookID, editionID, bookErr := s.resolveFloatingBook(ctx, item.Title, item.Author, item.ISBN)
+		if bookErr != nil {
+			rejected = append(rejected, p.Title)
+			decision["outcome"] = "rejected"
+			decision["reason"] = "floating_book_create_failed"
+			decision["floating_book_error"] = bookErr.Error()
+			s.emit(ctx, runID, "enrichment_decision", decision)
+			continue
+		}
+		item.BookID = &bookID
+		if editionID != uuid.Nil {
+			item.BookEditionID = &editionID
+		}
+
 		seen[normalizeTitle(item.Title)] = struct{}{}
 		accepted = append(accepted, *item)
 		decision["outcome"] = "accepted"
 		s.emit(ctx, runID, "enrichment_decision", decision)
 	}
 	return accepted, rejected
+}
+
+// resolveFloatingBook looks up an existing book + edition by ISBN (global,
+// not library-scoped) and returns its IDs. If no edition with this ISBN
+// exists, creates a new floating book (no library_books rows) and a
+// corresponding edition, then returns both IDs.
+//
+// A "floating" book is one with zero rows in the library_books junction —
+// it's a real work in the catalog that simply hasn't been added to any
+// library yet. Suggestions-as-books uses this to hang full BookPage
+// metadata + re-enrich + BookFinder affordances off a `buy` suggestion.
+func (s *SuggestionsService) resolveFloatingBook(ctx context.Context, title, author, isbn string) (uuid.UUID, uuid.UUID, error) {
+	if isbn != "" {
+		if existing, err := s.editions.FindByISBN(ctx, isbn); err == nil && existing != nil {
+			return existing.BookID, existing.ID, nil
+		}
+	}
+
+	mediaTypeID, err := s.defaultMediaTypeID(ctx)
+	if err != nil {
+		return uuid.Nil, uuid.Nil, fmt.Errorf("resolving default media type: %w", err)
+	}
+
+	bookID := uuid.New()
+	editionID := uuid.New()
+
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return uuid.Nil, uuid.Nil, fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	if err := s.books.Create(ctx, tx, bookID, title, "", mediaTypeID, ""); err != nil {
+		return uuid.Nil, uuid.Nil, fmt.Errorf("creating floating book: %w", err)
+	}
+	// Link the author as a contributor on the book so the BookPage renders
+	// with something useful before enrichment fills in the rest.
+	// (Skipped if author is blank — rare for post-enrichment items.)
+	_ = author // contributor linkage is an enhancement; worker enrichment
+	// will populate contributors on a subsequent pass. Leaving a TODO rather
+	// than half-building this path.
+
+	// Create the edition with just the ISBN; other fields (format, language,
+	// page count, etc.) can be filled in by a follow-up metadata enrichment
+	// pass triggered by the BookPage.
+	if err := s.editions.Create(ctx, tx, editionID, bookID,
+		models.EditionFormatPaperback, // placeholder — enrichment will correct
+		"", "", "", "", // language, edition_name, narrator, publisher
+		nil,         // publish_date
+		"", isbn, "", // isbn_10, isbn_13, description
+		nil, nil, // duration_seconds, page_count
+		true, // is_primary
+		nil,  // narrator_contributor_id
+	); err != nil {
+		return uuid.Nil, uuid.Nil, fmt.Errorf("creating floating edition: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return uuid.Nil, uuid.Nil, fmt.Errorf("commit: %w", err)
+	}
+	return bookID, editionID, nil
+}
+
+// defaultMediaTypeID returns the id of the "Novel" media type (or the first
+// media type in the table if Novel isn't present) for use when creating
+// floating books where we don't yet know the format.
+func (s *SuggestionsService) defaultMediaTypeID(ctx context.Context) (uuid.UUID, error) {
+	types, err := s.books.ListMediaTypes(ctx)
+	if err != nil {
+		return uuid.Nil, err
+	}
+	for _, t := range types {
+		if strings.EqualFold(t.Name, "novel") {
+			return t.ID, nil
+		}
+	}
+	if len(types) > 0 {
+		return types[0].ID, nil
+	}
+	return uuid.Nil, fmt.Errorf("no media types defined")
 }
 
 // findByTitleAuthor is the fallback path when ISBN lookup fails or mismatches.

--- a/internal/service/ai_suggestions.go
+++ b/internal/service/ai_suggestions.go
@@ -469,6 +469,7 @@ func (s *SuggestionsService) enrichBuy(ctx context.Context, runID uuid.UUID, lib
 		// search. Models hallucinate ISBNs far more often than they hallucinate
 		// the entire book, so recovering from a bad ISBN is high-value.
 		var item *repository.SuggestionInput
+		var itemMeta floatingBookMetadata
 		var primaryReason string
 		if p.ISBN != "" {
 			merged, err := s.providers.LookupISBNMerged(ctx, p.ISBN)
@@ -494,6 +495,26 @@ func (s *SuggestionsService) enrichBuy(ctx context.Context, runID uuid.UUID, lib
 					it.CoverURL = merged.Covers[0].CoverURL
 				}
 				item = &it
+				itemMeta = floatingBookMetadata{
+					Title:       merged.Title.Value,
+					ISBN10:      fieldValue(merged.ISBN10),
+					ISBN13:      fieldValueOr(merged.ISBN13, p.ISBN),
+					Description: fieldValue(merged.Description),
+					Publisher:   fieldValue(merged.Publisher),
+					PublishDate: fieldValue(merged.PublishDate),
+					Language:    fieldValue(merged.Language),
+					PageCount:   fieldValuePageCount(merged.PageCount),
+				}
+				if merged.Subtitle != nil {
+					itemMeta.Subtitle = merged.Subtitle.Value
+				}
+				if merged.Authors != nil && merged.Authors.Value != "" {
+					for _, a := range strings.Split(merged.Authors.Value, ",") {
+						if trimmed := strings.TrimSpace(a); trimmed != "" {
+							itemMeta.Authors = append(itemMeta.Authors, trimmed)
+						}
+					}
+				}
 			}
 		} else {
 			primaryReason = "missing_isbn"
@@ -547,13 +568,26 @@ func (s *SuggestionsService) enrichBuy(ctx context.Context, runID uuid.UUID, lib
 				CoverURL:  fallback.CoverURL,
 				Reasoning: p.Reason,
 			}
+			itemMeta = floatingBookMetadata{
+				Title:       fallback.Title,
+				Authors:     fallback.Authors,
+				ISBN13:      fallback.ISBN13,
+				ISBN10:      fallback.ISBN10,
+				Description: fallback.Description,
+				Publisher:   fallback.Publisher,
+				PublishDate: fallback.PublishDate,
+				Language:    fallback.Language,
+				PageCount:   fallback.PageCount,
+			}
 		}
 
 		// Resolve or create a floating book + edition for this buy suggestion
 		// so the suggestion has a stable book_id clients can use for detail
 		// views. A buy suggestion without a book_id now fails to persist
-		// (post-000008 schema change).
-		bookID, editionID, bookErr := s.resolveFloatingBook(ctx, item.Title, item.Author, item.ISBN)
+		// (post-000008 schema change). Populates the full metadata from the
+		// provider result so the BookDetailPage renders with author,
+		// description, publisher, etc. immediately.
+		bookID, editionID, bookErr := s.resolveFloatingBook(ctx, itemMeta)
 		if bookErr != nil {
 			rejected = append(rejected, p.Title)
 			decision["outcome"] = "rejected"
@@ -575,18 +609,48 @@ func (s *SuggestionsService) enrichBuy(ctx context.Context, runID uuid.UUID, lib
 	return accepted, rejected
 }
 
+// floatingBookMetadata carries the enrichment result into resolveFloatingBook
+// so we can populate the full book + edition + contributors on create rather
+// than leaving the row empty until a follow-up enrichment pass.
+type floatingBookMetadata struct {
+	Title       string
+	Subtitle    string
+	Description string
+	Authors     []string
+	Publisher   string
+	PublishDate string // free-form; parsed leniently
+	Language    string
+	PageCount   *int
+	ISBN10      string
+	ISBN13      string
+}
+
 // resolveFloatingBook looks up an existing book + edition by ISBN (global,
 // not library-scoped) and returns its IDs. If no edition with this ISBN
-// exists, creates a new floating book (no library_books rows) and a
-// corresponding edition, then returns both IDs.
+// exists, creates a new floating book (no library_books rows) populated
+// with every metadata field we already have from the enrichment result —
+// description, publisher, contributors (authors as book_contributors rows),
+// language, publish date, page count — so the BookDetailPage renders
+// something meaningful immediately rather than a bare title.
 //
 // A "floating" book is one with zero rows in the library_books junction —
 // it's a real work in the catalog that simply hasn't been added to any
 // library yet. Suggestions-as-books uses this to hang full BookPage
-// metadata + re-enrich + BookFinder affordances off a `buy` suggestion.
-func (s *SuggestionsService) resolveFloatingBook(ctx context.Context, title, author, isbn string) (uuid.UUID, uuid.UUID, error) {
-	if isbn != "" {
-		if existing, err := s.editions.FindByISBN(ctx, isbn); err == nil && existing != nil {
+// metadata + BookFinder affordances off a `buy` suggestion.
+//
+// Cover image download is not handled here — the provider's CoverURL is
+// an external URL; copying it into cover storage is a separate concern
+// owned by the metadata enrichment worker. Floating books render with
+// their title-initial fallback until a library acquisition triggers a
+// full enrichment pass.
+func (s *SuggestionsService) resolveFloatingBook(ctx context.Context, meta floatingBookMetadata) (uuid.UUID, uuid.UUID, error) {
+	// Prefer ISBN-13, fall back to ISBN-10 for the global lookup.
+	lookupISBN := meta.ISBN13
+	if lookupISBN == "" {
+		lookupISBN = meta.ISBN10
+	}
+	if lookupISBN != "" {
+		if existing, err := s.editions.FindByISBN(ctx, lookupISBN); err == nil && existing != nil {
 			return existing.BookID, existing.ID, nil
 		}
 	}
@@ -594,6 +658,39 @@ func (s *SuggestionsService) resolveFloatingBook(ctx context.Context, title, aut
 	mediaTypeID, err := s.defaultMediaTypeID(ctx)
 	if err != nil {
 		return uuid.Nil, uuid.Nil, fmt.Errorf("resolving default media type: %w", err)
+	}
+
+	// Resolve author names to contributor IDs up-front (outside the tx so
+	// a search/insert there doesn't block the transaction longer than
+	// necessary).
+	type contribResolve struct {
+		id   uuid.UUID
+		role string
+	}
+	var contribs []contribResolve
+	for _, name := range meta.Authors {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		c, err := s.findOrCreateContributor(ctx, name)
+		if err != nil {
+			// Non-fatal — skip this author and keep going. A thin book
+			// page beats a failed run.
+			slog.Warn("resolving author contributor", "name", name, "error", err)
+			continue
+		}
+		contribs = append(contribs, contribResolve{id: c.ID, role: "author"})
+	}
+
+	var publishDate *time.Time
+	if meta.PublishDate != "" {
+		for _, layout := range []string{"2006-01-02", "2006-01", "2006", "January 2, 2006", "Jan 2, 2006"} {
+			if t, perr := time.Parse(layout, meta.PublishDate); perr == nil {
+				publishDate = &t
+				break
+			}
+		}
 	}
 
 	bookID := uuid.New()
@@ -605,27 +702,28 @@ func (s *SuggestionsService) resolveFloatingBook(ctx context.Context, title, aut
 	}
 	defer tx.Rollback(ctx)
 
-	if err := s.books.Create(ctx, tx, bookID, title, "", mediaTypeID, ""); err != nil {
+	if err := s.books.Create(ctx, tx, bookID,
+		meta.Title, meta.Subtitle, mediaTypeID, meta.Description,
+	); err != nil {
 		return uuid.Nil, uuid.Nil, fmt.Errorf("creating floating book: %w", err)
 	}
-	// Link the author as a contributor on the book so the BookPage renders
-	// with something useful before enrichment fills in the rest.
-	// (Skipped if author is blank — rare for post-enrichment items.)
-	_ = author // contributor linkage is an enhancement; worker enrichment
-	// will populate contributors on a subsequent pass. Leaving a TODO rather
-	// than half-building this path.
 
-	// Create the edition with just the ISBN; other fields (format, language,
-	// page count, etc.) can be filled in by a follow-up metadata enrichment
-	// pass triggered by the BookPage.
+	for i, c := range contribs {
+		if err := s.books.EnsureBookContributor(ctx, tx, bookID, c.id, c.role); err != nil {
+			return uuid.Nil, uuid.Nil, fmt.Errorf("linking contributor: %w", err)
+		}
+		_ = i // display_order is handled by EnsureBookContributor
+	}
+
 	if err := s.editions.Create(ctx, tx, editionID, bookID,
-		models.EditionFormatPaperback, // placeholder — enrichment will correct
-		"", "", "", "", // language, edition_name, narrator, publisher
-		nil,         // publish_date
-		"", isbn, "", // isbn_10, isbn_13, description
-		nil, nil, // duration_seconds, page_count
-		true, // is_primary
-		nil,  // narrator_contributor_id
+		models.EditionFormatPaperback, // placeholder until real enrichment
+		meta.Language, "", "", // language, edition_name, narrator
+		meta.Publisher, publishDate,
+		meta.ISBN10, meta.ISBN13, "", // description lives on book, not edition
+		nil,            // duration_seconds
+		meta.PageCount, // page_count
+		true,           // is_primary
+		nil,            // narrator_contributor_id
 	); err != nil {
 		return uuid.Nil, uuid.Nil, fmt.Errorf("creating floating edition: %w", err)
 	}
@@ -634,6 +732,59 @@ func (s *SuggestionsService) resolveFloatingBook(ctx context.Context, title, aut
 		return uuid.Nil, uuid.Nil, fmt.Errorf("commit: %w", err)
 	}
 	return bookID, editionID, nil
+}
+
+// fieldValue returns the string value of a FieldResult, or "" when the
+// provider merge didn't agree on one.
+func fieldValue(f *providers.FieldResult) string {
+	if f == nil {
+		return ""
+	}
+	return f.Value
+}
+
+// fieldValueOr returns the FieldResult's value, or a fallback string when the
+// field is absent.
+func fieldValueOr(f *providers.FieldResult, fallback string) string {
+	if f == nil || f.Value == "" {
+		return fallback
+	}
+	return f.Value
+}
+
+// fieldValuePageCount parses a FieldResult string as a page count, returning
+// a *int or nil when absent/unparseable. The merged page_count field is
+// stringified; we re-convert here.
+func fieldValuePageCount(f *providers.FieldResult) *int {
+	if f == nil || f.Value == "" {
+		return nil
+	}
+	var n int
+	if _, err := fmt.Sscanf(f.Value, "%d", &n); err != nil || n <= 0 {
+		return nil
+	}
+	return &n
+}
+
+// findOrCreateContributor looks up a contributor by exact name match (case
+// insensitive) and returns it, or creates one if none exists.
+func (s *SuggestionsService) findOrCreateContributor(ctx context.Context, name string) (*models.Contributor, error) {
+	// Lazy contributor repo — we don't want a wiring change just for this
+	// one helper; route through the existing BookRepo since we already have
+	// it, via raw pool access.
+	const findQ = `SELECT id FROM contributors WHERE lower(name) = lower($1) LIMIT 1`
+	var pgID uuid.UUID
+	err := s.pool.QueryRow(ctx, findQ, name).Scan(&pgID)
+	if err == nil {
+		return &models.Contributor{ID: pgID, Name: name}, nil
+	}
+	const insertQ = `INSERT INTO contributors (id, name, sort_name, is_corporate) VALUES ($1, $2, $3, false) RETURNING id`
+	newID := uuid.New()
+	sortName := DeriveSortName(name)
+	if err := s.pool.QueryRow(ctx, insertQ, newID, name, sortName).Scan(&pgID); err != nil {
+		return nil, err
+	}
+	return &models.Contributor{ID: pgID, Name: name}, nil
 }
 
 // defaultMediaTypeID returns the id of the "Novel" media type (or the first

--- a/internal/service/book.go
+++ b/internal/service/book.go
@@ -38,11 +38,12 @@ type BookService struct {
 	tags         *repository.TagRepo
 	genres       *repository.GenreRepo
 	covers       *repository.CoverRepo
+	suggestions  *repository.AISuggestionsRepo
 	coverPath    string
 }
 
-func NewBookService(pool *pgxpool.Pool, books *repository.BookRepo, libraryBooks *repository.LibraryBookRepo, contributors *repository.ContributorRepo, editions *repository.EditionRepo, tags *repository.TagRepo, genres *repository.GenreRepo, covers *repository.CoverRepo, coverPath string) *BookService {
-	return &BookService{pool: pool, books: books, libraryBooks: libraryBooks, contributors: contributors, editions: editions, tags: tags, genres: genres, covers: covers, coverPath: coverPath}
+func NewBookService(pool *pgxpool.Pool, books *repository.BookRepo, libraryBooks *repository.LibraryBookRepo, contributors *repository.ContributorRepo, editions *repository.EditionRepo, tags *repository.TagRepo, genres *repository.GenreRepo, covers *repository.CoverRepo, suggestions *repository.AISuggestionsRepo, coverPath string) *BookService {
+	return &BookService{pool: pool, books: books, libraryBooks: libraryBooks, contributors: contributors, editions: editions, tags: tags, genres: genres, covers: covers, suggestions: suggestions, coverPath: coverPath}
 }
 
 // ─── Media types ──────────────────────────────────────────────────────────────
@@ -267,8 +268,22 @@ func (s *BookService) DeleteBook(ctx context.Context, id uuid.UUID) error {
 // AddBookToLibrary attaches an existing book to a library via the
 // library_books junction. Idempotent — re-adding a book already in the
 // library is a no-op.
+//
+// Remove-on-action: when the caller just added a book, any `buy`
+// suggestion they had pointing at that book has served its purpose and
+// gets deleted. Scoped to addedBy when present — otherwise we can't
+// attribute the action to a user, and we leave suggestions alone.
 func (s *BookService) AddBookToLibrary(ctx context.Context, libraryID, bookID uuid.UUID, addedBy *uuid.UUID) error {
-	return s.libraryBooks.AddBookToLibrary(ctx, nil, libraryID, bookID, addedBy)
+	if err := s.libraryBooks.AddBookToLibrary(ctx, nil, libraryID, bookID, addedBy); err != nil {
+		return err
+	}
+	if addedBy != nil && s.suggestions != nil {
+		if _, derr := s.suggestions.DeleteForActionTaken(ctx, *addedBy, bookID, "buy"); derr != nil {
+			slog.Warn("deleting buy suggestions after add-to-library",
+				"user_id", *addedBy, "book_id", bookID, "error", derr)
+		}
+	}
+	return nil
 }
 
 // RemoveBookFromLibrary drops the library_books junction row for this
@@ -393,10 +408,26 @@ func (s *BookService) GetInteraction(ctx context.Context, userID, editionID uuid
 }
 
 func (s *BookService) UpsertInteraction(ctx context.Context, userID, editionID uuid.UUID, req InteractionRequest) (*models.UserBookInteraction, error) {
-	return s.editions.UpsertInteraction(ctx, userID, editionID,
+	interaction, err := s.editions.UpsertInteraction(ctx, userID, editionID,
 		req.ReadStatus, req.Rating, req.Notes, req.Review,
 		req.DateStarted, req.DateFinished, req.IsFavorite,
 	)
+	if err != nil {
+		return nil, err
+	}
+	// Remove-on-action: if the user just logged a read on this edition,
+	// drop any read_next suggestion rows they had pointing at the same book.
+	// The edition's book_id is the key — a read of any edition of the book
+	// counts as reading the book.
+	if req.ReadStatus == "read" && s.suggestions != nil {
+		if edition, eerr := s.editions.FindByID(ctx, editionID); eerr == nil && edition != nil {
+			if _, derr := s.suggestions.DeleteForActionTaken(ctx, userID, edition.BookID, "read_next"); derr != nil {
+				slog.Warn("deleting read_next suggestions after read",
+					"user_id", userID, "book_id", edition.BookID, "error", derr)
+			}
+		}
+	}
+	return interaction, nil
 }
 
 func (s *BookService) DeleteInteraction(ctx context.Context, userID, editionID uuid.UUID) error {


### PR DESCRIPTION
- Every AI suggestion now references a real \`books\` row (buy suggestions get a floating book — no \`library_books\` rows — created by the worker or backfilled by migration 000008). Drops the denorm title/author/isbn/cover_url columns, swaps the FK to ON DELETE CASCADE, makes \`book_id\` NOT NULL.
- Remove-on-action lifecycle hooks: logging a 'read' drops any \`read_next\` suggestion for that book; adding a book to a library drops any \`buy\` suggestion. New library-agnostic \`GET /api/v1/books/{id}\` + \`/editions\` endpoints so the new web BookDetailPage can render a floating book.