### PR TITLE
feat(suggestions): 30-day window, per-book re-enrich, block/remove on detail page

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -2125,6 +2125,70 @@ const docTemplate = `{
                 }
             }
         },
+        "/books/{book_id}/enrich": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Queues a metadata enrichment job for one book, regardless of\nlibrary ownership. Used by the BookDetailPage \"Refresh\nmetadata\" button on floating (suggestion-backed) books and\nanywhere we want to touch up a single title.",
+                "tags": [
+                    "books"
+                ],
+                "summary": "Re-enrich metadata for a single book",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Book UUID",
+                        "name": "book_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_models.EnrichmentBatch"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/contributors": {
             "get": {
                 "security": [
@@ -9707,6 +9771,57 @@ const docTemplate = `{
                 }
             }
         },
+        "/me/suggestions/{id}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Hard-deletes a single suggestion. Used by both the \"Remove\"\nbutton on SuggestionCard / BookDetailPage and the cleaned-up\nDismiss flow (dismiss collapses into delete per the\nsuggestions-as-books plan).",
+                "tags": [
+                    "me",
+                    "ai"
+                ],
+                "summary": "Remove a suggestion",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Suggestion ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/me/suggestions/{id}/block": {
             "post": {
                 "security": [
@@ -10514,6 +10629,7 @@ const docTemplate = `{
                     }
                 },
                 "library_id": {
+                    "description": "LibraryID scopes the batch to a library when set. Null for\nfloating-book batches (e.g. re-enriching a suggestion-backed book not\nyet held by any library).",
                     "type": "string"
                 },
                 "library_name": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -2119,6 +2119,70 @@
                 }
             }
         },
+        "/books/{book_id}/enrich": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Queues a metadata enrichment job for one book, regardless of\nlibrary ownership. Used by the BookDetailPage \"Refresh\nmetadata\" button on floating (suggestion-backed) books and\nanywhere we want to touch up a single title.",
+                "tags": [
+                    "books"
+                ],
+                "summary": "Re-enrich metadata for a single book",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Book UUID",
+                        "name": "book_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_models.EnrichmentBatch"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/contributors": {
             "get": {
                 "security": [
@@ -9701,6 +9765,57 @@
                 }
             }
         },
+        "/me/suggestions/{id}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Hard-deletes a single suggestion. Used by both the \"Remove\"\nbutton on SuggestionCard / BookDetailPage and the cleaned-up\nDismiss flow (dismiss collapses into delete per the\nsuggestions-as-books plan).",
+                "tags": [
+                    "me",
+                    "ai"
+                ],
+                "summary": "Remove a suggestion",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Suggestion ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/me/suggestions/{id}/block": {
             "post": {
                 "security": [
@@ -10508,6 +10623,7 @@
                     }
                 },
                 "library_id": {
+                    "description": "LibraryID scopes the batch to a library when set. Null for\nfloating-book batches (e.g. re-enriching a suggestion-backed book not\nyet held by any library).",
                     "type": "string"
                 },
                 "library_name": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -47,6 +47,10 @@ definitions:
           $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_models.EnrichmentBatchItem'
         type: array
       library_id:
+        description: |-
+          LibraryID scopes the batch to a library when set. Null for
+          floating-book batches (e.g. re-enriching a suggestion-backed book not
+          yet held by any library).
         type: string
       library_name:
         type: string
@@ -2482,6 +2486,50 @@ paths:
       summary: Register a new user
       tags:
       - auth
+  /books/{book_id}/enrich:
+    post:
+      description: |-
+        Queues a metadata enrichment job for one book, regardless of
+        library ownership. Used by the BookDetailPage "Refresh
+        metadata" button on floating (suggestion-backed) books and
+        anywhere we want to touch up a single title.
+      parameters:
+      - description: Book UUID
+        in: path
+        name: book_id
+        required: true
+        type: string
+      responses:
+        "202":
+          description: Accepted
+          schema:
+            $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_models.EnrichmentBatch'
+        "400":
+          description: Bad Request
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+        "503":
+          description: Service Unavailable
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Re-enrich metadata for a single book
+      tags:
+      - books
   /contributors:
     get:
       description: Full-text search for contributors (authors, illustrators, etc.).
@@ -7233,6 +7281,42 @@ paths:
       security:
       - BearerAuth: []
       summary: List my AI suggestions
+      tags:
+      - me
+      - ai
+  /me/suggestions/{id}:
+    delete:
+      description: |-
+        Hard-deletes a single suggestion. Used by both the "Remove"
+        button on SuggestionCard / BookDetailPage and the cleaned-up
+        Dismiss flow (dismiss collapses into delete per the
+        suggestions-as-books plan).
+      parameters:
+      - description: Suggestion ID
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Remove a suggestion
       tags:
       - me
       - ai

--- a/internal/api/handlers/ai_suggestions.go
+++ b/internal/api/handlers/ai_suggestions.go
@@ -100,6 +100,32 @@ func (h *AISuggestionsHandler) ListSuggestions(w http.ResponseWriter, r *http.Re
 	typeFilter := r.URL.Query().Get("type")
 	statusFilter := r.URL.Query().Get("status")
 
+	// since accepts either an RFC3339 timestamp or a relative token like "30d"
+	// / "7d". A missing or empty value means no window. The UI uses "30d" on
+	// initial load and passes nothing when the user clicks "Show older".
+	var sincePtr *time.Time
+	if s := r.URL.Query().Get("since"); s != "" {
+		if d, ok := parseRelativeDays(s); ok {
+			t := time.Now().Add(-time.Duration(d) * 24 * time.Hour)
+			sincePtr = &t
+		} else if t, err := time.Parse(time.RFC3339, s); err == nil {
+			sincePtr = &t
+		} else {
+			respond.Error(w, http.StatusBadRequest, "invalid since: expected RFC3339 or NNd")
+			return
+		}
+	}
+
+	var bookIDPtr *uuid.UUID
+	if s := r.URL.Query().Get("book_id"); s != "" {
+		bookID, err := uuid.Parse(s)
+		if err != nil {
+			respond.Error(w, http.StatusBadRequest, "invalid book_id")
+			return
+		}
+		bookIDPtr = &bookID
+	}
+
 	var runIDPtr *uuid.UUID
 	if s := r.URL.Query().Get("run_id"); s != "" {
 		runID, err := uuid.Parse(s)
@@ -128,7 +154,14 @@ func (h *AISuggestionsHandler) ListSuggestions(w http.ResponseWriter, r *http.Re
 		statusFilter = "new"
 	}
 
-	items, err := h.repo.ListSuggestions(r.Context(), claims.UserID, typeFilter, statusFilter, runIDPtr)
+	// When filtering by book_id, clear the default status=new fallback so the
+	// caller sees every suggestion they have for the book (including
+	// interested, dismissed, etc.). The BookDetailPage needs that to decide
+	// whether to offer "Remove suggestion".
+	if bookIDPtr != nil && r.URL.Query().Get("status") == "" {
+		statusFilter = ""
+	}
+	items, err := h.repo.ListSuggestions(r.Context(), claims.UserID, typeFilter, statusFilter, runIDPtr, sincePtr, bookIDPtr)
 	if err != nil {
 		respond.ServerError(w, r, err)
 		return
@@ -179,6 +212,42 @@ func (h *AISuggestionsHandler) UpdateSuggestionStatus(w http.ResponseWriter, r *
 		return
 	}
 	if err := h.repo.UpdateSuggestionStatus(r.Context(), id, claims.UserID, body.Status); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			respond.Error(w, http.StatusNotFound, "suggestion not found")
+			return
+		}
+		respond.ServerError(w, r, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// DeleteSuggestion godoc
+//
+//	@Summary     Remove a suggestion
+//	@Description Hard-deletes a single suggestion. Used by both the "Remove"
+//	@Description button on SuggestionCard / BookDetailPage and the cleaned-up
+//	@Description Dismiss flow (dismiss collapses into delete per the
+//	@Description suggestions-as-books plan).
+//	@Tags        me,ai
+//	@Security    BearerAuth
+//	@Param       id    path      string  true  "Suggestion ID"
+//	@Success     204
+//	@Failure     400   {object}  object{error=string}
+//	@Failure     404   {object}  object{error=string}
+//	@Router      /me/suggestions/{id} [delete]
+func (h *AISuggestionsHandler) DeleteSuggestion(w http.ResponseWriter, r *http.Request) {
+	claims := middleware.ClaimsFromContext(r.Context())
+	if claims == nil {
+		respond.Error(w, http.StatusUnauthorized, "unauthenticated")
+		return
+	}
+	id, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		respond.Error(w, http.StatusBadRequest, "invalid id")
+		return
+	}
+	if err := h.repo.DeleteSuggestion(r.Context(), id, claims.UserID); err != nil {
 		if errors.Is(err, repository.ErrNotFound) {
 			respond.Error(w, http.StatusNotFound, "suggestion not found")
 			return
@@ -839,5 +908,24 @@ func (h *AISuggestionsHandler) AdminClearFinishedRuns(w http.ResponseWriter, r *
 		return
 	}
 	respond.JSON(w, http.StatusOK, map[string]any{"deleted": deleted})
+}
+
+// parseRelativeDays accepts tokens like "30d", "7d" and returns the integer
+// day count. Returns (0, false) for anything else.
+func parseRelativeDays(s string) (int, bool) {
+	if len(s) < 2 || s[len(s)-1] != 'd' {
+		return 0, false
+	}
+	n := 0
+	for _, r := range s[:len(s)-1] {
+		if r < '0' || r > '9' {
+			return 0, false
+		}
+		n = n*10 + int(r-'0')
+	}
+	if n <= 0 || n > 3650 {
+		return 0, false
+	}
+	return n, true
 }
 

--- a/internal/api/handlers/books.go
+++ b/internal/api/handlers/books.go
@@ -795,7 +795,7 @@ func (h *BookHandler) BulkEnrich(w http.ResponseWriter, r *http.Request) {
 
 	batch := &models.EnrichmentBatch{
 		ID:         uuid.New(),
-		LibraryID:  libraryID,
+		LibraryID:  &libraryID,
 		CreatedBy:  caller.UserID,
 		Type:       models.EnrichmentBatchTypeMetadata,
 		Force:      req.Force,
@@ -817,6 +817,64 @@ func (h *BookHandler) BulkEnrich(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	respond.JSON(w, http.StatusAccepted, batch)
+}
+
+// EnrichBook godoc
+//
+// @Summary     Re-enrich metadata for a single book
+// @Description Queues a metadata enrichment job for one book, regardless of
+// @Description library ownership. Used by the BookDetailPage "Refresh
+// @Description metadata" button on floating (suggestion-backed) books and
+// @Description anywhere we want to touch up a single title.
+// @Tags        books
+// @Security    BearerAuth
+// @Param       book_id  path      string  true  "Book UUID"
+// @Success     202      {object}  models.EnrichmentBatch
+// @Failure     400      {object}  object{error=string}
+// @Failure     401      {object}  object{error=string}
+// @Failure     503      {object}  object{error=string}
+// @Router      /books/{book_id}/enrich [post]
+func (h *BookHandler) EnrichBook(w http.ResponseWriter, r *http.Request) {
+	if h.riverClient == nil || h.enrichmentBatches == nil {
+		respond.Error(w, http.StatusServiceUnavailable, "job queue not available")
+		return
+	}
+
+	bookID, err := uuid.Parse(r.PathValue("book_id"))
+	if err != nil {
+		respond.Error(w, http.StatusBadRequest, "invalid book id")
+		return
+	}
+
+	caller := middleware.ClaimsFromContext(r.Context())
+	if caller == nil {
+		respond.Error(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+
+	batch := &models.EnrichmentBatch{
+		ID:         uuid.New(),
+		LibraryID:  nil, // library-agnostic — works for floating books
+		CreatedBy:  caller.UserID,
+		Type:       models.EnrichmentBatchTypeMetadata,
+		Force:      true, // one-off re-enrich always overwrites
+		Status:     models.EnrichmentBatchPending,
+		BookIDs:    []uuid.UUID{bookID},
+		TotalBooks: 1,
+	}
+	if err := h.enrichmentBatches.Create(r.Context(), batch); err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
+	if err := h.createBatchItems(r.Context(), batch.ID, batch.BookIDs); err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
+	if _, err := h.riverClient.Insert(r.Context(), models.EnrichmentBatchJobArgs{BatchID: batch.ID}, nil); err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
 	respond.JSON(w, http.StatusAccepted, batch)
 }
 
@@ -867,7 +925,7 @@ func (h *BookHandler) BulkRefreshCovers(w http.ResponseWriter, r *http.Request) 
 
 	batch := &models.EnrichmentBatch{
 		ID:         uuid.New(),
-		LibraryID:  libraryID,
+		LibraryID:  &libraryID,
 		CreatedBy:  caller.UserID,
 		Type:       models.EnrichmentBatchTypeCover,
 		Force:      false,

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -228,6 +228,7 @@ func NewRouter(ctx context.Context, db *pgxpool.Pool, cfg *config.Config, riverC
 	mux.Handle("GET /api/v1/me/suggestions/runs", requireAuth(http.HandlerFunc(aiSuggestionsHandler.ListMyRuns)))
 	mux.Handle("GET /api/v1/me/suggestions/runs/{id}", requireAuth(http.HandlerFunc(aiSuggestionsHandler.GetMyRun)))
 	mux.Handle("PUT /api/v1/me/suggestions/{id}/status", requireAuth(http.HandlerFunc(aiSuggestionsHandler.UpdateSuggestionStatus)))
+	mux.Handle("DELETE /api/v1/me/suggestions/{id}", requireAuth(http.HandlerFunc(aiSuggestionsHandler.DeleteSuggestion)))
 	mux.Handle("POST /api/v1/me/suggestions/{id}/block", requireAuth(http.HandlerFunc(aiSuggestionsHandler.BlockSuggestion)))
 
 	// Lookup (any authenticated user)
@@ -295,11 +296,9 @@ func NewRouter(ctx context.Context, db *pgxpool.Pool, cfg *config.Config, riverC
 	// consume book_id.
 	mux.Handle("GET /api/v1/books/{book_id}", requireAuth(http.HandlerFunc(bookHandler.GetBook)))
 	mux.Handle("GET /api/v1/books/{book_id}/editions", requireAuth(http.HandlerFunc(bookHandler.ListEditions)))
-	// Per-book re-enrichment against a floating book still needs a library
-	// context (enrichment_batches.library_id is non-null today). Add that
-	// endpoint in a follow-up when either (a) we make library_id nullable on
-	// the batch, or (b) we decide on a picker UX. For now, users can
-	// re-enrich after adding the book to a library.
+	// Single-book re-enrichment — works for floating books too since
+	// enrichment_batches.library_id is nullable post-000009.
+	mux.Handle("POST /api/v1/books/{book_id}/enrich", requireAuth(http.HandlerFunc(bookHandler.EnrichBook)))
 	mux.Handle("POST /api/v1/libraries/{library_id}/books/{book_id}/cover/fetch", requireLibraryPerm("books:update", http.HandlerFunc(bookHandler.FetchBookCover)))
 	mux.Handle("PUT /api/v1/libraries/{library_id}/books/{book_id}/cover", requireLibraryPerm("books:update", http.HandlerFunc(bookHandler.UploadBookCover)))
 	mux.Handle("DELETE /api/v1/libraries/{library_id}/books/{book_id}/cover", requireLibraryPerm("books:update", http.HandlerFunc(bookHandler.DeleteBookCover)))

--- a/internal/db/migrations/000009_enrichment_batches_nullable_library.down.sql
+++ b/internal/db/migrations/000009_enrichment_batches_nullable_library.down.sql
@@ -1,0 +1,12 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Copyright (C) 2026 fireball1725
+
+-- Re-require library_id on enrichment_batches. Any rows with NULL library_id
+-- (floating-book re-enrich batches) can't be downgraded cleanly; drop them
+-- first so the NOT NULL constraint can be added back. Restore from a
+-- pre-migration dump if that loses work you wanted to keep.
+
+DELETE FROM enrichment_batches WHERE library_id IS NULL;
+
+ALTER TABLE enrichment_batches
+    ALTER COLUMN library_id SET NOT NULL;

--- a/internal/db/migrations/000009_enrichment_batches_nullable_library.up.sql
+++ b/internal/db/migrations/000009_enrichment_batches_nullable_library.up.sql
@@ -1,0 +1,15 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Copyright (C) 2026 fireball1725
+
+-- Allow library_id to be NULL on enrichment_batches so we can run metadata
+-- enrichment against a floating book (one not yet held by any library).
+-- Suggestions-as-books surfaces a "Re-enrich" button on the BookDetailPage
+-- for suggestion-backed floating books; that button needs a batch to hang
+-- onto but there's no library to scope it to.
+--
+-- library_id stays on the row when present — it records the user's request
+-- context for library-scoped batches. Admin/global batches and floating-book
+-- batches just leave it NULL.
+
+ALTER TABLE enrichment_batches
+    ALTER COLUMN library_id DROP NOT NULL;

--- a/internal/models/enrichment_batch.go
+++ b/internal/models/enrichment_batch.go
@@ -55,7 +55,10 @@ type EnrichmentBatchItem struct {
 // metadata or cover refresh operation.
 type EnrichmentBatch struct {
 	ID             uuid.UUID              `json:"id"`
-	LibraryID      uuid.UUID              `json:"library_id"`
+	// LibraryID scopes the batch to a library when set. Null for
+	// floating-book batches (e.g. re-enriching a suggestion-backed book not
+	// yet held by any library).
+	LibraryID      *uuid.UUID             `json:"library_id,omitempty"`
 	LibraryName    string                 `json:"library_name,omitempty"`
 	CreatedBy      uuid.UUID              `json:"created_by"`
 	Type           EnrichmentBatchType    `json:"type"`

--- a/internal/repository/ai_suggestions.go
+++ b/internal/repository/ai_suggestions.go
@@ -503,7 +503,15 @@ func (r *AISuggestionsRepo) ListNewSuggestionKeys(ctx context.Context, userID uu
 // optionally scope to a specific run (non-nil runID). When runID is set, the
 // status filter is ignored — scoped views surface every suggestion the run
 // produced, including ones the user later dismissed or saved.
-func (r *AISuggestionsRepo) ListSuggestions(ctx context.Context, userID uuid.UUID, typeFilter, statusFilter string, runID *uuid.UUID) ([]*models.AISuggestionWithLibrary, error) {
+//
+// since is optional; when non-nil, only suggestions with created_at >= since
+// are returned. Used by the UI to show a 30-day rolling window by default
+// with a "show older" toggle that passes nil.
+//
+// bookID is optional; when non-nil, only suggestions for that specific book
+// are returned. Used by BookDetailPage to know whether to show the
+// remove-suggestion / block controls.
+func (r *AISuggestionsRepo) ListSuggestions(ctx context.Context, userID uuid.UUID, typeFilter, statusFilter string, runID *uuid.UUID, since *time.Time, bookID *uuid.UUID) ([]*models.AISuggestionWithLibrary, error) {
 	// For read_next suggestions, surface one library_id the user is a member
 	// of that holds the referenced book — used for direct navigation on the
 	// client. Under M2M a book can be in multiple libraries; we pick the
@@ -560,6 +568,17 @@ func (r *AISuggestionsRepo) ListSuggestions(ctx context.Context, userID uuid.UUI
 		q += fmt.Sprintf(" AND s.status = $%d", len(args)+1)
 		args = append(args, statusFilter)
 	}
+	// Apply the created_at window for the default "last N days" view. Skipped
+	// when scoping to a specific run — users viewing a run want every row
+	// that run produced regardless of age.
+	if since != nil && runID == nil {
+		q += fmt.Sprintf(" AND s.created_at >= $%d", len(args)+1)
+		args = append(args, *since)
+	}
+	if bookID != nil {
+		q += fmt.Sprintf(" AND s.book_id = $%d", len(args)+1)
+		args = append(args, *bookID)
+	}
 	q += " ORDER BY s.created_at DESC"
 	rows, err := r.db.Query(ctx, q, args...)
 	if err != nil {
@@ -597,6 +616,22 @@ func (r *AISuggestionsRepo) DeleteForActionTaken(ctx context.Context, userID, bo
 		return 0, fmt.Errorf("delete suggestions on action: %w", err)
 	}
 	return tag.RowsAffected(), nil
+}
+
+// DeleteSuggestion hard-deletes one suggestion scoped to a user. Used by the
+// "Remove suggestion" action on both SuggestionCard (dismiss) and
+// BookDetailPage. Returns ErrNotFound if the row doesn't exist or doesn't
+// belong to the caller.
+func (r *AISuggestionsRepo) DeleteSuggestion(ctx context.Context, id, userID uuid.UUID) error {
+	const q = `DELETE FROM ai_suggestions WHERE id = $1 AND user_id = $2`
+	tag, err := r.db.Exec(ctx, q, id, userID)
+	if err != nil {
+		return fmt.Errorf("delete suggestion: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
 }
 
 // UpdateSuggestionStatus changes the user-visible status flag. Returns

--- a/internal/repository/enrichment_batches.go
+++ b/internal/repository/enrichment_batches.go
@@ -338,7 +338,10 @@ func scanBatch(s batchScanner) (*models.EnrichmentBatch, error) {
 		return nil, err
 	}
 	b.ID = uuid.UUID(pgID.Bytes)
-	b.LibraryID = uuid.UUID(pgLibraryID.Bytes)
+	if pgLibraryID.Valid {
+		lid := uuid.UUID(pgLibraryID.Bytes)
+		b.LibraryID = &lid
+	}
 	b.CreatedBy = uuid.UUID(pgCreatedBy.Bytes)
 	b.Type = models.EnrichmentBatchType(batchType)
 	b.Status = models.EnrichmentBatchStatus(status)
@@ -369,7 +372,10 @@ func scanBatchWithLibraryName(s batchScanner) (*models.EnrichmentBatch, error) {
 		return nil, fmt.Errorf("scanning enrichment batch: %w", err)
 	}
 	b.ID = uuid.UUID(pgID.Bytes)
-	b.LibraryID = uuid.UUID(pgLibraryID.Bytes)
+	if pgLibraryID.Valid {
+		lid := uuid.UUID(pgLibraryID.Bytes)
+		b.LibraryID = &lid
+	}
 	b.CreatedBy = uuid.UUID(pgCreatedBy.Bytes)
 	b.Type = models.EnrichmentBatchType(batchType)
 	b.Status = models.EnrichmentBatchStatus(status)

--- a/internal/service/ai_suggestions.go
+++ b/internal/service/ai_suggestions.go
@@ -169,7 +169,7 @@ func (s *SuggestionsService) RunForUser(ctx context.Context, userID uuid.UUID, t
 	// the model to pick different titles this run. Without this the model
 	// deterministically regenerates the same picks every time, the unique index
 	// silently drops them, and the user sees no growth in the lists.
-	existing, err := s.repo.ListSuggestions(ctx, userID, "", "new", nil)
+	existing, err := s.repo.ListSuggestions(ctx, userID, "", "new", nil, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("load existing suggestions: %w", err)
 	}

--- a/internal/workers/enrichment_batch_worker.go
+++ b/internal/workers/enrichment_batch_worker.go
@@ -101,7 +101,7 @@ func (w *EnrichmentBatchWorker) Work(ctx context.Context, job *river.Job[models.
 			continue
 		}
 
-		bookErr := w.metadataWorker.ProcessBook(ctx, bookID, batch.LibraryID, batch.CreatedBy, batch.Force, coverOnly)
+		bookErr := w.metadataWorker.ProcessBook(ctx, bookID, batch.CreatedBy, batch.Force, coverOnly)
 
 		var itemStatus models.EnrichmentBatchItemStatus
 		var itemMsg string

--- a/internal/workers/import_worker.go
+++ b/internal/workers/import_worker.go
@@ -178,9 +178,10 @@ func (w *ImportWorker) spawnEnrichmentBatch(
 		bookIDs[i] = b.id
 	}
 
+	libraryID := importJob.LibraryID
 	batch := &models.EnrichmentBatch{
 		ID:         batchID,
-		LibraryID:  importJob.LibraryID,
+		LibraryID:  &libraryID,
 		CreatedBy:  importJob.CreatedBy,
 		Type:       batchType,
 		Force:      false,

--- a/internal/workers/metadata_worker.go
+++ b/internal/workers/metadata_worker.go
@@ -59,7 +59,7 @@ func NewMetadataWorker(
 func (w *MetadataWorker) Work(ctx context.Context, job *river.Job[models.MetadataEnrichmentJobArgs]) error {
 	args := job.Args
 	slog.Info("metadata enrichment started", "book_id", args.BookID, "force", args.Force, "cover_only", args.CoverOnly)
-	err := w.ProcessBook(ctx, args.BookID, args.LibraryID, args.CallerID, args.Force, args.CoverOnly)
+	err := w.ProcessBook(ctx, args.BookID, args.CallerID, args.Force, args.CoverOnly)
 	if err != nil && !errors.Is(err, ErrNoUpdate) {
 		return err // only real errors cause River retries
 	}
@@ -71,7 +71,10 @@ func (w *MetadataWorker) Work(ctx context.Context, job *river.Job[models.Metadat
 // Returns ErrNoUpdate when processing succeeded but nothing changed (no ISBN,
 // no covers from providers, already has cover). Returns a real error only for
 // transient failures worth retrying.
-func (w *MetadataWorker) ProcessBook(ctx context.Context, bookID, libraryID, callerID uuid.UUID, force, coverOnly bool) error {
+// ProcessBook enriches or refreshes the cover for a single book. libraryID is
+// no longer a parameter (books belong to zero or more libraries under M2M,
+// and the enrichment itself writes to the global book row regardless).
+func (w *MetadataWorker) ProcessBook(ctx context.Context, bookID, callerID uuid.UUID, force, coverOnly bool) error {
 	// Find an ISBN from the book's editions.
 	editions, err := w.editions.ListByBook(ctx, bookID)
 	if err != nil {
@@ -100,7 +103,7 @@ func (w *MetadataWorker) ProcessBook(ctx context.Context, bookID, libraryID, cal
 
 	// When cover_only=true, skip all text-field updates and only refresh the cover.
 	if !coverOnly {
-		if err := w.applyMerged(ctx, bookID, libraryID, callerID, merged, force); err != nil {
+		if err := w.applyMerged(ctx, bookID, callerID, merged, force); err != nil {
 			return fmt.Errorf("applying merged result: %w", err)
 		}
 	}
@@ -146,10 +149,11 @@ func (w *MetadataWorker) ProcessBook(ctx context.Context, bookID, libraryID, cal
 // When force=false only empty fields are filled; when force=true all fields are overwritten.
 func (w *MetadataWorker) applyMerged(
 	ctx context.Context,
-	bookID, libraryID, callerID uuid.UUID,
+	bookID, callerID uuid.UUID,
 	merged *providers.MergedBookResult,
 	force bool,
 ) error {
+	_ = callerID // reserved for audit trail; applyMerged itself doesn't use it
 	book, err := w.bookSvc.GetBook(ctx, bookID)
 	if err != nil {
 		return err


### PR DESCRIPTION
- 30-day default window on the mixed suggestions list with a "Show older" toggle; new \`since\` param on \`/me/suggestions\` accepts RFC3339 or \`NNd\`. Adds a \`book_id\` filter too so the detail page can find its matching suggestion.
- Per-book re-enrichment: migration 000009 makes \`enrichment_batches.library_id\` nullable and \`POST /api/v1/books/{id}/enrich\` queues a one-book metadata refresh (works for floating suggestion books). New \`DELETE /api/v1/me/suggestions/{id}\` for explicit removal.