### PR TITLE
feat(auth): personal access tokens with scope-capped permissions

### DIFF
--- a/internal/api/handlers/api_tokens.go
+++ b/internal/api/handlers/api_tokens.go
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725 (Adaléa)
+
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/fireball1725/librarium-api/internal/api/middleware"
+	"github.com/fireball1725/librarium-api/internal/api/respond"
+	"github.com/fireball1725/librarium-api/internal/models"
+	"github.com/fireball1725/librarium-api/internal/repository"
+	"github.com/google/uuid"
+)
+
+// APITokenHandler serves the `/me/api-tokens` endpoints used by the web UI
+// to mint, list, and revoke personal access tokens for the current user.
+type APITokenHandler struct {
+	tokens *repository.APITokenRepo
+}
+
+func NewAPITokenHandler(tokens *repository.APITokenRepo) *APITokenHandler {
+	return &APITokenHandler{tokens: tokens}
+}
+
+// ─── Wire shape ─────────────────────────────────────────────────────────────
+
+// tokenView is the safe public shape of an api_tokens row. Omits the hash;
+// includes the suffix so the UI can render `lbrm_pat_•••XXXX` to help the
+// user identify which token is which.
+type tokenView struct {
+	ID          uuid.UUID  `json:"id"`
+	Name        string     `json:"name"`
+	TokenSuffix string     `json:"token_suffix"`
+	Scopes      []string   `json:"scopes"`
+	LastUsedAt  *time.Time `json:"last_used_at,omitempty"`
+	ExpiresAt   *time.Time `json:"expires_at,omitempty"`
+	RevokedAt   *time.Time `json:"revoked_at,omitempty"`
+	CreatedAt   time.Time  `json:"created_at"`
+}
+
+func toTokenView(t *models.APIToken) tokenView {
+	return tokenView{
+		ID:          t.ID,
+		Name:        t.Name,
+		TokenSuffix: t.TokenSuffix,
+		Scopes:      t.Scopes,
+		LastUsedAt:  t.LastUsedAt,
+		ExpiresAt:   t.ExpiresAt,
+		RevokedAt:   t.RevokedAt,
+		CreatedAt:   t.CreatedAt,
+	}
+}
+
+// createTokenResponse is the ONLY response shape where the raw token appears.
+// The server intentionally has no endpoint to retrieve a token after this.
+type createTokenResponse struct {
+	tokenView
+	Token string `json:"token"`
+}
+
+type createTokenRequest struct {
+	Name      string     `json:"name"`
+	Scopes    []string   `json:"scopes"`
+	ExpiresAt *time.Time `json:"expires_at,omitempty"`
+}
+
+// ─── Handlers ───────────────────────────────────────────────────────────────
+
+// List godoc
+//
+//	@Summary     List the caller's API tokens
+//	@Description Returns every personal access token minted by the caller, including revoked ones, newest first. Raw token values are never returned; only metadata plus a four-character suffix.
+//	@Tags        me,api-tokens
+//	@Produce     json
+//	@Security    BearerAuth
+//	@Success     200  {array}   handlers.tokenView
+//	@Router      /me/api-tokens [get]
+func (h *APITokenHandler) List(w http.ResponseWriter, r *http.Request) {
+	claims := middleware.ClaimsFromContext(r.Context())
+	if claims == nil {
+		respond.Error(w, http.StatusUnauthorized, "authentication required")
+		return
+	}
+	rows, err := h.tokens.ListByUser(r.Context(), claims.UserID)
+	if err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
+	out := make([]tokenView, 0, len(rows))
+	for _, t := range rows {
+		out = append(out, toTokenView(t))
+	}
+	respond.JSON(w, http.StatusOK, out)
+}
+
+// Create godoc
+//
+//	@Summary     Mint a new personal access token
+//	@Description Creates a personal access token for the caller. The raw token value is returned in this response exactly once; the server stores only a sha256 hash and cannot retrieve it again. Lost tokens must be revoked and remintered.
+//	@Tags        me,api-tokens
+//	@Accept      json
+//	@Produce     json
+//	@Security    BearerAuth
+//	@Param       body  body      handlers.createTokenRequest  true  "Token metadata"
+//	@Success     201   {object}  handlers.createTokenResponse
+//	@Failure     400   {object}  object{error=string}
+//	@Router      /me/api-tokens [post]
+func (h *APITokenHandler) Create(w http.ResponseWriter, r *http.Request) {
+	claims := middleware.ClaimsFromContext(r.Context())
+	if claims == nil {
+		respond.Error(w, http.StatusUnauthorized, "authentication required")
+		return
+	}
+
+	// Minting new tokens requires an interactive session. Blocks a leaked
+	// PAT from self-perpetuating by spawning siblings, regardless of its
+	// scope set.
+	if claims.FromToken {
+		respond.Error(w, http.StatusForbidden, "api tokens can only be minted from an interactive session")
+		return
+	}
+
+	var body createTokenRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		respond.Error(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if len(body.Name) == 0 || len(body.Name) > 64 {
+		respond.Error(w, http.StatusBadRequest, "name is required (1-64 chars)")
+		return
+	}
+
+	// Normalize scopes: drop empties and dupes, preserve order.
+	scopes := normalizeScopes(body.Scopes)
+
+	minted, err := repository.Generate(claims.UserID, body.Name, scopes, body.ExpiresAt)
+	if err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
+	if err := h.tokens.Create(r.Context(), minted.Token); err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
+
+	respond.JSON(w, http.StatusCreated, createTokenResponse{
+		tokenView: toTokenView(minted.Token),
+		Token:     minted.Raw,
+	})
+}
+
+// Revoke godoc
+//
+//	@Summary     Revoke one of the caller's API tokens
+//	@Description Soft-deletes the token. Revocation takes effect immediately; subsequent auth attempts with the revoked token 401.
+//	@Tags        me,api-tokens
+//	@Security    BearerAuth
+//	@Param       id   path  string  true  "Token UUID"
+//	@Success     204
+//	@Failure     404  {object}  object{error=string}
+//	@Router      /me/api-tokens/{id} [delete]
+func (h *APITokenHandler) Revoke(w http.ResponseWriter, r *http.Request) {
+	claims := middleware.ClaimsFromContext(r.Context())
+	if claims == nil {
+		respond.Error(w, http.StatusUnauthorized, "authentication required")
+		return
+	}
+	id, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		respond.Error(w, http.StatusBadRequest, "invalid id")
+		return
+	}
+	if err := h.tokens.Revoke(r.Context(), claims.UserID, id); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			respond.Error(w, http.StatusNotFound, "token not found")
+			return
+		}
+		respond.ServerError(w, r, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+// normalizeScopes strips empties and duplicates while preserving order.
+func normalizeScopes(in []string) []string {
+	out := make([]string, 0, len(in))
+	seen := make(map[string]struct{}, len(in))
+	for _, s := range in {
+		if s == "" {
+			continue
+		}
+		if _, dup := seen[s]; dup {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}

--- a/internal/api/middleware/auth.go
+++ b/internal/api/middleware/auth.go
@@ -6,6 +6,7 @@ package middleware
 import (
 	"context"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -19,17 +20,60 @@ type contextKey string
 
 const claimsKey contextKey = "user_claims"
 
-// UserClaims holds the decoded JWT data attached to a request context.
+// UserClaims holds the decoded credential data attached to a request context.
+// Populated by either the JWT branch or the personal-access-token branch of
+// RequireAuth; downstream handlers and permission middleware don't care
+// which.
+//
+// TokenScopes carries the scope cap for PAT-authenticated requests. A nil
+// slice means "no token scope" — either the request came in with a JWT, or
+// the PAT had an empty scopes array (inherit user's full permissions).
+// A non-nil (possibly empty) slice means the caller is scope-capped: every
+// permission check must AND-intersect against this list.
 type UserClaims struct {
 	JTI             uuid.UUID
 	UserID          uuid.UUID
 	IsInstanceAdmin bool
 	ExpiresAt       time.Time
+	TokenScopes     []string
+	// FromToken is true when the request authenticated via a personal
+	// access token rather than an interactive JWT. Distinguishes
+	// full-access PATs (TokenScopes == nil) from real JWT sessions, which
+	// would otherwise look identical in the claims. Use this to gate
+	// actions that should only ever come from an interactive session —
+	// e.g. minting new API tokens.
+	FromToken bool
 }
 
-// RequireAuth validates the Bearer JWT, checks the denylist, and attaches
-// UserClaims to the request context.
-func RequireAuth(jwtSvc *auth.JWTService, denylist *repository.DenylistRepo) func(http.Handler) http.Handler {
+// ScopeAllows reports whether the caller's token scope permits the given
+// permission string. JWT-authenticated callers (TokenScopes == nil) always
+// pass. PAT-authenticated callers with an empty-but-non-nil scope list fail
+// closed — that state shouldn't occur (empty scopes in the DB become nil
+// here) but a fail-closed default is the safer code shape.
+func (c *UserClaims) ScopeAllows(perm string) bool {
+	if c.TokenScopes == nil {
+		return true
+	}
+	return slices.Contains(c.TokenScopes, perm)
+}
+
+// RequireAuth validates a Bearer credential and attaches UserClaims.
+// Accepts two credential shapes:
+//
+//   - JWT (default) — signed session token from the interactive login flow.
+//     Validated, checked against the denylist, attached as claims.
+//   - Personal access token (`lbrm_pat_...`) — long-lived credential minted
+//     by the user from the web UI for scripted/machine access. Looked up by
+//     sha256 in api_tokens, attached with TokenScopes for the RBAC layer to
+//     enforce.
+//
+// Downstream middleware and handlers treat the two identically except for
+// the scope enforcement in RequireLibraryPermission / RequireInstanceAdmin.
+func RequireAuth(
+	jwtSvc *auth.JWTService,
+	denylist *repository.DenylistRepo,
+	apiTokens *repository.APITokenRepo,
+) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			header := r.Header.Get("Authorization")
@@ -38,6 +82,18 @@ func RequireAuth(jwtSvc *auth.JWTService, denylist *repository.DenylistRepo) fun
 				return
 			}
 			tokenStr := strings.TrimPrefix(header, "Bearer ")
+
+			if strings.HasPrefix(tokenStr, repository.APITokenPrefix) {
+				claims, ok := authWithPAT(r.Context(), tokenStr, apiTokens)
+				if !ok {
+					respond.Error(w, http.StatusUnauthorized, "invalid or expired token")
+					return
+				}
+				next.ServeHTTP(w, r.WithContext(
+					context.WithValue(r.Context(), claimsKey, claims),
+				))
+				return
+			}
 
 			claims, err := jwtSvc.Validate(tokenStr)
 			if err != nil {
@@ -66,6 +122,53 @@ func RequireAuth(jwtSvc *auth.JWTService, denylist *repository.DenylistRepo) fun
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
+}
+
+// authWithPAT resolves an lbrm_pat_* bearer into UserClaims. Looks up the
+// token by its sha256 hash, joins the users table for the admin flag, and
+// fires a background TouchLastUsed so auth latency isn't blocked on the
+// write. Returns (claims, true) on success; (nil, false) for any failure
+// reason the caller surfaces as 401 without leaking a distinction.
+func authWithPAT(ctx context.Context, raw string, apiTokens *repository.APITokenRepo) (*UserClaims, bool) {
+	if apiTokens == nil {
+		return nil, false
+	}
+	hash := repository.HashToken(raw)
+	tok, err := apiTokens.FindActiveByHash(ctx, hash)
+	if err != nil || tok == nil {
+		return nil, false
+	}
+	admin, err := apiTokens.IsInstanceAdmin(ctx, tok.UserID)
+	if err != nil {
+		return nil, false
+	}
+
+	// Fire-and-forget: we don't want the request path blocked on this write
+	// and the token is already authenticated, so a failed touch is survivable.
+	go func(id uuid.UUID) {
+		bg, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = apiTokens.TouchLastUsed(bg, id)
+	}(tok.ID)
+
+	// Empty-scope token = inherit full user perms (classic PAT). Represent
+	// that by leaving TokenScopes as nil so ScopeAllows returns true.
+	var scopes []string
+	if len(tok.Scopes) > 0 {
+		scopes = tok.Scopes
+	}
+	expires := tok.CreatedAt
+	if tok.ExpiresAt != nil {
+		expires = *tok.ExpiresAt
+	}
+	return &UserClaims{
+		JTI:             tok.ID,
+		UserID:          tok.UserID,
+		IsInstanceAdmin: admin,
+		ExpiresAt:       expires,
+		TokenScopes:     scopes,
+		FromToken:       true,
+	}, true
 }
 
 // ClaimsFromContext retrieves UserClaims set by RequireAuth. Returns nil for unauthenticated requests.

--- a/internal/api/middleware/auth_test.go
+++ b/internal/api/middleware/auth_test.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725 (Adaléa)
+
+package middleware
+
+import "testing"
+
+func TestScopeAllows(t *testing.T) {
+	cases := []struct {
+		name   string
+		scopes []string
+		perm   string
+		want   bool
+	}{
+		{
+			name:   "nil scopes = JWT or full-access PAT: everything allowed",
+			scopes: nil,
+			perm:   "books:read",
+			want:   true,
+		},
+		{
+			name:   "empty scopes = fail-closed (shouldn't occur in practice)",
+			scopes: []string{},
+			perm:   "books:read",
+			want:   false,
+		},
+		{
+			name:   "perm present",
+			scopes: []string{"books:read", "loans:read"},
+			perm:   "books:read",
+			want:   true,
+		},
+		{
+			name:   "perm missing",
+			scopes: []string{"books:read", "loans:read"},
+			perm:   "books:create",
+			want:   false,
+		},
+		{
+			name:   "instance:admin requires explicit grant",
+			scopes: []string{"books:read"},
+			perm:   "instance:admin",
+			want:   false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			claims := &UserClaims{TokenScopes: c.scopes}
+			if got := claims.ScopeAllows(c.perm); got != c.want {
+				t.Errorf("ScopeAllows(%q) with scopes=%v = %v, want %v",
+					c.perm, c.scopes, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/api/middleware/rbac.go
+++ b/internal/api/middleware/rbac.go
@@ -11,12 +11,18 @@ import (
 )
 
 // RequireInstanceAdmin rejects requests from non-admin authenticated users.
-// Must be chained after RequireAuth.
+// Must be chained after RequireAuth. Also rejects PAT-authenticated requests
+// whose token scope doesn't include `instance:admin`, so an admin user's
+// scoped token can't accidentally reach admin endpoints.
 func RequireInstanceAdmin(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		claims := ClaimsFromContext(r.Context())
 		if claims == nil || !claims.IsInstanceAdmin {
 			respond.Error(w, http.StatusForbidden, "instance admin access required")
+			return
+		}
+		if !claims.ScopeAllows("instance:admin") {
+			respond.Error(w, http.StatusForbidden, "token scope does not permit this action")
 			return
 		}
 		next.ServeHTTP(w, r)
@@ -25,7 +31,11 @@ func RequireInstanceAdmin(next http.Handler) http.Handler {
 
 // RequireLibraryPermission checks that the authenticated user holds the given
 // permission in the library identified by the {library_id} path parameter.
-// Instance admins bypass the check. Must be chained after RequireAuth.
+// Instance admins bypass the library-role check, but the token-scope check
+// still applies — a scope-capped PAT minted by an admin cannot exceed its
+// scope even though the user could.
+//
+// Must be chained after RequireAuth.
 func RequireLibraryPermission(db *pgxpool.Pool, permission string) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -34,6 +44,12 @@ func RequireLibraryPermission(db *pgxpool.Pool, permission string) func(http.Han
 				respond.Error(w, http.StatusUnauthorized, "authentication required")
 				return
 			}
+
+			if !claims.ScopeAllows(permission) {
+				respond.Error(w, http.StatusForbidden, "token scope does not permit this action")
+				return
+			}
+
 			if claims.IsInstanceAdmin {
 				next.ServeHTTP(w, r)
 				return

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -97,6 +97,7 @@ func NewRouter(ctx context.Context, db *pgxpool.Pool, cfg *config.Config, riverC
 	shelfSvc := service.NewShelfService(shelfRepo, tagRepo)
 	importSvc := service.NewImportService(importJobRepo, riverClient)
 	enrichmentBatchRepo := repository.NewEnrichmentBatchRepo(db)
+	apiTokenRepo := repository.NewAPITokenRepo(db)
 
 	providerHandler := handlers.NewProviderHandler(providerSvc)
 	aiHandler := handlers.NewAIHandler(aiSvc)
@@ -126,7 +127,7 @@ func NewRouter(ctx context.Context, db *pgxpool.Pool, cfg *config.Config, riverC
 	releaseChecker := background.NewReleaseChecker(releaseSyncSvc, 24*time.Hour)
 	go releaseChecker.Start(ctx)
 
-	requireAuth := middleware.RequireAuth(jwtSvc, denylistRepo)
+	requireAuth := middleware.RequireAuth(jwtSvc, denylistRepo, apiTokenRepo)
 	// requireAdmin chains auth validation then instance-admin check
 	requireAdmin := func(h http.Handler) http.Handler {
 		return requireAuth(middleware.RequireInstanceAdmin(h))
@@ -168,6 +169,12 @@ func NewRouter(ctx context.Context, db *pgxpool.Pool, cfg *config.Config, riverC
 	mux.Handle("PUT /api/v1/auth/me/password", requireAuth(http.HandlerFunc(authHandler.UpdatePassword)))
 	mux.Handle("GET /api/v1/auth/me/preferences", requireAuth(http.HandlerFunc(authHandler.GetPreferences)))
 	mux.Handle("PATCH /api/v1/auth/me/preferences", requireAuth(http.HandlerFunc(authHandler.PatchPreferences)))
+
+	// Personal access tokens
+	apiTokenHandler := handlers.NewAPITokenHandler(apiTokenRepo)
+	mux.Handle("GET /api/v1/me/api-tokens", requireAuth(http.HandlerFunc(apiTokenHandler.List)))
+	mux.Handle("POST /api/v1/me/api-tokens", requireAuth(http.HandlerFunc(apiTokenHandler.Create)))
+	mux.Handle("DELETE /api/v1/me/api-tokens/{id}", requireAuth(http.HandlerFunc(apiTokenHandler.Revoke)))
 
 	// Admin — instance config (read-only view of runtime settings)
 	mux.Handle("GET /api/v1/admin/config", requireAdmin(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/db/migrations/000011_api_tokens.down.sql
+++ b/internal/db/migrations/000011_api_tokens.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS api_tokens;

--- a/internal/db/migrations/000011_api_tokens.up.sql
+++ b/internal/db/migrations/000011_api_tokens.up.sql
@@ -1,0 +1,31 @@
+-- Personal access tokens (PATs) for scripted / machine access to the API.
+--
+-- Each row represents one `lbrm_pat_<random>` credential minted by a user from
+-- the web UI. The raw token value is shown exactly once at creation and never
+-- again; we store only a sha256 hash for auth comparison plus the last four
+-- chars of the raw value so the UI can disambiguate tokens in the list without
+-- exposing them.
+--
+-- Scopes cap what a token can do, independent of the user's own effective
+-- permissions. An empty scopes array means "inherit user's full permissions"
+-- (classic PAT behaviour); a non-empty array is AND-intersected with the
+-- user's permissions at every permission check.
+
+CREATE TABLE api_tokens (
+    id            UUID        PRIMARY KEY,
+    user_id       UUID        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    name          TEXT        NOT NULL CHECK (char_length(name) BETWEEN 1 AND 64),
+    token_hash    TEXT        NOT NULL UNIQUE,
+    token_suffix  TEXT        NOT NULL CHECK (char_length(token_suffix) = 4),
+    scopes        TEXT[]      NOT NULL DEFAULT '{}',
+    last_used_at  TIMESTAMPTZ,
+    expires_at    TIMESTAMPTZ,
+    revoked_at    TIMESTAMPTZ,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_api_tokens_user_id     ON api_tokens(user_id);
+-- Hot path: auth middleware looks up an active token by hash. The partial
+-- index keeps the tree small by excluding revoked/expired rows.
+CREATE INDEX idx_api_tokens_hash_active ON api_tokens(token_hash)
+    WHERE revoked_at IS NULL;

--- a/internal/models/api_token.go
+++ b/internal/models/api_token.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725 (Adaléa)
+
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// APIToken is a personal access token minted by a user for scripted /
+// machine access to the API. The raw token value is shown exactly once at
+// creation; this row stores only a sha256 hash plus the last four chars of
+// the raw value for UI disambiguation.
+//
+// Scopes cap what the token can do: an empty slice means "inherit the user's
+// full permissions" (classic PAT behaviour), a non-empty slice is
+// AND-intersected with the user's permissions at every permission check.
+type APIToken struct {
+	ID          uuid.UUID
+	UserID      uuid.UUID
+	Name        string
+	TokenHash   string
+	TokenSuffix string
+	Scopes      []string
+	LastUsedAt  *time.Time
+	ExpiresAt   *time.Time
+	RevokedAt   *time.Time
+	CreatedAt   time.Time
+}
+
+// Active returns true if the token can be used right now: not revoked and
+// not past its expiry (if an expiry was set).
+func (t *APIToken) Active(now time.Time) bool {
+	if t.RevokedAt != nil {
+		return false
+	}
+	if t.ExpiresAt != nil && !t.ExpiresAt.After(now) {
+		return false
+	}
+	return true
+}

--- a/internal/repository/api_tokens.go
+++ b/internal/repository/api_tokens.go
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725 (Adaléa)
+
+package repository
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/fireball1725/librarium-api/internal/models"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// APITokenPrefix is the identifying prefix for every personal access token
+// the server issues. Kept as a constant so grep / secret-scanning tooling
+// has one canonical value to match.
+const APITokenPrefix = "lbrm_pat_"
+
+// apiTokenRandomLen is the number of base62 characters drawn from random
+// bytes for the secret body. 43 chars ≈ 256 bits of entropy.
+const apiTokenRandomLen = 43
+
+type APITokenRepo struct {
+	db *pgxpool.Pool
+}
+
+func NewAPITokenRepo(db *pgxpool.Pool) *APITokenRepo {
+	return &APITokenRepo{db: db}
+}
+
+// NewToken is the result of minting a token. `Raw` is the only time the
+// full credential is ever visible — it's returned once in the create
+// response and never again. `Token` is the stored row (without the raw
+// value) for the caller to persist and return metadata.
+type NewToken struct {
+	Raw   string
+	Token *models.APIToken
+}
+
+// Generate mints a fresh raw token and its stored row. Does not insert into
+// the DB — call Create with the NewToken value.
+func Generate(userID uuid.UUID, name string, scopes []string, expiresAt *time.Time) (*NewToken, error) {
+	body, err := randomBase62(apiTokenRandomLen)
+	if err != nil {
+		return nil, fmt.Errorf("random token body: %w", err)
+	}
+	raw := APITokenPrefix + body
+	hash := sha256.Sum256([]byte(raw))
+	suffix := raw[len(raw)-4:]
+
+	if scopes == nil {
+		scopes = []string{}
+	}
+
+	tok := &models.APIToken{
+		ID:          uuid.New(),
+		UserID:      userID,
+		Name:        name,
+		TokenHash:   hex.EncodeToString(hash[:]),
+		TokenSuffix: suffix,
+		Scopes:      scopes,
+		ExpiresAt:   expiresAt,
+		CreatedAt:   time.Now().UTC(),
+	}
+	return &NewToken{Raw: raw, Token: tok}, nil
+}
+
+// HashToken computes the storage hash for a raw token value. Used by the
+// auth middleware to look up an incoming header without trusting the client.
+func HashToken(raw string) string {
+	h := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(h[:])
+}
+
+// Create inserts a newly-minted token. The caller is responsible for also
+// returning the raw value to the client — the repo never re-reads it.
+func (r *APITokenRepo) Create(ctx context.Context, t *models.APIToken) error {
+	const q = `
+		INSERT INTO api_tokens (id, user_id, name, token_hash, token_suffix, scopes, expires_at, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`
+	_, err := r.db.Exec(ctx, q,
+		t.ID, t.UserID, t.Name, t.TokenHash, t.TokenSuffix, t.Scopes, t.ExpiresAt, t.CreatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("inserting api token: %w", err)
+	}
+	return nil
+}
+
+// ListByUser returns the caller's tokens, newest first, including already-
+// revoked rows so the UI can show a full history if it wants. Callers that
+// only want active tokens should filter on RevokedAt == nil.
+func (r *APITokenRepo) ListByUser(ctx context.Context, userID uuid.UUID) ([]*models.APIToken, error) {
+	const q = `
+		SELECT id, user_id, name, token_hash, token_suffix, scopes,
+		       last_used_at, expires_at, revoked_at, created_at
+		  FROM api_tokens
+		 WHERE user_id = $1
+		 ORDER BY created_at DESC`
+	rows, err := r.db.Query(ctx, q, userID)
+	if err != nil {
+		return nil, fmt.Errorf("listing api tokens: %w", err)
+	}
+	defer rows.Close()
+
+	var out []*models.APIToken
+	for rows.Next() {
+		t, err := scanToken(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, t)
+	}
+	return out, rows.Err()
+}
+
+// FindActiveByHash is the hot path for auth middleware. Returns the token
+// iff it exists, isn't revoked, and (if an expiry is set) isn't past it.
+func (r *APITokenRepo) FindActiveByHash(ctx context.Context, hash string) (*models.APIToken, error) {
+	const q = `
+		SELECT id, user_id, name, token_hash, token_suffix, scopes,
+		       last_used_at, expires_at, revoked_at, created_at
+		  FROM api_tokens
+		 WHERE token_hash = $1
+		   AND revoked_at IS NULL
+		   AND (expires_at IS NULL OR expires_at > NOW())`
+	row := r.db.QueryRow(ctx, q, hash)
+	t, err := scanToken(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	return t, err
+}
+
+// TouchLastUsed updates the token's last_used_at to now. Fire-and-forget
+// from the auth middleware so request latency isn't blocked on the write.
+// Silently swallows errors for the same reason.
+func (r *APITokenRepo) TouchLastUsed(ctx context.Context, id uuid.UUID) error {
+	_, err := r.db.Exec(ctx, `UPDATE api_tokens SET last_used_at = NOW() WHERE id = $1`, id)
+	return err
+}
+
+// IsInstanceAdmin is a small pointer lookup used by the PAT auth path to
+// populate UserClaims.IsInstanceAdmin without pulling in the full UserRepo
+// dependency. Keeps the middleware's package surface tight.
+func (r *APITokenRepo) IsInstanceAdmin(ctx context.Context, userID uuid.UUID) (bool, error) {
+	var admin bool
+	if err := r.db.QueryRow(ctx,
+		`SELECT is_instance_admin FROM users WHERE id = $1`, userID,
+	).Scan(&admin); err != nil {
+		return false, fmt.Errorf("loading user admin flag: %w", err)
+	}
+	return admin, nil
+}
+
+// Revoke soft-deletes a token by setting revoked_at. Scoped by user_id so
+// one user can't revoke another user's token by id.
+func (r *APITokenRepo) Revoke(ctx context.Context, userID, id uuid.UUID) error {
+	tag, err := r.db.Exec(ctx,
+		`UPDATE api_tokens SET revoked_at = NOW()
+		  WHERE id = $1 AND user_id = $2 AND revoked_at IS NULL`,
+		id, userID)
+	if err != nil {
+		return fmt.Errorf("revoking api token: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+func scanToken(s scanner) (*models.APIToken, error) {
+	t := &models.APIToken{}
+	if err := s.Scan(
+		&t.ID, &t.UserID, &t.Name, &t.TokenHash, &t.TokenSuffix, &t.Scopes,
+		&t.LastUsedAt, &t.ExpiresAt, &t.RevokedAt, &t.CreatedAt,
+	); err != nil {
+		return nil, fmt.Errorf("scanning api token: %w", err)
+	}
+	return t, nil
+}
+
+// randomBase62 returns a cryptographically-random string of the given length
+// using base62 alphabet. Uses crypto/rand for entropy; math/big is only used
+// as a convenient way to index into the alphabet.
+func randomBase62(n int) (string, error) {
+	const alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+	max := big.NewInt(int64(len(alphabet)))
+	buf := make([]byte, n)
+	for i := range n {
+		idx, err := rand.Int(rand.Reader, max)
+		if err != nil {
+			return "", err
+		}
+		buf[i] = alphabet[idx.Int64()]
+	}
+	return string(buf), nil
+}

--- a/internal/repository/api_tokens_test.go
+++ b/internal/repository/api_tokens_test.go
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725 (Adaléa)
+
+package repository
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/fireball1725/librarium-api/internal/models"
+	"github.com/google/uuid"
+)
+
+func TestGenerateProducesValidToken(t *testing.T) {
+	userID := uuid.New()
+	nt, err := Generate(userID, "test", nil, nil)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	// Raw token shape: prefix + 43 base62 chars = 52 total.
+	if !strings.HasPrefix(nt.Raw, APITokenPrefix) {
+		t.Errorf("raw token missing prefix: %q", nt.Raw)
+	}
+	wantLen := len(APITokenPrefix) + 43
+	if len(nt.Raw) != wantLen {
+		t.Errorf("raw token length = %d, want %d", len(nt.Raw), wantLen)
+	}
+
+	// Suffix stored = last 4 chars of raw.
+	if nt.Token.TokenSuffix != nt.Raw[len(nt.Raw)-4:] {
+		t.Errorf("suffix mismatch: stored %q vs raw tail %q",
+			nt.Token.TokenSuffix, nt.Raw[len(nt.Raw)-4:])
+	}
+
+	// Hash stored must match HashToken(raw) — this is the pact between
+	// minting and lookup.
+	if nt.Token.TokenHash != HashToken(nt.Raw) {
+		t.Errorf("stored hash does not match HashToken output")
+	}
+
+	// Scopes default to empty (never nil) so the DB insert is happy with
+	// a text[] column NOT NULL DEFAULT '{}'.
+	if nt.Token.Scopes == nil {
+		t.Errorf("Scopes is nil; should be empty slice when no scopes passed")
+	}
+
+	// Stamped fields.
+	if nt.Token.UserID != userID {
+		t.Errorf("UserID = %v, want %v", nt.Token.UserID, userID)
+	}
+	if nt.Token.Name != "test" {
+		t.Errorf("Name = %q, want %q", nt.Token.Name, "test")
+	}
+}
+
+func TestGenerateIsUnique(t *testing.T) {
+	// Sanity check: two consecutive generations yield distinct tokens.
+	// Not a rigorous entropy test, just a guard against accidentally
+	// seeding the RNG or caching output.
+	a, err := Generate(uuid.New(), "a", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := Generate(uuid.New(), "b", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a.Raw == b.Raw {
+		t.Errorf("two generated tokens are identical")
+	}
+	if a.Token.TokenHash == b.Token.TokenHash {
+		t.Errorf("two generated token hashes are identical")
+	}
+}
+
+func TestGeneratePreservesScopes(t *testing.T) {
+	scopes := []string{"books:read", "loans:read"}
+	nt, err := Generate(uuid.New(), "scoped", scopes, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nt.Token.Scopes) != 2 ||
+		nt.Token.Scopes[0] != "books:read" ||
+		nt.Token.Scopes[1] != "loans:read" {
+		t.Errorf("Scopes not preserved: got %v", nt.Token.Scopes)
+	}
+}
+
+func TestHashTokenDeterministic(t *testing.T) {
+	// Same input always produces the same hash — the middleware relies on
+	// this to look up tokens by hash without storing the raw value.
+	raw := "lbrm_pat_abcdef1234567890"
+	h1 := HashToken(raw)
+	h2 := HashToken(raw)
+	if h1 != h2 {
+		t.Errorf("HashToken is not deterministic: %q vs %q", h1, h2)
+	}
+	// Different inputs produce different hashes (guards against constant
+	// hashing / accidental stubbing).
+	if HashToken(raw) == HashToken(raw+"extra") {
+		t.Errorf("HashToken collision on trivially different input")
+	}
+	// sha256 hex = 64 chars. Not strictly required but catches a
+	// regression to a different (shorter) digest.
+	if len(h1) != 64 {
+		t.Errorf("HashToken length = %d, want 64 (hex-encoded sha256)", len(h1))
+	}
+}
+
+func TestAPITokenActive(t *testing.T) {
+	now := time.Date(2026, 4, 24, 0, 0, 0, 0, time.UTC)
+	past := now.Add(-1 * time.Hour)
+	future := now.Add(1 * time.Hour)
+
+	cases := []struct {
+		name    string
+		tok     models.APIToken
+		wantOK  bool
+	}{
+		{
+			name:   "fresh, no expiry",
+			tok:    models.APIToken{},
+			wantOK: true,
+		},
+		{
+			name:   "not-yet-expired",
+			tok:    models.APIToken{ExpiresAt: &future},
+			wantOK: true,
+		},
+		{
+			name:   "expired",
+			tok:    models.APIToken{ExpiresAt: &past},
+			wantOK: false,
+		},
+		{
+			name:   "revoked",
+			tok:    models.APIToken{RevokedAt: &past},
+			wantOK: false,
+		},
+		{
+			name:   "revoked beats not-yet-expired",
+			tok:    models.APIToken{RevokedAt: &past, ExpiresAt: &future},
+			wantOK: false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.tok.Active(now); got != c.wantOK {
+				t.Errorf("Active() = %v, want %v", got, c.wantOK)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- `lbrm_pat_*` tokens minted from `POST /me/api-tokens` (raw returned once, never again — only sha256 hash + 4-char suffix stored). Scopes are AND-intersected with the user's permissions at every RBAC check, so an admin can mint a genuinely read-only token.
- Auth middleware grows a PAT branch beside the existing JWT flow; RBAC middleware honours scopes before the user-permission check; PAT-authenticated callers can't mint sibling tokens.
- Plan: `plans/api-tokens.md`. Prereq for `librarium-mcp`.