### PR TITLE
feat(jobs): unified jobs framework — schema + Go runtime (PR 1)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -24,6 +24,8 @@ package main
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
@@ -39,6 +41,7 @@ import (
 	"github.com/fireball1725/librarium-api/internal/api"
 	"github.com/fireball1725/librarium-api/internal/config"
 	"github.com/fireball1725/librarium-api/internal/db"
+	"github.com/fireball1725/librarium-api/internal/jobs"
 	"github.com/fireball1725/librarium-api/internal/models"
 	"github.com/fireball1725/librarium-api/internal/providers"
 	bookProviders "github.com/fireball1725/librarium-api/internal/providers/books"
@@ -155,9 +158,11 @@ func main() {
 		aiSuggestionsRepo,
 		cfg.CoverStoragePath,
 	)
+	jobRepo := repository.NewJobRepo(pool)
 	suggestionsSvc := service.NewSuggestionsService(
 		pool,
 		aiSuggestionsRepo,
+		jobRepo,
 		repository.NewBookRepo(pool),
 		repository.NewEditionRepo(pool),
 		workerBookSvc,
@@ -213,12 +218,9 @@ func main() {
 	}
 	slog.Info("river worker started")
 
-	// ── AI suggestions scheduler ─────────────────────────────────────────────
-	// Poll every 5 minutes: for each opted-in user whose last run is older than
-	// the configured cadence, enqueue a River job. Cheap and good enough for a
-	// self-hosted single-node deployment; multi-node deployments will want a
-	// proper distributed cron.
-	go runSuggestionsScheduler(baseCtx, aiSuggestionsRepo, jobSvc, riverClient)
+	// ── Unified job scheduler ────────────────────────────────────────────────
+	// Walks job_schedules on a 30s tick and fires each kind's Enqueue hook
+	// when its cron expression is due. Kinds register their Enqueue below.
 
 	// ── HTTP server ───────────────────────────────────────────────────────────
 	addr := cfg.Host + ":" + cfg.Port
@@ -229,7 +231,69 @@ func main() {
 	if collector != nil {
 		metrics = collector
 	}
+	jobRegistry := jobs.NewRegistry()
+	// AI suggestions is the first scheduled kind. Its Enqueue replicates
+	// the previous per-user-fanout behaviour: walk opted-in users, skip
+	// any whose last run is inside the cadence window, enqueue a River
+	// job for everyone else.
+	jobRegistry.Register(&jobs.Definition{
+		Kind:        jobs.KindAISuggestions,
+		DisplayName: "AI suggestions",
+		Description: "Generates per-user book suggestions using the active AI provider.",
+		Schedulable: true,
+		DefaultCron: "0 3 * * *",
+		Enqueue: func(ctx context.Context, trig jobs.TriggerCtx, _ json.RawMessage) error {
+			cfg, err := jobSvc.GetAISuggestionsConfig(ctx)
+			if err != nil {
+				return fmt.Errorf("load ai-suggestions config: %w", err)
+			}
+			if !cfg.Enabled {
+				return nil
+			}
+			users, err := aiSuggestionsRepo.ListOptedInUsers(ctx)
+			if err != nil {
+				return fmt.Errorf("list opted-in users: %w", err)
+			}
+			cutoff := time.Now().Add(-time.Duration(cfg.IntervalMinutes) * time.Minute)
+			for _, u := range users {
+				last, err := aiSuggestionsRepo.LastRunAt(ctx, u.UserID)
+				if err != nil {
+					slog.Warn("ai scheduler: last-run lookup failed", "user_id", u.UserID, "error", err)
+					continue
+				}
+				if !last.IsZero() && last.After(cutoff) {
+					continue
+				}
+				if _, err := riverClient.Insert(ctx,
+					models.AISuggestionsJobArgs{UserID: u.UserID, TriggeredBy: "scheduler"}, nil); err != nil {
+					slog.Warn("ai scheduler: enqueue failed", "user_id", u.UserID, "error", err)
+				}
+			}
+			return nil
+		},
+	})
+	// Import and enrichment are run from user actions (no scheduled
+	// fanout yet), but register them for display on the jobs admin page.
+	jobRegistry.Register(&jobs.Definition{
+		Kind:        jobs.KindImport,
+		DisplayName: "CSV import",
+		Description: "Bulk imports rows from a CSV into the user's library.",
+		Schedulable: false,
+	})
+	jobRegistry.Register(&jobs.Definition{
+		Kind:        jobs.KindEnrichment,
+		DisplayName: "Metadata enrichment",
+		Description: "Fetches missing metadata / covers from providers for a batch of books.",
+		Schedulable: false,
+	})
+
+	// Kick the scheduler off after registry is populated.
+	jobRepoForSched := repository.NewJobRepo(pool)
+	scheduler := jobs.NewScheduler(jobRegistry, jobRepoForSched)
+	go scheduler.Run(baseCtx)
+
 	handler := api.NewRouter(baseCtx, pool, cfg, riverClient, metrics, api.RouterDeps{
+		JobRegistry: jobRegistry,
 		AISvc:       aiSvc,
 		ProviderSvc: providerSvc,
 	})
@@ -368,67 +432,6 @@ func pollQueueStats(ctx context.Context, pool *pgxpool.Pool) tui.QueueStats {
 		s.Active = append(s.Active, info)
 	}
 	return s
-}
-
-// runSuggestionsScheduler is a simple in-process cron for AI suggestions.
-// Every five minutes it reads the admin job config; if enabled, it walks every
-// opted-in user and enqueues a River job for any whose last run is older than
-// the cadence. River dedups via its own uniqueness semantics but we also check
-// LastRunAt in-process so we don't hammer the queue on each tick.
-func runSuggestionsScheduler(
-	ctx context.Context,
-	repo *repository.AISuggestionsRepo,
-	jobSvc *service.JobService,
-	riverClient *river.Client[pgx.Tx],
-) {
-	ticker := time.NewTicker(5 * time.Minute)
-	defer ticker.Stop()
-	// Kick off a first pass shortly after startup so freshly-configured
-	// deployments don't sit idle for 5 minutes.
-	first := time.NewTimer(30 * time.Second)
-	defer first.Stop()
-
-	run := func() {
-		cfg, err := jobSvc.GetAISuggestionsConfig(ctx)
-		if err != nil {
-			slog.Warn("ai scheduler: load config failed", "error", err)
-			return
-		}
-		if !cfg.Enabled || cfg.IntervalMinutes <= 0 {
-			return
-		}
-		users, err := repo.ListOptedInUsers(ctx)
-		if err != nil {
-			slog.Warn("ai scheduler: list users failed", "error", err)
-			return
-		}
-		cutoff := time.Now().Add(-time.Duration(cfg.IntervalMinutes) * time.Minute)
-		for _, u := range users {
-			last, err := repo.LastRunAt(ctx, u.UserID)
-			if err != nil {
-				slog.Warn("ai scheduler: last run lookup failed", "user_id", u.UserID, "error", err)
-				continue
-			}
-			if !last.IsZero() && last.After(cutoff) {
-				continue
-			}
-			if _, err := riverClient.Insert(ctx,
-				models.AISuggestionsJobArgs{UserID: u.UserID, TriggeredBy: "scheduler"}, nil); err != nil {
-				slog.Warn("ai scheduler: enqueue failed", "user_id", u.UserID, "error", err)
-			}
-		}
-	}
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-first.C:
-			run()
-		case <-ticker.C:
-			run()
-		}
-	}
 }
 
 // backfillContributorSortNames derives and persists sort_name for contributors

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -744,6 +744,264 @@ const docTemplate = `{
                 }
             }
         },
+        "/admin/jobs/history": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns jobs across every kind in a single paginated list.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin",
+                    "jobs"
+                ],
+                "summary": "List unified job history",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "filter by kind",
+                        "name": "kind",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "filter by status",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "RFC3339 or NNd",
+                        "name": "since",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "default 50, max 500",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "0-based",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "items": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/internal_api_handlers.JobView"
+                                    }
+                                },
+                                "total": {
+                                    "type": "integer"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin",
+                    "jobs"
+                ],
+                "summary": "Clear finished job history",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "restrict to one kind",
+                        "name": "kind",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "deleted": {
+                                    "type": "integer"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/jobs/schedules": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin",
+                    "jobs"
+                ],
+                "summary": "List job schedules",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/internal_api_handlers.ScheduleView"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/jobs/schedules/{kind}": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin",
+                    "jobs"
+                ],
+                "summary": "Upsert a job schedule",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "job kind",
+                        "name": "kind",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "schedule",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "config": {
+                                    "type": "object"
+                                },
+                                "cron": {
+                                    "type": "string"
+                                },
+                                "enabled": {
+                                    "type": "boolean"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_api_handlers.ScheduleView"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/jobs/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin",
+                    "jobs"
+                ],
+                "summary": "Get unified job detail with event log",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "job id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "events": {
+                                    "type": "array"
+                                },
+                                "job": {
+                                    "$ref": "#/definitions/internal_api_handlers.JobView"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "tags": [
+                    "admin",
+                    "jobs"
+                ],
+                "summary": "Delete a job entirely",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "job id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                }
+            }
+        },
         "/admin/providers": {
             "get": {
                 "security": [
@@ -11345,6 +11603,50 @@ const docTemplate = `{
                 }
             }
         },
+        "internal_api_handlers.JobView": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "created_by": {
+                    "type": "string"
+                },
+                "error": {
+                    "type": "string"
+                },
+                "finished_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "kind": {
+                    "type": "string"
+                },
+                "progress": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "schedule_id": {
+                    "type": "string"
+                },
+                "started_at": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "triggered_by": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
         "internal_api_handlers.MeSeriesResult": {
             "type": "object",
             "properties": {
@@ -11471,6 +11773,38 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "user_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api_handlers.ScheduleView": {
+            "type": "object",
+            "properties": {
+                "config": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "cron": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "kind": {
+                    "type": "string"
+                },
+                "last_fired_at": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -738,6 +738,264 @@
                 }
             }
         },
+        "/admin/jobs/history": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns jobs across every kind in a single paginated list.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin",
+                    "jobs"
+                ],
+                "summary": "List unified job history",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "filter by kind",
+                        "name": "kind",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "filter by status",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "RFC3339 or NNd",
+                        "name": "since",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "default 50, max 500",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "0-based",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "items": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/internal_api_handlers.JobView"
+                                    }
+                                },
+                                "total": {
+                                    "type": "integer"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin",
+                    "jobs"
+                ],
+                "summary": "Clear finished job history",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "restrict to one kind",
+                        "name": "kind",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "deleted": {
+                                    "type": "integer"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/jobs/schedules": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin",
+                    "jobs"
+                ],
+                "summary": "List job schedules",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/internal_api_handlers.ScheduleView"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/jobs/schedules/{kind}": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin",
+                    "jobs"
+                ],
+                "summary": "Upsert a job schedule",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "job kind",
+                        "name": "kind",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "schedule",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "config": {
+                                    "type": "object"
+                                },
+                                "cron": {
+                                    "type": "string"
+                                },
+                                "enabled": {
+                                    "type": "boolean"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_api_handlers.ScheduleView"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/jobs/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin",
+                    "jobs"
+                ],
+                "summary": "Get unified job detail with event log",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "job id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "events": {
+                                    "type": "array"
+                                },
+                                "job": {
+                                    "$ref": "#/definitions/internal_api_handlers.JobView"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "tags": [
+                    "admin",
+                    "jobs"
+                ],
+                "summary": "Delete a job entirely",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "job id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    }
+                }
+            }
+        },
         "/admin/providers": {
             "get": {
                 "security": [
@@ -11339,6 +11597,50 @@
                 }
             }
         },
+        "internal_api_handlers.JobView": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "created_by": {
+                    "type": "string"
+                },
+                "error": {
+                    "type": "string"
+                },
+                "finished_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "kind": {
+                    "type": "string"
+                },
+                "progress": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "schedule_id": {
+                    "type": "string"
+                },
+                "started_at": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "triggered_by": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
         "internal_api_handlers.MeSeriesResult": {
             "type": "object",
             "properties": {
@@ -11465,6 +11767,38 @@
                     "type": "string"
                 },
                 "user_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api_handlers.ScheduleView": {
+            "type": "object",
+            "properties": {
+                "config": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "cron": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "kind": {
+                    "type": "string"
+                },
+                "last_fired_at": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -545,6 +545,35 @@ definitions:
       type:
         type: string
     type: object
+  internal_api_handlers.JobView:
+    properties:
+      created_at:
+        type: string
+      created_by:
+        type: string
+      error:
+        type: string
+      finished_at:
+        type: string
+      id:
+        type: string
+      kind:
+        type: string
+      progress:
+        items:
+          type: integer
+        type: array
+      schedule_id:
+        type: string
+      started_at:
+        type: string
+      status:
+        type: string
+      triggered_by:
+        type: string
+      updated_at:
+        type: string
+    type: object
   internal_api_handlers.MeSeriesResult:
     properties:
       id:
@@ -631,6 +660,27 @@ definitions:
       triggered_by:
         type: string
       user_id:
+        type: string
+    type: object
+  internal_api_handlers.ScheduleView:
+    properties:
+      config:
+        items:
+          type: integer
+        type: array
+      cron:
+        type: string
+      description:
+        type: string
+      display_name:
+        type: string
+      enabled:
+        type: boolean
+      id:
+        type: string
+      kind:
+        type: string
+      last_fired_at:
         type: string
     type: object
   internal_api_handlers.SteeringView:
@@ -1440,6 +1490,48 @@ paths:
       tags:
       - admin
       - jobs
+  /admin/jobs/{id}:
+    delete:
+      parameters:
+      - description: job id
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+      security:
+      - BearerAuth: []
+      summary: Delete a job entirely
+      tags:
+      - admin
+      - jobs
+    get:
+      parameters:
+      - description: job id
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            properties:
+              events:
+                type: array
+              job:
+                $ref: '#/definitions/internal_api_handlers.JobView'
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Get unified job detail with event log
+      tags:
+      - admin
+      - jobs
   /admin/jobs/ai-suggestions:
     get:
       produces:
@@ -1604,6 +1696,125 @@ paths:
       security:
       - BearerAuth: []
       summary: Get any AI suggestion run (admin)
+      tags:
+      - admin
+      - jobs
+  /admin/jobs/history:
+    delete:
+      parameters:
+      - description: restrict to one kind
+        in: query
+        name: kind
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            properties:
+              deleted:
+                type: integer
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Clear finished job history
+      tags:
+      - admin
+      - jobs
+    get:
+      description: Returns jobs across every kind in a single paginated list.
+      parameters:
+      - description: filter by kind
+        in: query
+        name: kind
+        type: string
+      - description: filter by status
+        in: query
+        name: status
+        type: string
+      - description: RFC3339 or NNd
+        in: query
+        name: since
+        type: string
+      - description: default 50, max 500
+        in: query
+        name: limit
+        type: integer
+      - description: 0-based
+        in: query
+        name: offset
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            properties:
+              items:
+                items:
+                  $ref: '#/definitions/internal_api_handlers.JobView'
+                type: array
+              total:
+                type: integer
+            type: object
+      security:
+      - BearerAuth: []
+      summary: List unified job history
+      tags:
+      - admin
+      - jobs
+  /admin/jobs/schedules:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/internal_api_handlers.ScheduleView'
+            type: array
+      security:
+      - BearerAuth: []
+      summary: List job schedules
+      tags:
+      - admin
+      - jobs
+  /admin/jobs/schedules/{kind}:
+    put:
+      consumes:
+      - application/json
+      parameters:
+      - description: job kind
+        in: path
+        name: kind
+        required: true
+        type: string
+      - description: schedule
+        in: body
+        name: body
+        required: true
+        schema:
+          properties:
+            config:
+              type: object
+            cron:
+              type: string
+            enabled:
+              type: boolean
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/internal_api_handlers.ScheduleView'
+      security:
+      - BearerAuth: []
+      summary: Upsert a job schedule
       tags:
       - admin
       - jobs

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/jackc/pgx/v5 v5.9.1
 	github.com/riverqueue/river v0.34.0
 	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.34.0
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/swaggo/swag v1.16.6
 	golang.org/x/crypto v0.50.0
 )

--- a/internal/api/handlers/jobs_admin.go
+++ b/internal/api/handlers/jobs_admin.go
@@ -1,0 +1,337 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725 (Adaléa)
+
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/fireball1725/librarium-api/internal/api/respond"
+	"github.com/fireball1725/librarium-api/internal/jobs"
+	"github.com/fireball1725/librarium-api/internal/models"
+	"github.com/fireball1725/librarium-api/internal/repository"
+	"github.com/google/uuid"
+)
+
+// UnifiedJobsHandler backs the /admin/jobs/history surface — one entry
+// point that returns every kind of job in one shape. Kind-specific
+// endpoints (the per-type routes under /admin/jobs/ai-suggestions/...,
+// /enrichment-batches/..., /imports/...) stay for now so the existing
+// Jobs page keeps working until the web PR lands on these unified
+// endpoints.
+type UnifiedJobsHandler struct {
+	jobs     *repository.JobRepo
+	registry *jobs.Registry
+}
+
+func NewUnifiedJobsHandler(jr *repository.JobRepo, registry *jobs.Registry) *UnifiedJobsHandler {
+	return &UnifiedJobsHandler{jobs: jr, registry: registry}
+}
+
+// JobView is the wire-shape for one unified job row. Progress is a
+// per-kind JSON blob already stored on the umbrella row; the web renders
+// it via a kind-aware sub-component.
+type JobView struct {
+	ID          string          `json:"id"`
+	Kind        string          `json:"kind"`
+	Status      string          `json:"status"`
+	TriggeredBy string          `json:"triggered_by"`
+	CreatedBy   *string         `json:"created_by,omitempty"`
+	ScheduleID  *string         `json:"schedule_id,omitempty"`
+	Error       string          `json:"error,omitempty"`
+	Progress    json.RawMessage `json:"progress"`
+	StartedAt   *time.Time      `json:"started_at,omitempty"`
+	FinishedAt  *time.Time      `json:"finished_at,omitempty"`
+	CreatedAt   time.Time       `json:"created_at"`
+	UpdatedAt   time.Time       `json:"updated_at"`
+}
+
+func toJobView(j *models.Job) JobView {
+	v := JobView{
+		ID:          j.ID.String(),
+		Kind:        j.Kind,
+		Status:      string(j.Status),
+		TriggeredBy: string(j.TriggeredBy),
+		Error:       j.Error,
+		Progress:    j.Progress,
+		StartedAt:   j.StartedAt,
+		FinishedAt:  j.FinishedAt,
+		CreatedAt:   j.CreatedAt,
+		UpdatedAt:   j.UpdatedAt,
+	}
+	if j.CreatedBy != nil {
+		s := j.CreatedBy.String()
+		v.CreatedBy = &s
+	}
+	if j.ScheduleID != nil {
+		s := j.ScheduleID.String()
+		v.ScheduleID = &s
+	}
+	if len(v.Progress) == 0 {
+		v.Progress = json.RawMessage("{}")
+	}
+	return v
+}
+
+// History godoc
+//
+//	@Summary     List unified job history
+//	@Description Returns jobs across every kind in a single paginated list.
+//	@Tags        admin,jobs
+//	@Produce     json
+//	@Security    BearerAuth
+//	@Param       kind    query  string  false  "filter by kind"
+//	@Param       status  query  string  false  "filter by status"
+//	@Param       since   query  string  false  "RFC3339 or NNd"
+//	@Param       limit   query  int     false  "default 50, max 500"
+//	@Param       offset  query  int     false  "0-based"
+//	@Success     200  {object}  object{items=[]handlers.JobView,total=int}
+//	@Router      /admin/jobs/history [get]
+func (h *UnifiedJobsHandler) History(w http.ResponseWriter, r *http.Request) {
+	opts := repository.ListJobsOpts{
+		Kind:   r.URL.Query().Get("kind"),
+		Status: r.URL.Query().Get("status"),
+	}
+	if s := r.URL.Query().Get("since"); s != "" {
+		if t, err := time.Parse(time.RFC3339, s); err == nil {
+			opts.Since = &t
+		} else if n, ok := parseJobDays(s); ok {
+			t := time.Now().Add(-time.Duration(n) * 24 * time.Hour)
+			opts.Since = &t
+		} else {
+			respond.Error(w, http.StatusBadRequest, "invalid since")
+			return
+		}
+	}
+	if s := r.URL.Query().Get("limit"); s != "" {
+		if n, err := strconv.Atoi(s); err == nil {
+			opts.Limit = n
+		}
+	}
+	if s := r.URL.Query().Get("offset"); s != "" {
+		if n, err := strconv.Atoi(s); err == nil {
+			opts.Offset = n
+		}
+	}
+
+	items, total, err := h.jobs.ListJobs(r.Context(), opts)
+	if err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
+	out := make([]JobView, 0, len(items))
+	for _, j := range items {
+		out = append(out, toJobView(j))
+	}
+	respond.JSON(w, http.StatusOK, map[string]any{"items": out, "total": total})
+}
+
+// Detail godoc
+//
+//	@Summary     Get unified job detail with event log
+//	@Tags        admin,jobs
+//	@Produce     json
+//	@Security    BearerAuth
+//	@Param       id   path  string  true  "job id"
+//	@Success     200  {object}  object{job=handlers.JobView,events=array}
+//	@Router      /admin/jobs/{id} [get]
+func (h *UnifiedJobsHandler) Detail(w http.ResponseWriter, r *http.Request) {
+	id, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		respond.Error(w, http.StatusBadRequest, "invalid id")
+		return
+	}
+	j, err := h.jobs.GetJob(r.Context(), id)
+	if errors.Is(err, repository.ErrNotFound) {
+		respond.Error(w, http.StatusNotFound, "job not found")
+		return
+	}
+	if err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
+	evts, err := h.jobs.ListEvents(r.Context(), id)
+	if err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
+	respond.JSON(w, http.StatusOK, map[string]any{
+		"job":    toJobView(j),
+		"events": evts,
+	})
+}
+
+// Delete godoc
+//
+//	@Summary     Delete a job entirely
+//	@Tags        admin,jobs
+//	@Security    BearerAuth
+//	@Param       id   path  string  true  "job id"
+//	@Success     204
+//	@Router      /admin/jobs/{id} [delete]
+func (h *UnifiedJobsHandler) Delete(w http.ResponseWriter, r *http.Request) {
+	id, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		respond.Error(w, http.StatusBadRequest, "invalid id")
+		return
+	}
+	if err := h.jobs.DeleteJob(r.Context(), id); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			respond.Error(w, http.StatusNotFound, "job not found")
+			return
+		}
+		respond.ServerError(w, r, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// DeleteHistory godoc
+//
+//	@Summary     Clear finished job history
+//	@Tags        admin,jobs
+//	@Produce     json
+//	@Security    BearerAuth
+//	@Param       kind  query  string  false  "restrict to one kind"
+//	@Success     200  {object}  object{deleted=int}
+//	@Router      /admin/jobs/history [delete]
+func (h *UnifiedJobsHandler) DeleteHistory(w http.ResponseWriter, r *http.Request) {
+	kind := r.URL.Query().Get("kind")
+	n, err := h.jobs.DeleteFinished(r.Context(), kind)
+	if err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
+	respond.JSON(w, http.StatusOK, map[string]any{"deleted": n})
+}
+
+// ─── Schedules ───────────────────────────────────────────────────────────────
+
+// ScheduleView is a job_schedules row enriched with registry display info.
+type ScheduleView struct {
+	ID          string          `json:"id"`
+	Kind        string          `json:"kind"`
+	DisplayName string          `json:"display_name"`
+	Description string          `json:"description"`
+	Cron        string          `json:"cron"`
+	Enabled     bool            `json:"enabled"`
+	Config      json.RawMessage `json:"config"`
+	LastFiredAt *time.Time      `json:"last_fired_at,omitempty"`
+}
+
+// ListSchedules godoc
+//
+//	@Summary     List job schedules
+//	@Tags        admin,jobs
+//	@Produce     json
+//	@Security    BearerAuth
+//	@Success     200  {array}  handlers.ScheduleView
+//	@Router      /admin/jobs/schedules [get]
+func (h *UnifiedJobsHandler) ListSchedules(w http.ResponseWriter, r *http.Request) {
+	rows, err := h.jobs.ListSchedules(r.Context())
+	if err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
+	out := make([]ScheduleView, 0, len(rows))
+	for _, s := range rows {
+		v := ScheduleView{
+			ID:          s.ID.String(),
+			Kind:        s.Kind,
+			Cron:        s.Cron,
+			Enabled:     s.Enabled,
+			Config:      s.Config,
+			LastFiredAt: s.LastFiredAt,
+		}
+		if def := h.registry.Get(jobs.Kind(s.Kind)); def != nil {
+			v.DisplayName = def.DisplayName
+			v.Description = def.Description
+		} else {
+			v.DisplayName = s.Kind
+		}
+		if len(v.Config) == 0 {
+			v.Config = json.RawMessage("{}")
+		}
+		out = append(out, v)
+	}
+	respond.JSON(w, http.StatusOK, out)
+}
+
+// UpdateSchedule godoc
+//
+//	@Summary     Upsert a job schedule
+//	@Tags        admin,jobs
+//	@Accept      json
+//	@Produce     json
+//	@Security    BearerAuth
+//	@Param       kind  path  string  true  "job kind"
+//	@Param       body  body  object{cron=string,enabled=boolean,config=object}  true  "schedule"
+//	@Success     200  {object}  handlers.ScheduleView
+//	@Router      /admin/jobs/schedules/{kind} [put]
+func (h *UnifiedJobsHandler) UpdateSchedule(w http.ResponseWriter, r *http.Request) {
+	kind := r.PathValue("kind")
+	if kind == "" {
+		respond.Error(w, http.StatusBadRequest, "missing kind")
+		return
+	}
+	if h.registry.Get(jobs.Kind(kind)) == nil {
+		respond.Error(w, http.StatusBadRequest, "unknown job kind")
+		return
+	}
+	var body struct {
+		Cron    string          `json:"cron"`
+		Enabled bool            `json:"enabled"`
+		Config  json.RawMessage `json:"config"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		respond.Error(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if body.Cron == "" {
+		respond.Error(w, http.StatusBadRequest, "cron is required")
+		return
+	}
+	sched := &models.JobSchedule{
+		Kind:    kind,
+		Cron:    body.Cron,
+		Enabled: body.Enabled,
+		Config:  body.Config,
+	}
+	if err := h.jobs.UpsertSchedule(r.Context(), sched); err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
+	def := h.registry.Get(jobs.Kind(kind))
+	respond.JSON(w, http.StatusOK, ScheduleView{
+		ID:          sched.ID.String(),
+		Kind:        sched.Kind,
+		DisplayName: def.DisplayName,
+		Description: def.Description,
+		Cron:        sched.Cron,
+		Enabled:     sched.Enabled,
+		Config:      sched.Config,
+	})
+}
+
+// parseJobDays accepts tokens like "30d", "7d" and returns the integer
+// day count. Returns (0, false) for anything else.
+func parseJobDays(s string) (int, bool) {
+	if len(s) < 2 || s[len(s)-1] != 'd' {
+		return 0, false
+	}
+	n := 0
+	for _, r := range s[:len(s)-1] {
+		if r < '0' || r > '9' {
+			return 0, false
+		}
+		n = n*10 + int(r-'0')
+	}
+	if n <= 0 || n > 3650 {
+		return 0, false
+	}
+	return n, true
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -14,6 +14,7 @@ import (
 	"github.com/fireball1725/librarium-api/internal/auth"
 	"github.com/fireball1725/librarium-api/internal/background"
 	"github.com/fireball1725/librarium-api/internal/config"
+	"github.com/fireball1725/librarium-api/internal/jobs"
 	"github.com/fireball1725/librarium-api/internal/repository"
 	"github.com/fireball1725/librarium-api/internal/service"
 	"github.com/jackc/pgx/v5"
@@ -35,6 +36,7 @@ type MetricsCollector interface {
 type RouterDeps struct {
 	AISvc       *service.AIService
 	ProviderSvc *service.ProviderService
+	JobRegistry *jobs.Registry
 }
 
 func NewRouter(ctx context.Context, db *pgxpool.Pool, cfg *config.Config, riverClient *river.Client[pgx.Tx], metrics MetricsCollector, deps RouterDeps) http.Handler {
@@ -100,6 +102,7 @@ func NewRouter(ctx context.Context, db *pgxpool.Pool, cfg *config.Config, riverC
 	aiHandler := handlers.NewAIHandler(aiSvc)
 	aiUserHandler := handlers.NewAIUserHandler(aiUserSvc)
 	jobsHandler := handlers.NewJobsHandler(jobSvc)
+	unifiedJobsHandler := handlers.NewUnifiedJobsHandler(repository.NewJobRepo(db), deps.JobRegistry)
 	aiSuggestionsHandler := handlers.NewAISuggestionsHandler(aiSuggestionsRepo, riverClient, jobSvc, aiSvc)
 
 	authHandler := handlers.NewAuthHandler(authSvc, preferencesRepo)
@@ -201,6 +204,15 @@ func NewRouter(ctx context.Context, db *pgxpool.Pool, cfg *config.Config, riverC
 
 	// Admin — configurable scheduled jobs (instance admin only)
 	mux.Handle("GET /api/v1/admin/jobs", requireAdmin(http.HandlerFunc(jobsHandler.ListJobs)))
+	// Unified jobs surface (history/detail/cancel/delete + schedules). The
+	// existing per-kind endpoints stay registered below until the web side
+	// of the jobs-framework migration lands (PR 2).
+	mux.Handle("GET /api/v1/admin/jobs/history", requireAdmin(http.HandlerFunc(unifiedJobsHandler.History)))
+	mux.Handle("DELETE /api/v1/admin/jobs/history", requireAdmin(http.HandlerFunc(unifiedJobsHandler.DeleteHistory)))
+	mux.Handle("GET /api/v1/admin/jobs/schedules", requireAdmin(http.HandlerFunc(unifiedJobsHandler.ListSchedules)))
+	mux.Handle("PUT /api/v1/admin/jobs/schedules/{kind}", requireAdmin(http.HandlerFunc(unifiedJobsHandler.UpdateSchedule)))
+	mux.Handle("GET /api/v1/admin/jobs/{id}", requireAdmin(http.HandlerFunc(unifiedJobsHandler.Detail)))
+	mux.Handle("DELETE /api/v1/admin/jobs/{id}", requireAdmin(http.HandlerFunc(unifiedJobsHandler.Delete)))
 	mux.Handle("GET /api/v1/admin/jobs/ai-suggestions", requireAdmin(http.HandlerFunc(jobsHandler.GetAISuggestionsJob)))
 	mux.Handle("PUT /api/v1/admin/jobs/ai-suggestions", requireAdmin(http.HandlerFunc(jobsHandler.UpdateAISuggestionsJob)))
 	mux.Handle("POST /api/v1/admin/jobs/ai-suggestions/run", requireAdmin(http.HandlerFunc(aiSuggestionsHandler.AdminRunSuggestions)))

--- a/internal/db/migrations/000010_jobs_framework.down.sql
+++ b/internal/db/migrations/000010_jobs_framework.down.sql
@@ -1,0 +1,39 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Copyright (C) 2026 fireball1725
+
+-- Reverse the jobs framework migration. Lossy — ai_run_events lose their
+-- id/created_at precision since we rebuild from job_events via a join that
+-- could drop rows for jobs whose kind isn't ai_suggestions anymore.
+
+-- Re-create ai_run_events from the subset of job_events that belong to AI
+-- suggestion runs. Anything else in job_events (import/enrichment trails
+-- that never existed pre-migration but might exist post-upgrade) is lost.
+
+CREATE TABLE ai_run_events (
+    id         UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    run_id     UUID        NOT NULL REFERENCES ai_suggestion_runs(id) ON DELETE CASCADE,
+    seq        INT         NOT NULL,
+    type       TEXT        NOT NULL,
+    content    JSONB       NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_ai_run_events_run_seq ON ai_run_events(run_id, seq);
+
+INSERT INTO ai_run_events (id, run_id, seq, type, content, created_at)
+SELECT ev.id, asr.id, ev.seq, ev.type, ev.content, ev.created_at
+  FROM job_events ev
+  JOIN ai_suggestion_runs asr ON asr.job_id = ev.job_id;
+
+-- Drop the job_id FK columns (the umbrella no longer exists to point at).
+DROP INDEX IF EXISTS idx_import_jobs_job_id;
+DROP INDEX IF EXISTS idx_enrichment_batches_job_id;
+DROP INDEX IF EXISTS idx_ai_suggestion_runs_job_id;
+
+ALTER TABLE import_jobs         DROP COLUMN job_id;
+ALTER TABLE enrichment_batches  DROP COLUMN job_id;
+ALTER TABLE ai_suggestion_runs  DROP COLUMN job_id;
+
+DROP TABLE job_events;
+DROP TABLE jobs;
+DROP TABLE job_schedules;

--- a/internal/db/migrations/000010_jobs_framework.up.sql
+++ b/internal/db/migrations/000010_jobs_framework.up.sql
@@ -1,0 +1,250 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Copyright (C) 2026 fireball1725
+
+-- Unified jobs framework: one umbrella `jobs` table that every job kind
+-- (import, enrichment, ai_suggestions, ...and future ones) writes status +
+-- events into, a generalized `job_events` log, and a `job_schedules` table
+-- keyed on kind for cron-driven recurring runs.
+--
+-- Motivation + design: plans/jobs-framework.md. This migration is PR 1:
+-- schema + legacy backfill. Go-side rewiring lands in the same PR; web
+-- rewires to the new endpoints in PR 2.
+
+-- ── Umbrella tables ────────────────────────────────────────────────────────
+
+CREATE TABLE job_schedules (
+    id            UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    kind          TEXT        NOT NULL UNIQUE,
+    cron          TEXT        NOT NULL,
+    enabled       BOOLEAN     NOT NULL DEFAULT TRUE,
+    config        JSONB       NOT NULL DEFAULT '{}'::jsonb,
+    last_fired_at TIMESTAMPTZ,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TRIGGER job_schedules_updated_at
+    BEFORE UPDATE ON job_schedules
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+CREATE TABLE jobs (
+    id           UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    kind         TEXT        NOT NULL,
+    status       TEXT        NOT NULL DEFAULT 'pending',
+                  -- pending | running | completed | failed | cancelled
+    triggered_by TEXT        NOT NULL DEFAULT 'user',
+                  -- user | admin | scheduler | api
+    created_by   UUID        REFERENCES users(id),
+    schedule_id  UUID        REFERENCES job_schedules(id) ON DELETE SET NULL,
+    error        TEXT        NOT NULL DEFAULT '',
+    progress     JSONB       NOT NULL DEFAULT '{}'::jsonb,
+    started_at   TIMESTAMPTZ,
+    finished_at  TIMESTAMPTZ,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TRIGGER jobs_updated_at
+    BEFORE UPDATE ON jobs
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+CREATE INDEX idx_jobs_kind_status ON jobs(kind, status);
+CREATE INDEX idx_jobs_created_at  ON jobs(created_at DESC);
+CREATE INDEX idx_jobs_schedule_id ON jobs(schedule_id);
+
+CREATE TABLE job_events (
+    id         UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    job_id     UUID        NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
+    seq        INT         NOT NULL,
+    type       TEXT        NOT NULL,
+    content    JSONB       NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (job_id, seq)
+);
+
+CREATE INDEX idx_job_events_job_id ON job_events(job_id);
+
+-- ── Legacy table FKs to the umbrella ───────────────────────────────────────
+-- Each legacy "job-like" table gets a job_id column. Populated immediately
+-- below. The new umbrella row is authoritative for status/error/timestamps;
+-- kind-specific counters (rows/books/tokens) stay on the kind table.
+
+ALTER TABLE import_jobs         ADD COLUMN job_id UUID REFERENCES jobs(id) ON DELETE CASCADE;
+ALTER TABLE enrichment_batches  ADD COLUMN job_id UUID REFERENCES jobs(id) ON DELETE CASCADE;
+ALTER TABLE ai_suggestion_runs  ADD COLUMN job_id UUID REFERENCES jobs(id) ON DELETE CASCADE;
+
+-- ── Backfill: one jobs row per existing legacy row ─────────────────────────
+-- import_jobs and enrichment_batches don't have a started_at — we reuse
+-- created_at (runs start roughly when they're created in this codebase).
+-- finished_at is copied from updated_at when status is terminal, null
+-- otherwise. error is left empty (neither legacy table recorded one).
+
+WITH new_rows AS (
+    INSERT INTO jobs (kind, status, triggered_by, created_by, started_at, finished_at, created_at, updated_at)
+    SELECT
+        'import',
+        status,
+        'user',
+        created_by,
+        created_at,
+        CASE WHEN status IN ('completed', 'failed', 'cancelled') THEN updated_at ELSE NULL END,
+        created_at,
+        updated_at
+    FROM import_jobs
+    ORDER BY created_at
+    RETURNING id, created_at
+),
+paired AS (
+    SELECT
+        ij.id AS legacy_id,
+        j.id  AS job_id
+    FROM (
+        SELECT id, created_at, ROW_NUMBER() OVER (ORDER BY created_at) AS rn
+        FROM import_jobs
+    ) ij
+    JOIN (
+        SELECT id, created_at, ROW_NUMBER() OVER (ORDER BY created_at) AS rn
+        FROM new_rows
+    ) j USING (rn)
+)
+UPDATE import_jobs
+   SET job_id = paired.job_id
+  FROM paired
+ WHERE import_jobs.id = paired.legacy_id;
+
+WITH new_rows AS (
+    INSERT INTO jobs (kind, status, triggered_by, created_by, started_at, finished_at, created_at, updated_at)
+    SELECT
+        'enrichment',
+        status,
+        'user',
+        created_by,
+        created_at,
+        CASE WHEN status IN ('completed', 'failed', 'cancelled') THEN updated_at ELSE NULL END,
+        created_at,
+        updated_at
+    FROM enrichment_batches
+    ORDER BY created_at
+    RETURNING id, created_at
+),
+paired AS (
+    SELECT
+        eb.id AS legacy_id,
+        j.id  AS job_id
+    FROM (
+        SELECT id, created_at, ROW_NUMBER() OVER (ORDER BY created_at) AS rn
+        FROM enrichment_batches
+    ) eb
+    JOIN (
+        SELECT id, created_at, ROW_NUMBER() OVER (ORDER BY created_at) AS rn
+        FROM new_rows
+    ) j USING (rn)
+)
+UPDATE enrichment_batches
+   SET job_id = paired.job_id
+  FROM paired
+ WHERE enrichment_batches.id = paired.legacy_id;
+
+WITH new_rows AS (
+    INSERT INTO jobs (kind, status, triggered_by, created_by, error, started_at, finished_at, created_at, updated_at)
+    SELECT
+        'ai_suggestions',
+        status,
+        triggered_by,
+        user_id,
+        COALESCE(error, ''),
+        started_at,
+        finished_at,
+        started_at,
+        COALESCE(finished_at, started_at)
+    FROM ai_suggestion_runs
+    ORDER BY started_at
+    RETURNING id, started_at
+),
+paired AS (
+    SELECT
+        asr.id AS legacy_id,
+        j.id   AS job_id
+    FROM (
+        SELECT id, started_at, ROW_NUMBER() OVER (ORDER BY started_at) AS rn
+        FROM ai_suggestion_runs
+    ) asr
+    JOIN (
+        SELECT id, started_at, ROW_NUMBER() OVER (ORDER BY started_at) AS rn
+        FROM new_rows
+    ) j USING (rn)
+)
+UPDATE ai_suggestion_runs
+   SET job_id = paired.job_id
+  FROM paired
+ WHERE ai_suggestion_runs.id = paired.legacy_id;
+
+-- Every legacy row should now have a job_id. Lock it in.
+ALTER TABLE import_jobs         ALTER COLUMN job_id SET NOT NULL;
+ALTER TABLE enrichment_batches  ALTER COLUMN job_id SET NOT NULL;
+ALTER TABLE ai_suggestion_runs  ALTER COLUMN job_id SET NOT NULL;
+
+CREATE INDEX idx_import_jobs_job_id        ON import_jobs(job_id);
+CREATE INDEX idx_enrichment_batches_job_id ON enrichment_batches(job_id);
+CREATE INDEX idx_ai_suggestion_runs_job_id ON ai_suggestion_runs(job_id);
+
+-- ── Move ai_run_events → job_events ────────────────────────────────────────
+
+INSERT INTO job_events (id, job_id, seq, type, content, created_at)
+SELECT ev.id, asr.job_id, ev.seq, ev.type, ev.content, ev.created_at
+  FROM ai_run_events ev
+  JOIN ai_suggestion_runs asr ON asr.id = ev.run_id;
+
+DROP TABLE ai_run_events;
+
+-- ── Seed job_schedules from existing instance_settings ─────────────────────
+-- The AI suggestions job has a simple `interval_minutes` config today. Any
+-- value ≥ 60 that divides evenly into hours gets the cleanest cron; anything
+-- else rounds to daily at midnight UTC and the admin can fine-tune via the
+-- new cron editor once PR 2 ships.
+
+DO $$
+DECLARE
+    cfg JSONB;
+    interval_min INT;
+    cron_expr TEXT;
+    was_enabled BOOLEAN;
+BEGIN
+    SELECT value::jsonb INTO cfg
+      FROM instance_settings
+     WHERE key = 'job:ai-suggestions';
+
+    IF cfg IS NULL THEN
+        -- No saved config → seed a disabled daily schedule so the admin can
+        -- turn it on from the UI when they're ready.
+        INSERT INTO job_schedules (kind, cron, enabled)
+        VALUES ('ai_suggestions', '0 3 * * *', FALSE);
+        RETURN;
+    END IF;
+
+    interval_min := COALESCE((cfg->>'interval_minutes')::INT, 0);
+    was_enabled  := COALESCE((cfg->>'enabled')::BOOLEAN, FALSE);
+
+    IF interval_min <= 0 THEN
+        cron_expr := '0 3 * * *'; -- daily 3 AM fallback
+    ELSIF interval_min = 60 THEN
+        cron_expr := '0 * * * *';
+    ELSIF interval_min % 60 = 0 AND interval_min < 1440 THEN
+        -- hourly multiple: every N hours
+        cron_expr := FORMAT('0 */%s * * *', (interval_min / 60)::TEXT);
+    ELSIF interval_min = 1440 THEN
+        cron_expr := '0 0 * * *';
+    ELSIF interval_min % 1440 = 0 THEN
+        -- daily multiple: every N days
+        cron_expr := FORMAT('0 0 */%s * *', (interval_min / 1440)::TEXT);
+    ELSE
+        cron_expr := '0 3 * * *'; -- awkward value, land at daily 3 AM
+    END IF;
+
+    INSERT INTO job_schedules (kind, cron, enabled, config)
+    VALUES ('ai_suggestions', cron_expr, was_enabled, cfg)
+    ON CONFLICT (kind) DO UPDATE
+       SET cron    = EXCLUDED.cron,
+           enabled = EXCLUDED.enabled,
+           config  = EXCLUDED.config;
+END $$;

--- a/internal/jobs/registry.go
+++ b/internal/jobs/registry.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725 (Adaléa)
+
+// Package jobs holds the kind registry and runtime glue that bridges the
+// unified jobs umbrella (jobs / job_events / job_schedules tables) to
+// River-backed workers. Each job kind (import, enrichment, AI suggestions,
+// etc.) registers a Definition here that tells the scheduler how to turn
+// a schedule row + trigger into a River enqueue.
+package jobs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/fireball1725/librarium-api/internal/models"
+	"github.com/google/uuid"
+)
+
+// Kind is the stable string identifier for a job kind. Matches
+// jobs.kind, job_schedules.kind, and the Definition registered below.
+type Kind string
+
+// Built-in kinds. New kinds can declare their own constants alongside
+// their worker package and register from there.
+const (
+	KindImport         Kind = "import"
+	KindEnrichment     Kind = "enrichment"
+	KindAISuggestions  Kind = "ai_suggestions"
+)
+
+// TriggerCtx is everything the Enqueue hook of a Definition needs
+// beyond the kind-specific config JSON. ScheduleID is set when the
+// trigger came from the cron scheduler; nil otherwise.
+type TriggerCtx struct {
+	JobID       uuid.UUID
+	TriggeredBy models.JobTriggeredBy
+	CreatedBy   *uuid.UUID
+	ScheduleID  *uuid.UUID
+}
+
+// EnqueueFn is the bridge from the framework to the kind's worker. It
+// receives the umbrella jobs row that's already been created + the
+// config JSON from either the schedule row or the inline admin/user
+// request. Implementations hand off to the River client registered
+// at wire-time.
+type EnqueueFn func(ctx context.Context, trig TriggerCtx, config json.RawMessage) error
+
+// Definition is the per-kind registration. Workers fill this in at
+// startup; the scheduler and admin endpoints read from the registry to
+// figure out what's available and how to fire it.
+type Definition struct {
+	Kind        Kind
+	DisplayName string
+	Description string
+	// Schedulable means it can appear in the job_schedules table with
+	// a cron expression. One-off queued jobs (import/enrichment) may
+	// be un-schedulable.
+	Schedulable bool
+	// DefaultCron is the seed value when an admin first enables a
+	// schedule for this kind from the UI.
+	DefaultCron string
+	// Enqueue turns a trigger into a River job. Called by the
+	// scheduler loop (for scheduled runs) or directly by admin /
+	// user-facing endpoints (for manual runs).
+	Enqueue EnqueueFn
+}
+
+// Registry is the runtime map of Kind → Definition. Safe for concurrent
+// reads after wire-up; Register is expected to only be called from main
+// during startup.
+type Registry struct {
+	mu   sync.RWMutex
+	defs map[Kind]*Definition
+}
+
+func NewRegistry() *Registry {
+	return &Registry{defs: map[Kind]*Definition{}}
+}
+
+// Register adds or replaces a kind's definition. Replacing on a second
+// Register is not an error — tests sometimes rebuild the registry with
+// mocks.
+func (r *Registry) Register(def *Definition) {
+	if def == nil || def.Kind == "" {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.defs[def.Kind] = def
+}
+
+// Get returns the definition for a kind, or nil if not registered.
+func (r *Registry) Get(k Kind) *Definition {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.defs[k]
+}
+
+// All returns every registered definition in a stable order (by Kind).
+// Used by the admin Jobs page to enumerate what's available.
+func (r *Registry) All() []*Definition {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]*Definition, 0, len(r.defs))
+	for _, d := range r.defs {
+		out = append(out, d)
+	}
+	// Stable order so the UI doesn't shuffle on every page load.
+	// Simple bubble — we have a handful of kinds.
+	for i := 0; i < len(out); i++ {
+		for j := i + 1; j < len(out); j++ {
+			if out[j].Kind < out[i].Kind {
+				out[i], out[j] = out[j], out[i]
+			}
+		}
+	}
+	return out
+}
+
+// MustGet is a convenience for call sites that are certain the kind is
+// registered (e.g. a scheduler tick reading a kind out of
+// job_schedules that was written by the same process).
+func (r *Registry) MustGet(k Kind) *Definition {
+	d := r.Get(k)
+	if d == nil {
+		panic(fmt.Sprintf("jobs: kind %q not registered", k))
+	}
+	return d
+}

--- a/internal/jobs/scheduler.go
+++ b/internal/jobs/scheduler.go
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725 (Adaléa)
+
+package jobs
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"time"
+
+	"github.com/fireball1725/librarium-api/internal/models"
+	"github.com/fireball1725/librarium-api/internal/repository"
+	"github.com/google/uuid"
+	"github.com/robfig/cron/v3"
+)
+
+// Scheduler walks job_schedules on a short tick, parses each row's cron
+// expression, and fires the kind's Enqueue hook when the next scheduled
+// time has passed since last_fired_at. Replaces the previous hardcoded
+// AI-suggestions ticker — new kinds drop in by registering a Definition
+// with an Enqueue hook.
+type Scheduler struct {
+	registry *Registry
+	jobs     *repository.JobRepo
+	parser   cron.Parser
+}
+
+// NewScheduler wires up a scheduler around the given registry + repo.
+// Uses the standard 5-field cron parser (minute / hour / day-of-month /
+// month / day-of-week) — `react-js-cron` on the web emits the same.
+func NewScheduler(registry *Registry, jr *repository.JobRepo) *Scheduler {
+	return &Scheduler{
+		registry: registry,
+		jobs:     jr,
+		// NB: default parser doesn't support seconds. Keep it 5-field to
+		// match the UI editor; if we ever want second-level granularity
+		// we'll swap to cron.Descriptor explicitly.
+		parser: cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow),
+	}
+}
+
+// Run blocks until ctx is cancelled. Fires a tick every 30 seconds —
+// fine-grained enough that a "once a minute" cron misses at most one
+// minute, and infrequent enough that the DB query is trivial.
+func (s *Scheduler) Run(ctx context.Context) {
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+	// First tick after 10s so fresh startups don't sit idle waiting on
+	// the next 30s boundary.
+	first := time.NewTimer(10 * time.Second)
+	defer first.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-first.C:
+			s.tick(ctx)
+		case <-ticker.C:
+			s.tick(ctx)
+		}
+	}
+}
+
+// tick walks every schedule row once. Per-schedule errors are logged but
+// don't stop the loop — one bad kind shouldn't starve others.
+func (s *Scheduler) tick(ctx context.Context) {
+	schedules, err := s.jobs.ListSchedules(ctx)
+	if err != nil {
+		slog.Warn("scheduler: list schedules failed", "error", err)
+		return
+	}
+	now := time.Now()
+	for _, sched := range schedules {
+		if !sched.Enabled {
+			continue
+		}
+		def := s.registry.Get(Kind(sched.Kind))
+		if def == nil || def.Enqueue == nil {
+			// Kind isn't wired up for cron firing (yet). Leave the
+			// schedule row alone — admin can still edit it; we just
+			// won't fire until a worker registers an Enqueue.
+			continue
+		}
+
+		schedule, err := s.parser.Parse(sched.Cron)
+		if err != nil {
+			slog.Warn("scheduler: invalid cron", "kind", sched.Kind, "cron", sched.Cron, "error", err)
+			continue
+		}
+
+		// Reference time for "what's the next fire relative to a known
+		// previous fire". For fresh schedules with no last_fired_at we
+		// use created_at so a never-fired-before schedule fires on the
+		// first tick that's past its first cron time.
+		prev := sched.CreatedAt
+		if sched.LastFiredAt != nil {
+			prev = *sched.LastFiredAt
+		}
+		next := schedule.Next(prev)
+		if next.After(now) {
+			continue
+		}
+
+		if err := s.fire(ctx, sched, def); err != nil {
+			slog.Warn("scheduler: enqueue failed", "kind", sched.Kind, "error", err)
+			// Don't stamp last_fired_at — let the next tick retry.
+			continue
+		}
+		if err := s.jobs.MarkScheduleFired(ctx, sched.ID); err != nil {
+			slog.Warn("scheduler: mark fired failed", "kind", sched.Kind, "error", err)
+		}
+	}
+}
+
+// fire creates an umbrella jobs row for the scheduled trigger and hands
+// off to the kind's Enqueue hook. The umbrella row is the record of
+// "the scheduler ticked this kind"; Enqueue is free to create further
+// per-work umbrella rows (e.g. AI suggestions fans out per-user) or
+// treat the scheduler's row as the work itself (e.g. cover backfill
+// runs once against the catalog).
+//
+// After Enqueue returns, this scheduler-tick row transitions to
+// completed or failed. Per-work rows (if any) manage their own
+// lifecycle independently.
+func (s *Scheduler) fire(ctx context.Context, sched *models.JobSchedule, def *Definition) error {
+	now := time.Now()
+	j := &models.Job{
+		Kind:        string(sched.Kind),
+		Status:      models.JobStatusRunning,
+		TriggeredBy: models.JobTriggeredByScheduler,
+		ScheduleID:  &sched.ID,
+		StartedAt:   &now,
+	}
+	if err := s.jobs.CreateJob(ctx, j); err != nil {
+		return err
+	}
+	cfg := sched.Config
+	if len(cfg) == 0 {
+		cfg = json.RawMessage("{}")
+	}
+	if err := def.Enqueue(ctx, TriggerCtx{
+		JobID:       j.ID,
+		TriggeredBy: models.JobTriggeredByScheduler,
+		ScheduleID:  &sched.ID,
+	}, cfg); err != nil {
+		_ = s.jobs.MarkFinished(ctx, j.ID, models.JobStatusFailed, err.Error())
+		return err
+	}
+	return s.jobs.MarkFinished(ctx, j.ID, models.JobStatusCompleted, "")
+}
+
+// ensure uuid is imported for nil checks elsewhere that compile by
+// referencing this package first — no-op body.
+var _ = uuid.Nil

--- a/internal/models/job.go
+++ b/internal/models/job.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725 (Adaléa)
+
+package models
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// JobStatus is the canonical status for a row in the unified jobs table.
+// Every kind uses this same set of values; kind-specific counters
+// (rows/books/tokens) live on the kind's own table.
+type JobStatus string
+
+const (
+	JobStatusPending   JobStatus = "pending"
+	JobStatusRunning   JobStatus = "running"
+	JobStatusCompleted JobStatus = "completed"
+	JobStatusFailed    JobStatus = "failed"
+	JobStatusCancelled JobStatus = "cancelled"
+)
+
+// JobTriggeredBy records who (or what) asked a job to run. Used for audit
+// trails and to distinguish cost attribution (scheduler runs are free
+// attention; user runs count against rate limits; admin runs bypass both).
+type JobTriggeredBy string
+
+const (
+	JobTriggeredByUser      JobTriggeredBy = "user"
+	JobTriggeredByAdmin     JobTriggeredBy = "admin"
+	JobTriggeredByScheduler JobTriggeredBy = "scheduler"
+	JobTriggeredByAPI       JobTriggeredBy = "api"
+)
+
+// Job is one execution of some kind of work — import, enrichment, AI
+// suggestions, cover backfill, etc. Each kind may attach extra rows to
+// its own table (see import_jobs, enrichment_batches,
+// ai_suggestion_runs); the umbrella row is the source of truth for
+// status + timestamps + event log.
+type Job struct {
+	ID          uuid.UUID
+	Kind        string
+	Status      JobStatus
+	TriggeredBy JobTriggeredBy
+	CreatedBy   *uuid.UUID // null when system-triggered
+	ScheduleID  *uuid.UUID // set when this run was fired by a job_schedules row
+	Error       string
+	// Progress is a kind-specific JSON blob for summary UI. Import uses
+	// {processed,failed,skipped,total}; enrichment similar; AI suggestions
+	// uses {tokens_in,tokens_out,cost_usd}. Kept opaque at this layer.
+	Progress    json.RawMessage
+	StartedAt   *time.Time
+	FinishedAt  *time.Time
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
+// JobEvent is one entry in a job's progress log. Type is free-form per
+// kind (e.g. "prompt" and "ai_response" for AI suggestions; "row_done"
+// for imports). Clients render a generic timeline and let per-kind UI
+// opt in to richer rendering.
+type JobEvent struct {
+	ID        uuid.UUID
+	JobID     uuid.UUID
+	Seq       int
+	Type      string
+	Content   json.RawMessage
+	CreatedAt time.Time
+}
+
+// JobSchedule is a cron-driven recurring job. One row per Kind today;
+// scope keys can be added later if we need per-user or per-library
+// schedules.
+type JobSchedule struct {
+	ID          uuid.UUID
+	Kind        string
+	Cron        string // standard 5-field cron expression
+	Enabled     bool
+	Config      json.RawMessage // kind-specific tunables
+	LastFiredAt *time.Time
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}

--- a/internal/repository/ai_suggestions.go
+++ b/internal/repository/ai_suggestions.go
@@ -13,6 +13,7 @@ import (
 	"github.com/fireball1725/librarium-api/internal/models"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -261,34 +262,58 @@ func (r *AISuggestionsRepo) BookExistsInLibrary(ctx context.Context, libraryID u
 
 // CreateRun inserts a run row in 'running' state and returns its ID. steering
 // is the raw JSON payload persisted on the row (nil for unsteered runs); pass
-// it pre-marshalled so this helper stays taxonomy-agnostic.
-func (r *AISuggestionsRepo) CreateRun(ctx context.Context, userID uuid.UUID, triggeredBy, providerType, modelID string, steering []byte) (uuid.UUID, error) {
+// it pre-marshalled so this helper stays taxonomy-agnostic. jobID links the
+// run to its umbrella jobs row (created by the service layer before calling
+// this helper).
+func (r *AISuggestionsRepo) CreateRun(ctx context.Context, jobID, userID uuid.UUID, triggeredBy, providerType, modelID string, steering []byte) (uuid.UUID, error) {
 	const q = `
-		INSERT INTO ai_suggestion_runs (user_id, triggered_by, provider_type, model_id, status, steering)
-		VALUES ($1, $2, $3, $4, 'running', $5) RETURNING id`
+		INSERT INTO ai_suggestion_runs (job_id, user_id, triggered_by, provider_type, model_id, status, steering)
+		VALUES ($1, $2, $3, $4, $5, 'running', $6) RETURNING id`
 	var id uuid.UUID
 	var steeringArg any
 	if len(steering) > 0 {
 		steeringArg = steering
 	}
-	if err := r.db.QueryRow(ctx, q, userID, triggeredBy, providerType, modelID, steeringArg).Scan(&id); err != nil {
+	if err := r.db.QueryRow(ctx, q, jobID, userID, triggeredBy, providerType, modelID, steeringArg).Scan(&id); err != nil {
 		return uuid.Nil, fmt.Errorf("create run: %w", err)
 	}
 	return id, nil
 }
 
 // FinishRun marks a run complete (or failed) and records usage totals.
+// Mirrors the status to the umbrella jobs row so unified history queries
+// see a consistent final state.
 func (r *AISuggestionsRepo) FinishRun(ctx context.Context, runID uuid.UUID, status, errMsg string, tokensIn, tokensOut int, costUSD float64) error {
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
 	const q = `
 		UPDATE ai_suggestion_runs
 		SET status = $2, error = $3, tokens_in = $4, tokens_out = $5,
 		    estimated_cost_usd = $6, finished_at = $7
-		WHERE id = $1`
-	_, err := r.db.Exec(ctx, q, runID, status, nilIfEmpty(errMsg), tokensIn, tokensOut, costUSD, time.Now())
-	if err != nil {
+		WHERE id = $1
+		RETURNING job_id`
+	var pgJobID pgtype.UUID
+	if err := tx.QueryRow(ctx, q, runID, status, nilIfEmpty(errMsg), tokensIn, tokensOut, costUSD, time.Now()).
+		Scan(&pgJobID); err != nil {
 		return fmt.Errorf("finish run: %w", err)
 	}
-	return nil
+	if pgJobID.Valid {
+		const updJob = `
+			UPDATE jobs
+			   SET status      = $2,
+			       error       = $3,
+			       progress    = jsonb_build_object('tokens_in', $4::int, 'tokens_out', $5::int, 'cost_usd', $6::numeric),
+			       finished_at = COALESCE(finished_at, NOW())
+			 WHERE id = $1`
+		if _, err := tx.Exec(ctx, updJob, uuid.UUID(pgJobID.Bytes), status, errMsg, tokensIn, tokensOut, costUSD); err != nil {
+			return fmt.Errorf("updating umbrella job: %w", err)
+		}
+	}
+	return tx.Commit(ctx)
 }
 
 // LastRunAt returns the most recent finished/running run timestamp for a user,
@@ -698,9 +723,10 @@ func (r *AISuggestionsRepo) GetSuggestion(ctx context.Context, id, userID uuid.U
 
 // ─── Run events (observability) ───────────────────────────────────────────────
 
-// AppendEvent writes one pipeline event tied to a run. Sequence is computed
-// server-side via COALESCE(MAX(seq)+1, 0) so callers don't race each other.
-// content is marshaled to JSON; nil is stored as '{}'.
+// AppendEvent writes one pipeline event tied to a run. Routes through
+// job_events via the run's job_id — ai_run_events was collapsed into the
+// unified event log in 000010. Sequence is computed server-side so
+// concurrent callers don't race each other.
 func (r *AISuggestionsRepo) AppendEvent(ctx context.Context, runID uuid.UUID, eventType string, content any) error {
 	var payload []byte
 	if content == nil {
@@ -715,10 +741,12 @@ func (r *AISuggestionsRepo) AppendEvent(ctx context.Context, runID uuid.UUID, ev
 		payload = b
 	}
 	const q = `
-		INSERT INTO ai_run_events (run_id, seq, type, content)
-		VALUES ($1,
-		        COALESCE((SELECT MAX(seq) + 1 FROM ai_run_events WHERE run_id = $1), 0),
-		        $2, $3::jsonb)`
+		INSERT INTO job_events (job_id, seq, type, content)
+		SELECT asr.job_id,
+		       COALESCE((SELECT MAX(seq) + 1 FROM job_events WHERE job_id = asr.job_id), 0),
+		       $2, $3::jsonb
+		  FROM ai_suggestion_runs asr
+		 WHERE asr.id = $1`
 	if _, err := r.db.Exec(ctx, q, runID, eventType, payload); err != nil {
 		return fmt.Errorf("append run event: %w", err)
 	}
@@ -726,10 +754,15 @@ func (r *AISuggestionsRepo) AppendEvent(ctx context.Context, runID uuid.UUID, ev
 }
 
 // ListEventsByRun returns every event recorded for a run, ordered by seq.
+// Translates from the run id to the umbrella job_id and reads from
+// job_events.
 func (r *AISuggestionsRepo) ListEventsByRun(ctx context.Context, runID uuid.UUID) ([]*models.AIRunEvent, error) {
 	const q = `
-		SELECT id, run_id, seq, type, content, created_at
-		FROM ai_run_events WHERE run_id = $1 ORDER BY seq ASC`
+		SELECT ev.id, $1::uuid AS run_id, ev.seq, ev.type, ev.content, ev.created_at
+		  FROM job_events ev
+		  JOIN ai_suggestion_runs asr ON asr.job_id = ev.job_id
+		 WHERE asr.id = $1
+		 ORDER BY ev.seq ASC`
 	rows, err := r.db.Query(ctx, q, runID)
 	if err != nil {
 		return nil, fmt.Errorf("list run events: %w", err)

--- a/internal/repository/enrichment_batches.go
+++ b/internal/repository/enrichment_batches.go
@@ -30,18 +30,41 @@ func (r *EnrichmentBatchRepo) Create(ctx context.Context, batch *models.Enrichme
 	if err != nil {
 		return fmt.Errorf("marshaling book_ids: %w", err)
 	}
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	// Create the umbrella jobs row first so the batch row can reference it
+	// via job_id. Kind is "enrichment"; status mirrors the batch.
+	triggeredBy := "user"
+	if batch.LibraryID == nil {
+		// No library context = floating-book re-enrich from the BookDetailPage.
+		triggeredBy = "user"
+	}
+	var jobID uuid.UUID
+	if err := tx.QueryRow(ctx, `
+		INSERT INTO jobs (kind, status, triggered_by, created_by)
+		VALUES ('enrichment', $1, $2, $3)
+		RETURNING id`,
+		string(batch.Status), triggeredBy, batch.CreatedBy,
+	).Scan(&jobID); err != nil {
+		return fmt.Errorf("creating umbrella job: %w", err)
+	}
+
 	const q = `
 		INSERT INTO enrichment_batches
-		            (id, library_id, created_by, type, force, status, book_ids, total_books)
-		VALUES      ($1, $2, $3, $4, $5, $6, $7, $8)`
-	if _, err := r.db.Exec(ctx, q,
-		batch.ID, batch.LibraryID, batch.CreatedBy,
+		            (id, job_id, library_id, created_by, type, force, status, book_ids, total_books)
+		VALUES      ($1, $2, $3, $4, $5, $6, $7, $8, $9)`
+	if _, err := tx.Exec(ctx, q,
+		batch.ID, jobID, batch.LibraryID, batch.CreatedBy,
 		string(batch.Type), batch.Force, string(batch.Status),
 		bookIDsJSON, batch.TotalBooks,
 	); err != nil {
 		return fmt.Errorf("inserting enrichment batch: %w", err)
 	}
-	return nil
+	return tx.Commit(ctx)
 }
 
 // Get returns a single enrichment batch by ID (no items).
@@ -192,14 +215,33 @@ func (r *EnrichmentBatchRepo) ResyncCounters(ctx context.Context, batchID uuid.U
 	return nil
 }
 
-// UpdateStatus updates the status of a batch. Never overwrites a 'cancelled' status.
+// UpdateStatus updates the status of a batch. Never overwrites a
+// 'cancelled' status. Mirrors the change to the umbrella jobs row so the
+// unified history stays consistent, stamping started_at/finished_at when
+// transitioning into/out of running.
 func (r *EnrichmentBatchRepo) UpdateStatus(ctx context.Context, id uuid.UUID, status models.EnrichmentBatchStatus) error {
 	const q = `
 		UPDATE enrichment_batches
 		SET    status = $2, updated_at = now()
-		WHERE  id = $1 AND status != 'cancelled'`
-	if _, err := r.db.Exec(ctx, q, id, string(status)); err != nil {
+		WHERE  id = $1 AND status != 'cancelled'
+		RETURNING job_id`
+	var pgJobID pgtype.UUID
+	if err := r.db.QueryRow(ctx, q, id, string(status)).Scan(&pgJobID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil // either missing or already cancelled — caller doesn't care
+		}
 		return fmt.Errorf("updating enrichment batch status: %w", err)
+	}
+	if pgJobID.Valid {
+		const updJob = `
+			UPDATE jobs
+			   SET status      = $2,
+			       started_at  = CASE WHEN $2 = 'running' AND started_at IS NULL THEN NOW() ELSE started_at END,
+			       finished_at = CASE WHEN $2 IN ('completed','failed','cancelled') THEN COALESCE(finished_at, NOW()) ELSE finished_at END
+			 WHERE id = $1`
+		if _, err := r.db.Exec(ctx, updJob, uuid.UUID(pgJobID.Bytes), string(status)); err != nil {
+			return fmt.Errorf("mirroring status to umbrella job: %w", err)
+		}
 	}
 	return nil
 }

--- a/internal/repository/import_jobs.go
+++ b/internal/repository/import_jobs.go
@@ -37,11 +37,23 @@ func (r *ImportJobRepo) CreateJob(ctx context.Context, job *models.ImportJob, it
 	}
 	defer tx.Rollback(ctx)
 
+	// Create the umbrella jobs row first so the import row can reference it
+	// via job_id. Kind is "import"; status mirrors the import row.
+	var umbrellaID uuid.UUID
+	if err := tx.QueryRow(ctx, `
+		INSERT INTO jobs (kind, status, triggered_by, created_by)
+		VALUES ('import', $1, 'user', $2)
+		RETURNING id`,
+		string(job.Status), job.CreatedBy,
+	).Scan(&umbrellaID); err != nil {
+		return fmt.Errorf("creating umbrella job: %w", err)
+	}
+
 	const qJob = `
-		INSERT INTO import_jobs (id, library_id, created_by, status, total_rows, options)
-		VALUES ($1, $2, $3, $4, $5, $6)`
+		INSERT INTO import_jobs (id, job_id, library_id, created_by, status, total_rows, options)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)`
 	if _, err := tx.Exec(ctx, qJob,
-		job.ID, job.LibraryID, job.CreatedBy,
+		job.ID, umbrellaID, job.LibraryID, job.CreatedBy,
 		string(job.Status), job.TotalRows, optionsJSON,
 	); err != nil {
 		return fmt.Errorf("inserting import job: %w", err)
@@ -139,14 +151,36 @@ func (r *ImportJobRepo) listItems(ctx context.Context, jobID uuid.UUID) ([]model
 }
 
 // UpdateJobStatus updates the status and counters of a job.
-// It never overwrites a 'cancelled' status so a user cancel cannot be undone by the worker.
+// It never overwrites a 'cancelled' status so a user cancel cannot be
+// undone by the worker. Mirrors the status and progress counters to the
+// umbrella jobs row so unified history stays in sync.
 func (r *ImportJobRepo) UpdateJobStatus(ctx context.Context, id uuid.UUID, status models.ImportJobStatus, processed, failed, skipped int) error {
 	const q = `
 		UPDATE import_jobs
 		SET status = $2, processed_rows = $3, failed_rows = $4, skipped_rows = $5, updated_at = now()
-		WHERE id = $1 AND status != 'cancelled'`
-	if _, err := r.db.Exec(ctx, q, id, string(status), processed, failed, skipped); err != nil {
+		WHERE id = $1 AND status != 'cancelled'
+		RETURNING job_id, total_rows`
+	var (
+		pgJobID pgtype.UUID
+		total   int
+	)
+	if err := r.db.QueryRow(ctx, q, id, string(status), processed, failed, skipped).Scan(&pgJobID, &total); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil // already cancelled / missing
+		}
 		return fmt.Errorf("updating import job status: %w", err)
+	}
+	if pgJobID.Valid {
+		const updJob = `
+			UPDATE jobs
+			   SET status      = $2,
+			       progress    = jsonb_build_object('processed', $3::int, 'failed', $4::int, 'skipped', $5::int, 'total', $6::int),
+			       started_at  = CASE WHEN $2 = 'running' AND started_at IS NULL THEN NOW() ELSE started_at END,
+			       finished_at = CASE WHEN $2 IN ('completed','failed','cancelled') THEN COALESCE(finished_at, NOW()) ELSE finished_at END
+			 WHERE id = $1`
+		if _, err := r.db.Exec(ctx, updJob, uuid.UUID(pgJobID.Bytes), string(status), processed, failed, skipped, total); err != nil {
+			return fmt.Errorf("mirroring status to umbrella job: %w", err)
+		}
 	}
 	return nil
 }

--- a/internal/repository/jobs.go
+++ b/internal/repository/jobs.go
@@ -1,0 +1,436 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725 (Adaléa)
+
+package repository
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/fireball1725/librarium-api/internal/models"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// JobRepo manages the umbrella jobs/job_events/job_schedules tables.
+type JobRepo struct {
+	db *pgxpool.Pool
+}
+
+func NewJobRepo(db *pgxpool.Pool) *JobRepo {
+	return &JobRepo{db: db}
+}
+
+// ─── jobs ─────────────────────────────────────────────────────────────────────
+
+// CreateJob inserts an umbrella row for a new run and returns the filled
+// model (id, timestamps populated from the DB). Called from workers /
+// services at the start of a run, before River is told to pick it up.
+func (r *JobRepo) CreateJob(ctx context.Context, j *models.Job) error {
+	const q = `
+		INSERT INTO jobs (kind, status, triggered_by, created_by, schedule_id,
+		                  error, progress, started_at, finished_at)
+		VALUES           ($1, $2, $3, $4, $5, $6, COALESCE($7, '{}'::jsonb), $8, $9)
+		RETURNING id, created_at, updated_at`
+	progress := j.Progress
+	if len(progress) == 0 {
+		progress = json.RawMessage("{}")
+	}
+	status := j.Status
+	if status == "" {
+		status = models.JobStatusPending
+	}
+	trig := j.TriggeredBy
+	if trig == "" {
+		trig = models.JobTriggeredByUser
+	}
+	var pgID pgtype.UUID
+	if err := r.db.QueryRow(ctx, q,
+		j.Kind, string(status), string(trig),
+		nullableUUID(j.CreatedBy), nullableUUID(j.ScheduleID),
+		j.Error, progress, j.StartedAt, j.FinishedAt,
+	).Scan(&pgID, &j.CreatedAt, &j.UpdatedAt); err != nil {
+		return fmt.Errorf("inserting job: %w", err)
+	}
+	j.ID = uuid.UUID(pgID.Bytes)
+	j.Status = status
+	j.TriggeredBy = trig
+	if len(j.Progress) == 0 {
+		j.Progress = progress
+	}
+	return nil
+}
+
+// MarkRunning flips a job to running and stamps started_at if still null.
+func (r *JobRepo) MarkRunning(ctx context.Context, jobID uuid.UUID) error {
+	_, err := r.db.Exec(ctx, `
+		UPDATE jobs
+		   SET status     = 'running',
+		       started_at = COALESCE(started_at, NOW())
+		 WHERE id = $1`, jobID)
+	if err != nil {
+		return fmt.Errorf("marking job running: %w", err)
+	}
+	return nil
+}
+
+// MarkFinished flips a job to completed or failed (based on err) and
+// stamps finished_at. Errors are recorded on the row for the UI to
+// surface. Idempotent — callers that might fire it more than once (e.g.
+// panic handlers layered on a normal return) see the same final state.
+func (r *JobRepo) MarkFinished(ctx context.Context, jobID uuid.UUID, status models.JobStatus, errMsg string) error {
+	_, err := r.db.Exec(ctx, `
+		UPDATE jobs
+		   SET status      = $2,
+		       error       = $3,
+		       finished_at = COALESCE(finished_at, NOW())
+		 WHERE id = $1`, jobID, string(status), errMsg)
+	if err != nil {
+		return fmt.Errorf("marking job finished: %w", err)
+	}
+	return nil
+}
+
+// UpdateProgress replaces the progress JSON blob. Callers typically
+// read-modify-write but we don't enforce atomicity here — kind-specific
+// counter tables (import_job_items etc.) are authoritative; this is a
+// denormalised summary the UI renders without joins.
+func (r *JobRepo) UpdateProgress(ctx context.Context, jobID uuid.UUID, progress json.RawMessage) error {
+	if len(progress) == 0 {
+		progress = json.RawMessage("{}")
+	}
+	_, err := r.db.Exec(ctx, `UPDATE jobs SET progress = $2 WHERE id = $1`, jobID, progress)
+	if err != nil {
+		return fmt.Errorf("updating job progress: %w", err)
+	}
+	return nil
+}
+
+// GetJob fetches a single job by id. Returns ErrNotFound when no row.
+func (r *JobRepo) GetJob(ctx context.Context, id uuid.UUID) (*models.Job, error) {
+	const q = `
+		SELECT id, kind, status, triggered_by, created_by, schedule_id,
+		       error, progress, started_at, finished_at, created_at, updated_at
+		  FROM jobs
+		 WHERE id = $1`
+	j, err := scanJob(r.db.QueryRow(ctx, q, id))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("fetching job: %w", err)
+	}
+	return j, nil
+}
+
+// ListJobsOpts filters ListJobs. Zero-value = no filter for that field.
+type ListJobsOpts struct {
+	Kind      string      // empty = any kind
+	Status    string      // empty = any status
+	CreatedBy *uuid.UUID  // nil = any caller
+	Since     *time.Time  // nil = no time floor
+	Limit     int         // 0 = default 50
+	Offset    int
+}
+
+// ListJobs returns a paginated slice of jobs ordered newest first.
+func (r *JobRepo) ListJobs(ctx context.Context, opts ListJobsOpts) ([]*models.Job, int, error) {
+	where := []string{"1=1"}
+	args := []any{}
+	argIdx := 1
+
+	if opts.Kind != "" {
+		where = append(where, fmt.Sprintf("kind = $%d", argIdx))
+		args = append(args, opts.Kind)
+		argIdx++
+	}
+	if opts.Status != "" {
+		where = append(where, fmt.Sprintf("status = $%d", argIdx))
+		args = append(args, opts.Status)
+		argIdx++
+	}
+	if opts.CreatedBy != nil {
+		where = append(where, fmt.Sprintf("created_by = $%d", argIdx))
+		args = append(args, *opts.CreatedBy)
+		argIdx++
+	}
+	if opts.Since != nil {
+		where = append(where, fmt.Sprintf("created_at >= $%d", argIdx))
+		args = append(args, *opts.Since)
+		argIdx++
+	}
+	whereSQL := ""
+	for i, w := range where {
+		if i == 0 {
+			whereSQL = "WHERE " + w
+		} else {
+			whereSQL += " AND " + w
+		}
+	}
+
+	limit := opts.Limit
+	if limit <= 0 || limit > 500 {
+		limit = 50
+	}
+
+	var total int
+	if err := r.db.QueryRow(ctx,
+		"SELECT COUNT(*) FROM jobs "+whereSQL, args...).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("counting jobs: %w", err)
+	}
+
+	args = append(args, limit, opts.Offset)
+	q := `
+		SELECT id, kind, status, triggered_by, created_by, schedule_id,
+		       error, progress, started_at, finished_at, created_at, updated_at
+		  FROM jobs ` + whereSQL + fmt.Sprintf(`
+		 ORDER BY created_at DESC
+		 LIMIT $%d OFFSET $%d`, argIdx, argIdx+1)
+
+	rows, err := r.db.Query(ctx, q, args...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("listing jobs: %w", err)
+	}
+	defer rows.Close()
+
+	var out []*models.Job
+	for rows.Next() {
+		j, err := scanJob(rows)
+		if err != nil {
+			return nil, 0, err
+		}
+		out = append(out, j)
+	}
+	return out, total, rows.Err()
+}
+
+// DeleteJob removes a job and cascades through kind-specific tables +
+// job_events via ON DELETE CASCADE.
+func (r *JobRepo) DeleteJob(ctx context.Context, id uuid.UUID) error {
+	tag, err := r.db.Exec(ctx, `DELETE FROM jobs WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("deleting job: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// DeleteFinished hard-deletes every job row in a terminal state
+// (completed/failed/cancelled). Used by the "Clear history" admin action.
+// Returns the deleted count.
+func (r *JobRepo) DeleteFinished(ctx context.Context, kind string) (int64, error) {
+	where := "status IN ('completed','failed','cancelled')"
+	args := []any{}
+	if kind != "" {
+		where += " AND kind = $1"
+		args = append(args, kind)
+	}
+	tag, err := r.db.Exec(ctx, "DELETE FROM jobs WHERE "+where, args...)
+	if err != nil {
+		return 0, fmt.Errorf("deleting finished jobs: %w", err)
+	}
+	return tag.RowsAffected(), nil
+}
+
+// ─── job_events ───────────────────────────────────────────────────────────────
+
+// AppendEvent writes one pipeline event tied to a job. Sequence is
+// computed server-side via COALESCE(MAX(seq)+1, 0) so concurrent callers
+// don't race each other. Content is JSON-encoded server-side when passed
+// as any; pre-marshaled bytes are used as-is.
+func (r *JobRepo) AppendEvent(ctx context.Context, jobID uuid.UUID, eventType string, content any) error {
+	var payload []byte
+	switch v := content.(type) {
+	case nil:
+		payload = []byte("{}")
+	case []byte:
+		payload = v
+	case json.RawMessage:
+		payload = v
+	default:
+		b, err := json.Marshal(content)
+		if err != nil {
+			return fmt.Errorf("marshal event content: %w", err)
+		}
+		payload = b
+	}
+	const q = `
+		INSERT INTO job_events (job_id, seq, type, content)
+		VALUES ($1, COALESCE((SELECT MAX(seq)+1 FROM job_events WHERE job_id = $1), 0), $2, $3)`
+	if _, err := r.db.Exec(ctx, q, jobID, eventType, payload); err != nil {
+		return fmt.Errorf("inserting job event: %w", err)
+	}
+	return nil
+}
+
+// ListEvents returns every event for a job in sequence order.
+func (r *JobRepo) ListEvents(ctx context.Context, jobID uuid.UUID) ([]*models.JobEvent, error) {
+	const q = `
+		SELECT id, job_id, seq, type, content, created_at
+		  FROM job_events
+		 WHERE job_id = $1
+		 ORDER BY seq ASC`
+	rows, err := r.db.Query(ctx, q, jobID)
+	if err != nil {
+		return nil, fmt.Errorf("listing job events: %w", err)
+	}
+	defer rows.Close()
+
+	var out []*models.JobEvent
+	for rows.Next() {
+		var (
+			pgID    pgtype.UUID
+			pgJobID pgtype.UUID
+			e       models.JobEvent
+		)
+		if err := rows.Scan(&pgID, &pgJobID, &e.Seq, &e.Type, &e.Content, &e.CreatedAt); err != nil {
+			return nil, err
+		}
+		e.ID = uuid.UUID(pgID.Bytes)
+		e.JobID = uuid.UUID(pgJobID.Bytes)
+		out = append(out, &e)
+	}
+	return out, rows.Err()
+}
+
+// ─── job_schedules ────────────────────────────────────────────────────────────
+
+// GetSchedule returns the schedule row for a kind, or ErrNotFound.
+func (r *JobRepo) GetSchedule(ctx context.Context, kind string) (*models.JobSchedule, error) {
+	const q = `
+		SELECT id, kind, cron, enabled, config, last_fired_at, created_at, updated_at
+		  FROM job_schedules
+		 WHERE kind = $1`
+	s, err := scanSchedule(r.db.QueryRow(ctx, q, kind))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("fetching schedule: %w", err)
+	}
+	return s, nil
+}
+
+// ListSchedules returns every schedule row, ordered by kind.
+func (r *JobRepo) ListSchedules(ctx context.Context) ([]*models.JobSchedule, error) {
+	const q = `
+		SELECT id, kind, cron, enabled, config, last_fired_at, created_at, updated_at
+		  FROM job_schedules
+		 ORDER BY kind`
+	rows, err := r.db.Query(ctx, q)
+	if err != nil {
+		return nil, fmt.Errorf("listing schedules: %w", err)
+	}
+	defer rows.Close()
+	var out []*models.JobSchedule
+	for rows.Next() {
+		s, err := scanSchedule(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, s)
+	}
+	return out, rows.Err()
+}
+
+// UpsertSchedule creates or updates the schedule for a kind.
+func (r *JobRepo) UpsertSchedule(ctx context.Context, s *models.JobSchedule) error {
+	config := s.Config
+	if len(config) == 0 {
+		config = json.RawMessage("{}")
+	}
+	const q = `
+		INSERT INTO job_schedules (kind, cron, enabled, config)
+		VALUES ($1, $2, $3, $4)
+		ON CONFLICT (kind) DO UPDATE
+		   SET cron    = EXCLUDED.cron,
+		       enabled = EXCLUDED.enabled,
+		       config  = EXCLUDED.config,
+		       updated_at = NOW()
+		RETURNING id, created_at, updated_at`
+	var pgID pgtype.UUID
+	if err := r.db.QueryRow(ctx, q, s.Kind, s.Cron, s.Enabled, config).
+		Scan(&pgID, &s.CreatedAt, &s.UpdatedAt); err != nil {
+		return fmt.Errorf("upserting schedule: %w", err)
+	}
+	s.ID = uuid.UUID(pgID.Bytes)
+	return nil
+}
+
+// MarkScheduleFired stamps last_fired_at = NOW() on a schedule. Used by
+// the scheduler loop after it enqueues a run so the next tick doesn't
+// immediately re-fire.
+func (r *JobRepo) MarkScheduleFired(ctx context.Context, id uuid.UUID) error {
+	_, err := r.db.Exec(ctx, `UPDATE job_schedules SET last_fired_at = NOW() WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("marking schedule fired: %w", err)
+	}
+	return nil
+}
+
+// ─── scanners ─────────────────────────────────────────────────────────────────
+
+func scanJob(s scanner) (*models.Job, error) {
+	var (
+		pgID         pgtype.UUID
+		pgCreatedBy  pgtype.UUID
+		pgScheduleID pgtype.UUID
+		status       string
+		triggeredBy  string
+		progress     []byte
+		j            models.Job
+	)
+	if err := s.Scan(
+		&pgID, &j.Kind, &status, &triggeredBy, &pgCreatedBy, &pgScheduleID,
+		&j.Error, &progress, &j.StartedAt, &j.FinishedAt, &j.CreatedAt, &j.UpdatedAt,
+	); err != nil {
+		return nil, err
+	}
+	j.ID = uuid.UUID(pgID.Bytes)
+	j.Status = models.JobStatus(status)
+	j.TriggeredBy = models.JobTriggeredBy(triggeredBy)
+	if pgCreatedBy.Valid {
+		id := uuid.UUID(pgCreatedBy.Bytes)
+		j.CreatedBy = &id
+	}
+	if pgScheduleID.Valid {
+		id := uuid.UUID(pgScheduleID.Bytes)
+		j.ScheduleID = &id
+	}
+	j.Progress = progress
+	return &j, nil
+}
+
+func scanSchedule(s scanner) (*models.JobSchedule, error) {
+	var (
+		pgID    pgtype.UUID
+		config  []byte
+		sched   models.JobSchedule
+	)
+	if err := s.Scan(
+		&pgID, &sched.Kind, &sched.Cron, &sched.Enabled, &config,
+		&sched.LastFiredAt, &sched.CreatedAt, &sched.UpdatedAt,
+	); err != nil {
+		return nil, err
+	}
+	sched.ID = uuid.UUID(pgID.Bytes)
+	sched.Config = config
+	return &sched, nil
+}
+
+// nullableUUID is a small helper — pgx accepts *uuid.UUID natively but
+// a pgtype.UUID with Valid=false is clearer at the call site when the
+// caller already has a *uuid.UUID in hand.
+func nullableUUID(id *uuid.UUID) any {
+	if id == nil {
+		return nil
+	}
+	return *id
+}

--- a/internal/service/ai_suggestions.go
+++ b/internal/service/ai_suggestions.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/fireball1725/librarium-api/internal/ai"
+	"github.com/fireball1725/librarium-api/internal/jobs"
 	"github.com/fireball1725/librarium-api/internal/models"
 	"github.com/fireball1725/librarium-api/internal/providers"
 	"github.com/fireball1725/librarium-api/internal/repository"
@@ -53,6 +54,7 @@ const (
 // providers, backfill if buy candidates fell short, persist the batch.
 type SuggestionsService struct {
 	repo       *repository.AISuggestionsRepo
+	jobRepo    *repository.JobRepo
 	books      *repository.BookRepo
 	editions   *repository.EditionRepo
 	bookSvc    *BookService
@@ -67,6 +69,7 @@ type SuggestionsService struct {
 func NewSuggestionsService(
 	pool *pgxpool.Pool,
 	repo *repository.AISuggestionsRepo,
+	jobRepo *repository.JobRepo,
 	books *repository.BookRepo,
 	editions *repository.EditionRepo,
 	bookSvc *BookService,
@@ -79,6 +82,7 @@ func NewSuggestionsService(
 	return &SuggestionsService{
 		pool:       pool,
 		repo:       repo,
+		jobRepo:    jobRepo,
 		books:      books,
 		editions:   editions,
 		bookSvc:    bookSvc,
@@ -210,13 +214,27 @@ func (s *SuggestionsService) RunForUser(ctx context.Context, userID uuid.UUID, t
 	prompt := buildSuggestionsPrompt(titles, user.TasteProfile, blocks, perms, cfg, existingBuy, existingReadNext, hydrated)
 
 	// ── Record run starting ──────────────────────────────────────────────────
-	// Stamping the configured model on the run row (and pipeline_start event)
-	// lets the admin read the timeline later and see which model produced the
-	// output — useful when comparing Ollama model choices or spotting a silent
-	// config drift.
+	// Two-step creation — first an umbrella jobs row, then the
+	// kind-specific ai_suggestion_runs row that references it. Stamping the
+	// configured model on the run row (and pipeline_start event) lets the
+	// admin read the timeline later and see which model produced the output.
 	modelID := provider.ConfiguredModel()
-	runID, err := s.repo.CreateRun(ctx, userID, triggeredBy, info.Name, modelID, steeringJSON)
+	job := &models.Job{
+		Kind:        string(jobs.KindAISuggestions),
+		Status:      models.JobStatusRunning,
+		TriggeredBy: models.JobTriggeredBy(triggeredBy),
+		CreatedBy:   &userID,
+	}
+	now := time.Now()
+	job.StartedAt = &now
+	if err := s.jobRepo.CreateJob(ctx, job); err != nil {
+		return nil, fmt.Errorf("create umbrella job: %w", err)
+	}
+	runID, err := s.repo.CreateRun(ctx, job.ID, userID, triggeredBy, info.Name, modelID, steeringJSON)
 	if err != nil {
+		// umbrella row exists but kind-specific row failed; mark umbrella
+		// as failed so it shows up in history with the right state.
+		_ = s.jobRepo.MarkFinished(ctx, job.ID, models.JobStatusFailed, err.Error())
 		return nil, err
 	}
 	start := time.Now()


### PR DESCRIPTION
PR 1 of 2 for plans/jobs-framework.md. Lays down the umbrella schema (\`jobs\`, \`job_events\`, \`job_schedules\`) via migration 000010 and the Go-side plumbing — Registry + Definition, JobRepo, a robfig/cron-based scheduler, unified admin endpoints. Legacy per-kind routes still serve the current Jobs page.

PR 2 will rewrite the web JobsPage on the new endpoints, add a react-js-cron editor, and land the cover-backfill scheduled job as the first kind shipped through the framework.