### PR TITLE
feat(jobs): cover-backfill kind + schedule seeding (PR 2)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -256,17 +256,28 @@ func main() {
 				return fmt.Errorf("list opted-in users: %w", err)
 			}
 			cutoff := time.Now().Add(-time.Duration(cfg.IntervalMinutes) * time.Minute)
+			triggeredBy := string(trig.TriggeredBy)
+			if triggeredBy == "" {
+				triggeredBy = "scheduler"
+			}
+			// Admin-triggered Run Now is an explicit request — bypass the
+			// per-user cadence cooldown so a user whose last run is still
+			// inside the window still gets enqueued. The cooldown exists
+			// to keep the scheduler tick from re-running the same users.
+			bypassCooldown := triggeredBy == string(models.JobTriggeredByAdmin)
 			for _, u := range users {
-				last, err := aiSuggestionsRepo.LastRunAt(ctx, u.UserID)
-				if err != nil {
-					slog.Warn("ai scheduler: last-run lookup failed", "user_id", u.UserID, "error", err)
-					continue
-				}
-				if !last.IsZero() && last.After(cutoff) {
-					continue
+				if !bypassCooldown {
+					last, err := aiSuggestionsRepo.LastRunAt(ctx, u.UserID)
+					if err != nil {
+						slog.Warn("ai scheduler: last-run lookup failed", "user_id", u.UserID, "error", err)
+						continue
+					}
+					if !last.IsZero() && last.After(cutoff) {
+						continue
+					}
 				}
 				if _, err := riverClient.Insert(ctx,
-					models.AISuggestionsJobArgs{UserID: u.UserID, TriggeredBy: "scheduler"}, nil); err != nil {
+					models.AISuggestionsJobArgs{UserID: u.UserID, TriggeredBy: triggeredBy}, nil); err != nil {
 					slog.Warn("ai scheduler: enqueue failed", "user_id", u.UserID, "error", err)
 				}
 			}
@@ -302,14 +313,43 @@ func main() {
 		Schedulable: true,
 		DefaultCron: "0 3 * * *",
 		Enqueue: func(ctx context.Context, trig jobs.TriggerCtx, _ json.RawMessage) error {
+			// Pick an owner for the enrichment batches. Admin Run-Now sets
+			// trig.CreatedBy; cron-triggered runs don't, so we fall back
+			// to the first instance admin (the enrichment_batches.created_by
+			// column is NOT NULL today — relaxing that is a separate
+			// change).
+			owner := uuid.Nil
+			if trig.CreatedBy != nil {
+				owner = *trig.CreatedBy
+			} else {
+				if err := pool.QueryRow(ctx,
+					`SELECT id FROM users WHERE is_instance_admin = true ORDER BY created_at LIMIT 1`,
+				).Scan(&owner); err != nil {
+					slog.Warn("cover backfill: no admin user to attribute to", "error", err)
+					return err
+				}
+			}
 			ids, err := coverBookRepo.ListBooksMissingCover(ctx, 1000)
 			if err != nil {
 				return fmt.Errorf("list books missing cover: %w", err)
+			}
+			// Stamp the parent umbrella with the total book count so history
+			// shows a real number instead of an empty progress blob. The
+			// parent job's "work" is enumerate + dispatch, so we count it
+			// as processed once the enqueue loop completes successfully.
+			if progressJSON, perr := json.Marshal(map[string]any{
+				"processed": len(ids),
+				"total":     len(ids),
+			}); perr == nil {
+				_ = jobRepo.UpdateProgress(ctx, trig.JobID, progressJSON)
 			}
 			if len(ids) == 0 {
 				slog.Info("cover backfill: no books missing covers")
 				return nil
 			}
+			// Bulk-lookup titles once up-front so each item row carries a
+			// human-readable label, matching the manual "Search covers" path.
+			titles, _ := coverBookRepo.TitlesByIDs(ctx, ids)
 			for i := 0; i < len(ids); i += coverBackfillChunk {
 				end := i + coverBackfillChunk
 				if end > len(ids) {
@@ -319,7 +359,7 @@ func main() {
 				batch := &models.EnrichmentBatch{
 					ID:         uuid.New(),
 					LibraryID:  nil, // catalog-wide — not scoped to a library
-					CreatedBy:  uuid.Nil,
+					CreatedBy:  owner,
 					Type:       models.EnrichmentBatchTypeCover,
 					Force:      false,
 					Status:     models.EnrichmentBatchPending,
@@ -334,10 +374,11 @@ func main() {
 				for _, id := range chunk {
 					bookID := id
 					items = append(items, models.EnrichmentBatchItem{
-						ID:      uuid.New(),
-						BatchID: batch.ID,
-						BookID:  &bookID,
-						Status:  models.EnrichmentItemPending,
+						ID:        uuid.New(),
+						BatchID:   batch.ID,
+						BookID:    &bookID,
+						BookTitle: titles[bookID],
+						Status:    models.EnrichmentItemPending,
 					})
 				}
 				if err := coverEnrichmentRepo.CreateItems(ctx, items); err != nil {

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -51,6 +51,7 @@ import (
 	"github.com/fireball1725/librarium-api/internal/tui"
 	"github.com/fireball1725/librarium-api/internal/version"
 	"github.com/fireball1725/librarium-api/internal/workers"
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/riverqueue/river"
@@ -286,9 +287,99 @@ func main() {
 		Description: "Fetches missing metadata / covers from providers for a batch of books.",
 		Schedulable: false,
 	})
+	// Cover backfill — first scheduled kind shipped through the unified
+	// framework. Walks the catalog for books with no primary cover and
+	// queues cover-only enrichment batches for them, chunked to avoid
+	// one giant job. Non-fatal per-chunk — a single failing ISBN lookup
+	// shouldn't stall the sweep.
+	const coverBackfillChunk = 50
+	coverBookRepo := repository.NewBookRepo(pool)
+	coverEnrichmentRepo := repository.NewEnrichmentBatchRepo(pool)
+	jobRegistry.Register(&jobs.Definition{
+		Kind:        jobs.KindCoverBackfill,
+		DisplayName: "Cover backfill",
+		Description: "Finds books without a cover image and queues cover-only metadata enrichment for them.",
+		Schedulable: true,
+		DefaultCron: "0 3 * * *",
+		Enqueue: func(ctx context.Context, trig jobs.TriggerCtx, _ json.RawMessage) error {
+			ids, err := coverBookRepo.ListBooksMissingCover(ctx, 1000)
+			if err != nil {
+				return fmt.Errorf("list books missing cover: %w", err)
+			}
+			if len(ids) == 0 {
+				slog.Info("cover backfill: no books missing covers")
+				return nil
+			}
+			for i := 0; i < len(ids); i += coverBackfillChunk {
+				end := i + coverBackfillChunk
+				if end > len(ids) {
+					end = len(ids)
+				}
+				chunk := ids[i:end]
+				batch := &models.EnrichmentBatch{
+					ID:         uuid.New(),
+					LibraryID:  nil, // catalog-wide — not scoped to a library
+					CreatedBy:  uuid.Nil,
+					Type:       models.EnrichmentBatchTypeCover,
+					Force:      false,
+					Status:     models.EnrichmentBatchPending,
+					BookIDs:    chunk,
+					TotalBooks: len(chunk),
+				}
+				if err := coverEnrichmentRepo.Create(ctx, batch); err != nil {
+					slog.Warn("cover backfill: creating batch failed", "error", err)
+					continue
+				}
+				items := make([]models.EnrichmentBatchItem, 0, len(chunk))
+				for _, id := range chunk {
+					bookID := id
+					items = append(items, models.EnrichmentBatchItem{
+						ID:      uuid.New(),
+						BatchID: batch.ID,
+						BookID:  &bookID,
+						Status:  models.EnrichmentItemPending,
+					})
+				}
+				if err := coverEnrichmentRepo.CreateItems(ctx, items); err != nil {
+					slog.Warn("cover backfill: creating items failed", "batch_id", batch.ID, "error", err)
+					continue
+				}
+				if _, err := riverClient.Insert(ctx,
+					models.EnrichmentBatchJobArgs{BatchID: batch.ID}, nil); err != nil {
+					slog.Warn("cover backfill: enqueue failed", "batch_id", batch.ID, "error", err)
+				}
+			}
+			slog.Info("cover backfill: enqueued", "books", len(ids))
+			return nil
+		},
+	})
 
 	// Kick the scheduler off after registry is populated.
 	jobRepoForSched := repository.NewJobRepo(pool)
+	// Seed default schedule rows for any schedulable kind that doesn't
+	// have one yet. Ensures new kinds (e.g. cover_backfill) show up in
+	// the admin UI on first boot after upgrade without a custom
+	// migration per kind — the Definition itself carries the default
+	// cron, and the seed is idempotent via the kind UNIQUE constraint.
+	for _, def := range jobRegistry.All() {
+		if !def.Schedulable {
+			continue
+		}
+		if _, err := jobRepoForSched.GetSchedule(baseCtx, string(def.Kind)); err == nil {
+			continue // already there
+		}
+		cron := def.DefaultCron
+		if cron == "" {
+			cron = "0 3 * * *"
+		}
+		if err := jobRepoForSched.UpsertSchedule(baseCtx, &models.JobSchedule{
+			Kind:    string(def.Kind),
+			Cron:    cron,
+			Enabled: false, // admin flips this on from the UI
+		}); err != nil {
+			slog.Warn("seeding schedule failed", "kind", def.Kind, "error", err)
+		}
+	}
 	scheduler := jobs.NewScheduler(jobRegistry, jobRepoForSched)
 	go scheduler.Run(baseCtx)
 

--- a/internal/api/handlers/ai_suggestions.go
+++ b/internal/api/handlers/ai_suggestions.go
@@ -512,6 +512,7 @@ type RunView struct {
 	TokensIn         int           `json:"tokens_in"`
 	TokensOut        int           `json:"tokens_out"`
 	EstimatedCostUSD float64       `json:"estimated_cost_usd"`
+	SuggestionCount  int           `json:"suggestion_count"`
 	StartedAt        string        `json:"started_at"`
 	FinishedAt       string        `json:"finished_at,omitempty"`
 	Steering         *SteeringView `json:"steering,omitempty"`
@@ -558,6 +559,7 @@ func runToView(r *models.AISuggestionRun, includeUser bool) RunView {
 		TokensIn:         r.TokensIn,
 		TokensOut:        r.TokensOut,
 		EstimatedCostUSD: r.EstimatedCostUSD,
+		SuggestionCount:  r.SuggestionCount,
 		StartedAt:        r.StartedAt.Format("2006-01-02T15:04:05Z07:00"),
 	}
 	if includeUser {
@@ -798,7 +800,9 @@ func (h *AISuggestionsHandler) AdminGetRun(w http.ResponseWriter, r *http.Reques
 		respond.ServerError(w, r, err)
 		return
 	}
-	events, err := h.repo.ListEventsByRun(r.Context(), id)
+	// Events filter by the real run id — the path id may have been an
+	// umbrella job id (resolved by GetRun above).
+	events, err := h.repo.ListEventsByRun(r.Context(), run.ID)
 	if err != nil {
 		respond.ServerError(w, r, err)
 		return

--- a/internal/api/handlers/jobs_admin.go
+++ b/internal/api/handlers/jobs_admin.go
@@ -15,7 +15,13 @@ import (
 	"github.com/fireball1725/librarium-api/internal/models"
 	"github.com/fireball1725/librarium-api/internal/repository"
 	"github.com/google/uuid"
+	"github.com/robfig/cron/v3"
 )
+
+// cronParser parses the standard 5-field expressions the UI emits. Kept
+// package-level so repeated calls don't reallocate; Parse itself is
+// stateless so this is safe to reuse.
+var cronParser = cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
 
 // UnifiedJobsHandler backs the /admin/jobs/history surface — one entry
 // point that returns every kind of job in one shape. Kind-specific
@@ -212,6 +218,10 @@ func (h *UnifiedJobsHandler) DeleteHistory(w http.ResponseWriter, r *http.Reques
 // ─── Schedules ───────────────────────────────────────────────────────────────
 
 // ScheduleView is a job_schedules row enriched with registry display info.
+// next_fire_at is computed server-side from the cron expression + the
+// schedule row's last_fired_at (or created_at when never fired). The UI
+// uses it to render a live countdown and sort; keeping the calculation
+// server-side avoids cross-timezone weirdness on the client.
 type ScheduleView struct {
 	ID          string          `json:"id"`
 	Kind        string          `json:"kind"`
@@ -221,6 +231,7 @@ type ScheduleView struct {
 	Enabled     bool            `json:"enabled"`
 	Config      json.RawMessage `json:"config"`
 	LastFiredAt *time.Time      `json:"last_fired_at,omitempty"`
+	NextFireAt  *time.Time      `json:"next_fire_at,omitempty"`
 }
 
 // ListSchedules godoc
@@ -256,9 +267,39 @@ func (h *UnifiedJobsHandler) ListSchedules(w http.ResponseWriter, r *http.Reques
 		if len(v.Config) == 0 {
 			v.Config = json.RawMessage("{}")
 		}
+		// Compute next fire only for enabled schedules — a disabled row
+		// has no meaningful "next run" and the UI can render a dash.
+		if s.Enabled {
+			if t, ok := computeNextFire(s); ok {
+				v.NextFireAt = &t
+			}
+		}
 		out = append(out, v)
 	}
 	respond.JSON(w, http.StatusOK, out)
+}
+
+// computeNextFire parses the schedule's cron expression and returns the
+// next scheduled fire time based on last_fired_at (or created_at when
+// the schedule has never fired). Mirrors the scheduler's own logic so
+// the UI sees the same next-run the scheduler will actually use.
+func computeNextFire(s *models.JobSchedule) (time.Time, bool) {
+	sched, err := cronParser.Parse(s.Cron)
+	if err != nil {
+		return time.Time{}, false
+	}
+	prev := s.CreatedAt
+	if s.LastFiredAt != nil {
+		prev = *s.LastFiredAt
+	}
+	next := sched.Next(prev)
+	// If the computed next is already in the past (admin re-enabled a
+	// schedule whose last fire was long ago), roll forward to the next
+	// fire from "now".
+	if next.Before(time.Now()) {
+		next = sched.Next(time.Now())
+	}
+	return next, true
 }
 
 // UpdateSchedule godoc

--- a/internal/api/handlers/jobs_admin.go
+++ b/internal/api/handlers/jobs_admin.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/fireball1725/librarium-api/internal/api/middleware"
 	"github.com/fireball1725/librarium-api/internal/api/respond"
 	"github.com/fireball1725/librarium-api/internal/jobs"
 	"github.com/fireball1725/librarium-api/internal/models"
@@ -300,6 +301,71 @@ func computeNextFire(s *models.JobSchedule) (time.Time, bool) {
 		next = sched.Next(time.Now())
 	}
 	return next, true
+}
+
+// RunNow godoc
+//
+//	@Summary     Run a scheduled job once, now
+//	@Description Fires the kind's Enqueue hook immediately, bypassing the
+//	@Description cron. Creates an umbrella jobs row with triggered_by=admin
+//	@Description so the run shows up in history as admin-triggered.
+//	@Tags        admin,jobs
+//	@Security    BearerAuth
+//	@Param       kind  path  string  true  "job kind"
+//	@Success     202   {object}  handlers.JobView
+//	@Failure     400   {object}  object{error=string}
+//	@Failure     404   {object}  object{error=string}
+//	@Router      /admin/jobs/schedules/{kind}/run [post]
+func (h *UnifiedJobsHandler) RunNow(w http.ResponseWriter, r *http.Request) {
+	kind := r.PathValue("kind")
+	if kind == "" {
+		respond.Error(w, http.StatusBadRequest, "missing kind")
+		return
+	}
+	def := h.registry.Get(jobs.Kind(kind))
+	if def == nil {
+		respond.Error(w, http.StatusNotFound, "unknown job kind")
+		return
+	}
+	if def.Enqueue == nil {
+		respond.Error(w, http.StatusBadRequest, "this kind doesn't support manual run")
+		return
+	}
+	// Look up the schedule's config (if any) — admin-run uses whatever
+	// the kind has stored. Missing schedule = empty config.
+	var cfg json.RawMessage = json.RawMessage("{}")
+	if s, err := h.jobs.GetSchedule(r.Context(), kind); err == nil && s != nil {
+		if len(s.Config) > 0 {
+			cfg = s.Config
+		}
+	}
+
+	now := time.Now()
+	j := &models.Job{
+		Kind:        kind,
+		Status:      models.JobStatusRunning,
+		TriggeredBy: models.JobTriggeredByAdmin,
+		StartedAt:   &now,
+	}
+	if claims := middleware.ClaimsFromContext(r.Context()); claims != nil {
+		uid := claims.UserID
+		j.CreatedBy = &uid
+	}
+	if err := h.jobs.CreateJob(r.Context(), j); err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
+	if err := def.Enqueue(r.Context(), jobs.TriggerCtx{
+		JobID:       j.ID,
+		TriggeredBy: models.JobTriggeredByAdmin,
+		CreatedBy:   j.CreatedBy,
+	}, cfg); err != nil {
+		_ = h.jobs.MarkFinished(r.Context(), j.ID, models.JobStatusFailed, err.Error())
+		respond.ServerError(w, r, err)
+		return
+	}
+	_ = h.jobs.MarkFinished(r.Context(), j.ID, models.JobStatusCompleted, "")
+	respond.JSON(w, http.StatusAccepted, toJobView(j))
 }
 
 // UpdateSchedule godoc

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -211,6 +211,7 @@ func NewRouter(ctx context.Context, db *pgxpool.Pool, cfg *config.Config, riverC
 	mux.Handle("DELETE /api/v1/admin/jobs/history", requireAdmin(http.HandlerFunc(unifiedJobsHandler.DeleteHistory)))
 	mux.Handle("GET /api/v1/admin/jobs/schedules", requireAdmin(http.HandlerFunc(unifiedJobsHandler.ListSchedules)))
 	mux.Handle("PUT /api/v1/admin/jobs/schedules/{kind}", requireAdmin(http.HandlerFunc(unifiedJobsHandler.UpdateSchedule)))
+	mux.Handle("POST /api/v1/admin/jobs/schedules/{kind}/run", requireAdmin(http.HandlerFunc(unifiedJobsHandler.RunNow)))
 	mux.Handle("GET /api/v1/admin/jobs/{id}", requireAdmin(http.HandlerFunc(unifiedJobsHandler.Detail)))
 	mux.Handle("DELETE /api/v1/admin/jobs/{id}", requireAdmin(http.HandlerFunc(unifiedJobsHandler.Delete)))
 	mux.Handle("GET /api/v1/admin/jobs/ai-suggestions", requireAdmin(http.HandlerFunc(jobsHandler.GetAISuggestionsJob)))

--- a/internal/jobs/registry.go
+++ b/internal/jobs/registry.go
@@ -28,6 +28,7 @@ const (
 	KindImport         Kind = "import"
 	KindEnrichment     Kind = "enrichment"
 	KindAISuggestions  Kind = "ai_suggestions"
+	KindCoverBackfill  Kind = "cover_backfill"
 )
 
 // TriggerCtx is everything the Enqueue hook of a Definition needs

--- a/internal/models/ai_suggestion.go
+++ b/internal/models/ai_suggestion.go
@@ -53,6 +53,10 @@ type AISuggestionRun struct {
 	// runs. Handlers decode into SuggestionSteering and hydrate the IDs to
 	// display names on the way out.
 	Steering json.RawMessage
+	// SuggestionCount is the number of ai_suggestions rows still linked to
+	// this run (FK is SET NULL on clear, so this drops to 0 once the admin
+	// wipes the pipeline log). Populated by list queries, zero otherwise.
+	SuggestionCount int
 }
 
 // AISuggestion is one rendered recommendation — either a book to buy (not in

--- a/internal/repository/ai_suggestions.go
+++ b/internal/repository/ai_suggestions.go
@@ -779,19 +779,24 @@ func (r *AISuggestionsRepo) ListEventsByRun(ctx context.Context, runID uuid.UUID
 	return out, rows.Err()
 }
 
-// GetRun fetches a single run row by ID. Returns ErrNotFound when missing.
-// Callers that need per-user scoping should check UserID after fetching.
+// GetRun fetches a single run row by its own ID or the umbrella jobs row
+// id it hangs off of. The unified history endpoint returns umbrella ids,
+// so accepting both lets the web expand a row without an extra lookup.
+// Returns ErrNotFound when missing. Callers that need per-user scoping
+// should check UserID after fetching.
 func (r *AISuggestionsRepo) GetRun(ctx context.Context, runID uuid.UUID) (*models.AISuggestionRun, error) {
 	const q = `
-		SELECT id, user_id, triggered_by, provider_type, model_id, status,
-		       COALESCE(error,''), tokens_in, tokens_out, estimated_cost_usd,
-		       started_at, finished_at, steering
-		FROM ai_suggestion_runs WHERE id = $1`
+		SELECT r.id, r.user_id, r.triggered_by, r.provider_type, r.model_id, r.status,
+		       COALESCE(r.error,''), r.tokens_in, r.tokens_out, r.estimated_cost_usd,
+		       r.started_at, r.finished_at, r.steering,
+		       (SELECT COUNT(*) FROM ai_suggestions s WHERE s.run_id = r.id)
+		FROM ai_suggestion_runs r WHERE r.id = $1 OR r.job_id = $1
+		LIMIT 1`
 	run := &models.AISuggestionRun{}
 	err := r.db.QueryRow(ctx, q, runID).Scan(
 		&run.ID, &run.UserID, &run.TriggeredBy, &run.ProviderType, &run.ModelID,
 		&run.Status, &run.Error, &run.TokensIn, &run.TokensOut, &run.EstimatedCostUSD,
-		&run.StartedAt, &run.FinishedAt, &run.Steering,
+		&run.StartedAt, &run.FinishedAt, &run.Steering, &run.SuggestionCount,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, ErrNotFound
@@ -803,16 +808,19 @@ func (r *AISuggestionsRepo) GetRun(ctx context.Context, runID uuid.UUID) (*model
 }
 
 // ListRunsByUser returns the caller's most recent suggestion runs, newest first.
+// Each row includes a count of suggestions still linked to it (the FK SET-NULLs
+// when an admin clears history, so this can drop to 0 even for a successful run).
 func (r *AISuggestionsRepo) ListRunsByUser(ctx context.Context, userID uuid.UUID, limit int) ([]*models.AISuggestionRun, error) {
 	if limit <= 0 {
 		limit = 25
 	}
 	const q = `
-		SELECT id, user_id, triggered_by, provider_type, model_id, status,
-		       COALESCE(error,''), tokens_in, tokens_out, estimated_cost_usd,
-		       started_at, finished_at, steering
-		FROM ai_suggestion_runs WHERE user_id = $1
-		ORDER BY started_at DESC LIMIT $2`
+		SELECT r.id, r.user_id, r.triggered_by, r.provider_type, r.model_id, r.status,
+		       COALESCE(r.error,''), r.tokens_in, r.tokens_out, r.estimated_cost_usd,
+		       r.started_at, r.finished_at, r.steering,
+		       (SELECT COUNT(*) FROM ai_suggestions s WHERE s.run_id = r.id)
+		FROM ai_suggestion_runs r WHERE r.user_id = $1
+		ORDER BY r.started_at DESC LIMIT $2`
 	return scanRuns(r.db.Query(ctx, q, userID, limit))
 }
 
@@ -823,11 +831,12 @@ func (r *AISuggestionsRepo) ListRecentRuns(ctx context.Context, limit int) ([]*m
 		limit = 50
 	}
 	const q = `
-		SELECT id, user_id, triggered_by, provider_type, model_id, status,
-		       COALESCE(error,''), tokens_in, tokens_out, estimated_cost_usd,
-		       started_at, finished_at, steering
-		FROM ai_suggestion_runs
-		ORDER BY started_at DESC LIMIT $1`
+		SELECT r.id, r.user_id, r.triggered_by, r.provider_type, r.model_id, r.status,
+		       COALESCE(r.error,''), r.tokens_in, r.tokens_out, r.estimated_cost_usd,
+		       r.started_at, r.finished_at, r.steering,
+		       (SELECT COUNT(*) FROM ai_suggestions s WHERE s.run_id = r.id)
+		FROM ai_suggestion_runs r
+		ORDER BY r.started_at DESC LIMIT $1`
 	return scanRuns(r.db.Query(ctx, q, limit))
 }
 
@@ -842,7 +851,7 @@ func scanRuns(rows pgx.Rows, err error) ([]*models.AISuggestionRun, error) {
 		if err := rows.Scan(
 			&run.ID, &run.UserID, &run.TriggeredBy, &run.ProviderType, &run.ModelID,
 			&run.Status, &run.Error, &run.TokensIn, &run.TokensOut, &run.EstimatedCostUSD,
-			&run.StartedAt, &run.FinishedAt, &run.Steering,
+			&run.StartedAt, &run.FinishedAt, &run.Steering, &run.SuggestionCount,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/repository/books.go
+++ b/internal/repository/books.go
@@ -821,6 +821,40 @@ func scanBook(s scanner) (*models.Book, error) {
 	return &b, nil
 }
 
+// ListBooksMissingCover returns every book id that has no primary cover
+// image associated with it. Used by the cover-backfill scheduled job to
+// find candidates for metadata enrichment.
+func (r *BookRepo) ListBooksMissingCover(ctx context.Context, limit int) ([]uuid.UUID, error) {
+	if limit <= 0 {
+		limit = 1000
+	}
+	const q = `
+		SELECT b.id
+		  FROM books b
+		 WHERE NOT EXISTS (
+		         SELECT 1 FROM cover_images ci
+		          WHERE ci.entity_type = 'book'
+		            AND ci.entity_id   = b.id
+		            AND ci.is_primary  = TRUE
+		       )
+		 ORDER BY b.created_at DESC
+		 LIMIT $1`
+	rows, err := r.db.Query(ctx, q, limit)
+	if err != nil {
+		return nil, fmt.Errorf("listing books missing cover: %w", err)
+	}
+	defer rows.Close()
+	var out []uuid.UUID
+	for rows.Next() {
+		var pgID pgtype.UUID
+		if err := rows.Scan(&pgID); err != nil {
+			return nil, err
+		}
+		out = append(out, uuid.UUID(pgID.Bytes))
+	}
+	return out, rows.Err()
+}
+
 // TitlesByIDs returns a map of book ID → title for the given IDs.
 // Missing IDs are simply absent from the result map.
 func (r *BookRepo) TitlesByIDs(ctx context.Context, ids []uuid.UUID) (map[uuid.UUID]string, error) {

--- a/internal/repository/enrichment_batches.go
+++ b/internal/repository/enrichment_batches.go
@@ -37,18 +37,21 @@ func (r *EnrichmentBatchRepo) Create(ctx context.Context, batch *models.Enrichme
 	defer tx.Rollback(ctx)
 
 	// Create the umbrella jobs row first so the batch row can reference it
-	// via job_id. Kind is "enrichment"; status mirrors the batch.
+	// via job_id. Kind is "enrichment"; status mirrors the batch, translated
+	// from the legacy processing/done vocabulary to the canonical
+	// running/completed set the umbrella uses.
 	triggeredBy := "user"
 	if batch.LibraryID == nil {
-		// No library context = floating-book re-enrich from the BookDetailPage.
-		triggeredBy = "user"
+		// No library context = floating-book re-enrich or the cover-backfill
+		// scheduler. Both trace back to an admin/system trigger.
+		triggeredBy = "admin"
 	}
 	var jobID uuid.UUID
 	if err := tx.QueryRow(ctx, `
 		INSERT INTO jobs (kind, status, triggered_by, created_by)
 		VALUES ('enrichment', $1, $2, $3)
 		RETURNING id`,
-		string(batch.Status), triggeredBy, batch.CreatedBy,
+		normalizeStatusForJobs(string(batch.Status)), triggeredBy, batch.CreatedBy,
 	).Scan(&jobID); err != nil {
 		return fmt.Errorf("creating umbrella job: %w", err)
 	}
@@ -68,12 +71,16 @@ func (r *EnrichmentBatchRepo) Create(ctx context.Context, batch *models.Enrichme
 }
 
 // Get returns a single enrichment batch by ID (no items).
+// Get resolves a batch by either its own id or the umbrella jobs row id
+// it hangs off of. The unified history endpoint returns umbrella ids, so
+// accepting both lets the web expand a row without an extra lookup.
 func (r *EnrichmentBatchRepo) Get(ctx context.Context, id uuid.UUID) (*models.EnrichmentBatch, error) {
 	const q = `
 		SELECT id, library_id, created_by, type, force, status, book_ids,
 		       total_books, processed_books, failed_books, skipped_books, created_at, updated_at
 		FROM   enrichment_batches
-		WHERE  id = $1`
+		WHERE  id = $1 OR job_id = $1
+		LIMIT  1`
 	row := r.db.QueryRow(ctx, q, id)
 	batch, err := scanBatch(row)
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -82,13 +89,15 @@ func (r *EnrichmentBatchRepo) Get(ctx context.Context, id uuid.UUID) (*models.En
 	return batch, err
 }
 
-// GetWithItems returns a batch including its per-book items.
+// GetWithItems returns a batch including its per-book items. The input id
+// may be either the batch id or its umbrella job id; item listing always
+// uses the resolved batch id.
 func (r *EnrichmentBatchRepo) GetWithItems(ctx context.Context, id uuid.UUID) (*models.EnrichmentBatch, error) {
 	batch, err := r.Get(ctx, id)
 	if err != nil {
 		return nil, err
 	}
-	items, err := r.ListItems(ctx, id)
+	items, err := r.ListItems(ctx, batch.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -218,15 +227,20 @@ func (r *EnrichmentBatchRepo) ResyncCounters(ctx context.Context, batchID uuid.U
 // UpdateStatus updates the status of a batch. Never overwrites a
 // 'cancelled' status. Mirrors the change to the umbrella jobs row so the
 // unified history stays consistent, stamping started_at/finished_at when
-// transitioning into/out of running.
+// transitioning into/out of running and copying the batch counters into
+// jobs.progress so the UI can render "N/M books" without joining back to
+// the legacy table.
 func (r *EnrichmentBatchRepo) UpdateStatus(ctx context.Context, id uuid.UUID, status models.EnrichmentBatchStatus) error {
 	const q = `
 		UPDATE enrichment_batches
 		SET    status = $2, updated_at = now()
 		WHERE  id = $1 AND status != 'cancelled'
-		RETURNING job_id`
-	var pgJobID pgtype.UUID
-	if err := r.db.QueryRow(ctx, q, id, string(status)).Scan(&pgJobID); err != nil {
+		RETURNING job_id, processed_books, failed_books, skipped_books, total_books`
+	var (
+		pgJobID                            pgtype.UUID
+		processed, failed, skipped, total  int
+	)
+	if err := r.db.QueryRow(ctx, q, id, string(status)).Scan(&pgJobID, &processed, &failed, &skipped, &total); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil // either missing or already cancelled — caller doesn't care
 		}
@@ -236,10 +250,11 @@ func (r *EnrichmentBatchRepo) UpdateStatus(ctx context.Context, id uuid.UUID, st
 		const updJob = `
 			UPDATE jobs
 			   SET status      = $2,
+			       progress    = jsonb_build_object('processed', $3::int, 'failed', $4::int, 'skipped', $5::int, 'total', $6::int),
 			       started_at  = CASE WHEN $2 = 'running' AND started_at IS NULL THEN NOW() ELSE started_at END,
 			       finished_at = CASE WHEN $2 IN ('completed','failed','cancelled') THEN COALESCE(finished_at, NOW()) ELSE finished_at END
 			 WHERE id = $1`
-		if _, err := r.db.Exec(ctx, updJob, uuid.UUID(pgJobID.Bytes), string(status)); err != nil {
+		if _, err := r.db.Exec(ctx, updJob, uuid.UUID(pgJobID.Bytes), normalizeStatusForJobs(string(status)), processed, failed, skipped, total); err != nil {
 			return fmt.Errorf("mirroring status to umbrella job: %w", err)
 		}
 	}

--- a/internal/repository/import_jobs.go
+++ b/internal/repository/import_jobs.go
@@ -44,7 +44,7 @@ func (r *ImportJobRepo) CreateJob(ctx context.Context, job *models.ImportJob, it
 		INSERT INTO jobs (kind, status, triggered_by, created_by)
 		VALUES ('import', $1, 'user', $2)
 		RETURNING id`,
-		string(job.Status), job.CreatedBy,
+		normalizeStatusForJobs(string(job.Status)), job.CreatedBy,
 	).Scan(&umbrellaID); err != nil {
 		return fmt.Errorf("creating umbrella job: %w", err)
 	}
@@ -178,7 +178,7 @@ func (r *ImportJobRepo) UpdateJobStatus(ctx context.Context, id uuid.UUID, statu
 			       started_at  = CASE WHEN $2 = 'running' AND started_at IS NULL THEN NOW() ELSE started_at END,
 			       finished_at = CASE WHEN $2 IN ('completed','failed','cancelled') THEN COALESCE(finished_at, NOW()) ELSE finished_at END
 			 WHERE id = $1`
-		if _, err := r.db.Exec(ctx, updJob, uuid.UUID(pgJobID.Bytes), string(status), processed, failed, skipped, total); err != nil {
+		if _, err := r.db.Exec(ctx, updJob, uuid.UUID(pgJobID.Bytes), normalizeStatusForJobs(string(status)), processed, failed, skipped, total); err != nil {
 			return fmt.Errorf("mirroring status to umbrella job: %w", err)
 		}
 	}

--- a/internal/repository/jobs.go
+++ b/internal/repository/jobs.go
@@ -224,9 +224,10 @@ func (r *JobRepo) DeleteJob(ctx context.Context, id uuid.UUID) error {
 
 // DeleteFinished hard-deletes every job row in a terminal state
 // (completed/failed/cancelled). Used by the "Clear history" admin action.
+// Includes legacy 'done' for rows written before the status normalizer.
 // Returns the deleted count.
 func (r *JobRepo) DeleteFinished(ctx context.Context, kind string) (int64, error) {
-	where := "status IN ('completed','failed','cancelled')"
+	where := "status IN ('completed','done','failed','cancelled')"
 	args := []any{}
 	if kind != "" {
 		where += " AND kind = $1"
@@ -423,6 +424,23 @@ func scanSchedule(s scanner) (*models.JobSchedule, error) {
 	sched.ID = uuid.UUID(pgID.Bytes)
 	sched.Config = config
 	return &sched, nil
+}
+
+// normalizeStatusForJobs translates the legacy status vocabulary
+// (`processing`/`done`) used by import_jobs and enrichment_batches into
+// the canonical values on the umbrella jobs table (`running`/`completed`).
+// Other values (pending/failed/cancelled) pass through unchanged. Used by
+// the mirroring paths on those two repos; AI suggestions already uses
+// the canonical set directly.
+func normalizeStatusForJobs(s string) string {
+	switch s {
+	case "processing":
+		return "running"
+	case "done":
+		return "completed"
+	default:
+		return s
+	}
 }
 
 // nullableUUID is a small helper — pgx accepts *uuid.UUID natively but


### PR DESCRIPTION
- New \`cover_backfill\` scheduled kind: queries books with no primary cover, chunks 50 per batch, enqueues \`cover-only\` enrichment. Library-agnostic — works across the whole catalog.
- Boot-time schedule seeding: every Schedulable kind with no row gets a disabled default-cron entry so new kinds show up in the admin UI automatically.