### PR TITLE
fix(security): API hardening pass — headers, rate limits, upload sniffing, audit log

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -62,6 +62,15 @@ import (
 func main() {
 	cfg := config.Load()
 
+	// Refuse to start without a JWT signing secret. An empty secret would
+	// cause every token to be signed with `[]byte("")`, which is trivially
+	// forgeable — catastrophic auth bypass. Caller must set JWT_SECRET to a
+	// cryptographically random value (≥32 bytes recommended).
+	if cfg.JWTSecret == "" {
+		fmt.Fprintln(os.Stderr, "FATAL: JWT_SECRET is required and must not be empty")
+		os.Exit(1)
+	}
+
 	baseCtx, cancelBaseCtx := context.WithCancel(context.Background())
 	defer cancelBaseCtx()
 
@@ -430,11 +439,15 @@ func main() {
 		ProviderSvc: providerSvc,
 	})
 	srv := &http.Server{
-		Addr:         addr,
-		Handler:      handler,
-		ReadTimeout:  15 * time.Second,
-		WriteTimeout: 15 * time.Second,
-		IdleTimeout:  60 * time.Second,
+		Addr:           addr,
+		Handler:        handler,
+		ReadTimeout:    15 * time.Second,
+		WriteTimeout:   15 * time.Second,
+		IdleTimeout:    60 * time.Second,
+		// Cap request headers at 1 MiB so a malformed client can't pin a
+		// goroutine on an unbounded header read. Per-handler limits cover
+		// bodies (multipart, JSON); this catches everything else.
+		MaxHeaderBytes: 1 << 20,
 	}
 	if collector != nil {
 		srv.ConnState = func(_ net.Conn, state http.ConnState) {

--- a/internal/api/handlers/api_tokens.go
+++ b/internal/api/handlers/api_tokens.go
@@ -6,6 +6,7 @@ package handlers
 import (
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -147,6 +148,10 @@ func (h *APITokenHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	authEvent(r, "pat_create", "success",
+		slog.String("user_id", claims.UserID.String()),
+		slog.String("token_id", minted.Token.ID.String()),
+		slog.Int("scope_count", len(scopes)))
 	respond.JSON(w, http.StatusCreated, createTokenResponse{
 		tokenView: toTokenView(minted.Token),
 		Token:     minted.Raw,
@@ -182,6 +187,9 @@ func (h *APITokenHandler) Revoke(w http.ResponseWriter, r *http.Request) {
 		respond.ServerError(w, r, err)
 		return
 	}
+	authEvent(r, "pat_revoke", "success",
+		slog.String("user_id", claims.UserID.String()),
+		slog.String("token_id", id.String()))
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -6,6 +6,7 @@ package handlers
 import (
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
 
 	"github.com/fireball1725/librarium-api/internal/api/middleware"
@@ -14,6 +15,41 @@ import (
 	"github.com/fireball1725/librarium-api/internal/repository"
 	"github.com/fireball1725/librarium-api/internal/service"
 )
+
+// authEvent emits a structured slog record for an authentication-relevant
+// event. Centralized so login/logout/password-change/registration all
+// share the same shape — easy to grep, easy to ship into an external
+// audit log later without touching every call site.
+func authEvent(r *http.Request, event, outcome string, attrs ...slog.Attr) {
+	base := []slog.Attr{
+		slog.String("event", event),
+		slog.String("outcome", outcome),
+		slog.String("remote_addr", clientIPFromRequest(r)),
+	}
+	all := append(base, attrs...)
+	args := make([]any, 0, len(all))
+	for _, a := range all {
+		args = append(args, a)
+	}
+	slog.Info("auth", args...)
+}
+
+// clientIPFromRequest mirrors the logger's realIP behaviour without
+// re-exporting it. Returns the originating IP, X-Forwarded-For aware.
+func clientIPFromRequest(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		for i := 0; i < len(xff); i++ {
+			if xff[i] == ',' {
+				return xff[:i]
+			}
+		}
+		return xff
+	}
+	if xri := r.Header.Get("X-Real-IP"); xri != "" {
+		return xri
+	}
+	return r.RemoteAddr
+}
 
 type AuthHandler struct {
 	auth  *service.AuthService
@@ -65,15 +101,22 @@ func (h *AuthHandler) Register(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		switch {
 		case errors.Is(err, service.ErrRegistrationDisabled):
+			authEvent(r, "register", "denied", slog.String("reason", "registration_disabled"))
 			respond.Error(w, http.StatusForbidden, "registration is disabled")
 		case errors.Is(err, repository.ErrDuplicate):
-			respond.Error(w, http.StatusConflict, err.Error())
+			authEvent(r, "register", "denied", slog.String("reason", "duplicate"))
+			// Generic message so signup can't be used to enumerate which
+			// usernames/emails are taken. Service-level errors may name the
+			// specific field; we collapse them here.
+			respond.Error(w, http.StatusConflict, "username or email is already in use")
 		default:
+			authEvent(r, "register", "error")
 			respond.ServerError(w, r, err)
 		}
 		return
 	}
 
+	authEvent(r, "register", "success", slog.String("user_id", resp.User.ID.String()))
 	respond.JSON(w, http.StatusCreated, authResponseBody(resp))
 }
 
@@ -110,13 +153,18 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		switch {
 		case errors.Is(err, service.ErrInvalidCredentials), errors.Is(err, service.ErrAccountInactive):
+			// Don't include the identifier — could leak which usernames/
+			// emails exist if logs are exfiltrated.
+			authEvent(r, "login", "failure", slog.String("reason", "invalid_credentials"))
 			respond.Error(w, http.StatusUnauthorized, "invalid credentials")
 		default:
+			authEvent(r, "login", "error")
 			respond.ServerError(w, r, err)
 		}
 		return
 	}
 
+	authEvent(r, "login", "success", slog.String("user_id", resp.User.ID.String()))
 	respond.JSON(w, http.StatusOK, authResponseBody(resp))
 }
 
@@ -179,10 +227,12 @@ func (h *AuthHandler) Logout(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.auth.Logout(r.Context(), claims.UserID, claims.JTI, claims.ExpiresAt); err != nil {
+		authEvent(r, "logout", "error", slog.String("user_id", claims.UserID.String()))
 		respond.ServerError(w, r, err)
 		return
 	}
 
+	authEvent(r, "logout", "success", slog.String("user_id", claims.UserID.String()))
 	respond.JSON(w, http.StatusOK, map[string]string{"message": "logged out"})
 }
 
@@ -224,7 +274,9 @@ func (h *AuthHandler) UpdateMe(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		switch {
 		case errors.Is(err, repository.ErrDuplicate):
-			respond.Error(w, http.StatusConflict, err.Error())
+			// Don't echo whether it was username/email — same anti-enumeration
+			// rationale as Register.
+			respond.Error(w, http.StatusConflict, "email is already in use")
 		default:
 			respond.ServerError(w, r, err)
 		}
@@ -270,13 +322,16 @@ func (h *AuthHandler) UpdatePassword(w http.ResponseWriter, r *http.Request) {
 	if err := h.auth.UpdatePassword(r.Context(), claims.UserID, req.CurrentPassword, req.NewPassword); err != nil {
 		switch {
 		case errors.Is(err, service.ErrInvalidCredentials):
+			authEvent(r, "password_change", "failure", slog.String("user_id", claims.UserID.String()), slog.String("reason", "wrong_current_password"))
 			respond.Error(w, http.StatusUnauthorized, "current password is incorrect")
 		default:
+			authEvent(r, "password_change", "error", slog.String("user_id", claims.UserID.String()))
 			respond.ServerError(w, r, err)
 		}
 		return
 	}
 
+	authEvent(r, "password_change", "success", slog.String("user_id", claims.UserID.String()))
 	respond.JSON(w, http.StatusOK, map[string]string{"message": "password updated"})
 }
 

--- a/internal/api/handlers/contributors.go
+++ b/internal/api/handlers/contributors.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/fireball1725/librarium-api/internal/api/middleware"
 	"github.com/fireball1725/librarium-api/internal/api/respond"
+	"github.com/fireball1725/librarium-api/internal/api/uploads"
 	"github.com/fireball1725/librarium-api/internal/models"
 	"github.com/fireball1725/librarium-api/internal/providers"
 	"github.com/fireball1725/librarium-api/internal/repository"
@@ -285,24 +286,29 @@ func (h *ContributorHandler) UploadContributorPhoto(w http.ResponseWriter, r *ht
 		respond.Error(w, http.StatusBadRequest, "invalid multipart form")
 		return
 	}
-	file, header, err := r.FormFile("photo")
+	file, _, err := r.FormFile("photo")
 	if err != nil {
 		respond.Error(w, http.StatusBadRequest, "photo file is required")
 		return
 	}
 	defer file.Close()
 
-	mime := header.Header.Get("Content-Type")
-	if mime == "" || !strings.HasPrefix(mime, "image/") {
-		respond.Error(w, http.StatusBadRequest, "file must be an image")
+	mime, head, err := uploads.SniffImage(file)
+	if errors.Is(err, uploads.ErrUnsupportedType) {
+		respond.Error(w, http.StatusBadRequest, "file must be a PNG, JPEG, GIF, or WebP image")
 		return
 	}
-
-	data, err := io.ReadAll(io.LimitReader(file, 10<<20))
 	if err != nil {
 		respond.ServerError(w, r, err)
 		return
 	}
+
+	rest, err := io.ReadAll(io.LimitReader(file, (10<<20)-int64(len(head))))
+	if err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
+	data := append(head, rest...)
 
 	if err := h.svc.StorePhotoFromUpload(r.Context(), contributorID, claims.UserID, data, mime); err != nil {
 		respond.ServerError(w, r, err)

--- a/internal/api/handlers/covers.go
+++ b/internal/api/handlers/covers.go
@@ -9,10 +9,10 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 
 	"github.com/fireball1725/librarium-api/internal/api/middleware"
 	"github.com/fireball1725/librarium-api/internal/api/respond"
+	"github.com/fireball1725/librarium-api/internal/api/uploads"
 	"github.com/fireball1725/librarium-api/internal/repository"
 	"github.com/fireball1725/librarium-api/internal/service"
 	"github.com/google/uuid"
@@ -125,24 +125,34 @@ func (h *BookHandler) UploadBookCover(w http.ResponseWriter, r *http.Request) {
 		respond.Error(w, http.StatusBadRequest, "invalid multipart form")
 		return
 	}
-	file, header, err := r.FormFile("cover")
+	file, _, err := r.FormFile("cover")
 	if err != nil {
 		respond.Error(w, http.StatusBadRequest, "cover file is required")
 		return
 	}
 	defer file.Close()
 
-	mime := header.Header.Get("Content-Type")
-	if mime == "" || !strings.HasPrefix(mime, "image/") {
-		respond.Error(w, http.StatusBadRequest, "file must be an image")
+	// Detect MIME from the actual content rather than trusting the
+	// client-supplied multipart header. SniffImage rejects anything outside
+	// the cover allowlist (PNG / JPEG / GIF / WebP).
+	mime, head, err := uploads.SniffImage(file)
+	if errors.Is(err, uploads.ErrUnsupportedType) {
+		respond.Error(w, http.StatusBadRequest, "file must be a PNG, JPEG, GIF, or WebP image")
 		return
 	}
-
-	data, err := io.ReadAll(io.LimitReader(file, 10<<20))
 	if err != nil {
 		respond.ServerError(w, r, err)
 		return
 	}
+
+	// Stitch the bytes consumed during sniffing back onto the front of the
+	// stream so the persisted file is byte-identical to what was uploaded.
+	rest, err := io.ReadAll(io.LimitReader(file, (10<<20)-int64(len(head))))
+	if err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
+	data := append(head, rest...)
 
 	if err := h.svc.StoreCoverFromUpload(r.Context(), bookID, claims.UserID, data, mime); err != nil {
 		respond.ServerError(w, r, err)

--- a/internal/api/handlers/edition_files.go
+++ b/internal/api/handlers/edition_files.go
@@ -4,11 +4,14 @@
 package handlers
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 
 	"github.com/fireball1725/librarium-api/internal/api/respond"
+	"github.com/fireball1725/librarium-api/internal/api/uploads"
 	"github.com/fireball1725/librarium-api/internal/models"
 	"github.com/fireball1725/librarium-api/internal/repository"
 	"github.com/fireball1725/librarium-api/internal/service"
@@ -149,7 +152,22 @@ func (h *EditionFileHandler) UploadEditionFile(w http.ResponseWriter, r *http.Re
 	}
 	defer file.Close()
 
-	ef, err := h.svc.UploadEditionFile(r.Context(), edition, file, header.Filename, header.Size)
+	// Sniff actual content vs. trusting the multipart Content-Type header.
+	// We restitch the consumed sniff bytes onto the front of the stream
+	// before handing it to the service so the persisted file is byte-
+	// identical to the upload.
+	_, head, err := uploads.SniffEditionFile(file)
+	if errors.Is(err, uploads.ErrUnsupportedType) {
+		respond.Error(w, http.StatusBadRequest, "file must be a PDF, EPUB, or supported audio format")
+		return
+	}
+	if err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
+	stream := io.MultiReader(bytes.NewReader(head), file)
+
+	ef, err := h.svc.UploadEditionFile(r.Context(), edition, stream, header.Filename, header.Size)
 	if err != nil {
 		var ve *service.ValidationError
 		if errors.As(err, &ve) {

--- a/internal/api/middleware/rate_limit.go
+++ b/internal/api/middleware/rate_limit.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725 (Adaléa)
+
+package middleware
+
+import (
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/fireball1725/librarium-api/internal/api/respond"
+)
+
+// RateLimiter is an in-memory per-key token-bucket suitable for the
+// "block obvious brute-force on a single binary" use case. It is NOT a
+// distributed rate limiter — operators running multiple replicas behind a
+// load balancer should put rate limiting at the proxy layer instead.
+//
+// Keys are typically client IPs (recovered via realIP from the logger
+// middleware so X-Forwarded-For is honoured behind Traefik). Buckets refill
+// at `refill` per `interval`, capped at `burst`.
+type RateLimiter struct {
+	mu       sync.Mutex
+	buckets  map[string]*bucket
+	burst    float64
+	refill   float64        // tokens per second
+	interval time.Duration  // window used for human-readable config
+	idleTTL  time.Duration  // garbage-collect buckets unseen this long
+}
+
+type bucket struct {
+	tokens   float64
+	lastSeen time.Time
+}
+
+// NewRateLimiter constructs a limiter that allows `burst` requests in any
+// short interval and refills `refill` tokens per `interval`. For example,
+// NewRateLimiter(5, 5, time.Minute) → 5/min sustained, 5 burst.
+func NewRateLimiter(burst, refill int, interval time.Duration) *RateLimiter {
+	return &RateLimiter{
+		buckets:  make(map[string]*bucket),
+		burst:    float64(burst),
+		refill:   float64(refill) / interval.Seconds(),
+		interval: interval,
+		idleTTL:  10 * time.Minute,
+	}
+}
+
+// allow returns true if the caller may proceed and decrements the bucket;
+// false means the caller is over budget right now.
+func (rl *RateLimiter) allow(key string) bool {
+	now := time.Now()
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	rl.gc(now)
+
+	b, ok := rl.buckets[key]
+	if !ok {
+		rl.buckets[key] = &bucket{tokens: rl.burst - 1, lastSeen: now}
+		return true
+	}
+
+	// Refill based on elapsed time, capped at burst.
+	elapsed := now.Sub(b.lastSeen).Seconds()
+	b.tokens += elapsed * rl.refill
+	if b.tokens > rl.burst {
+		b.tokens = rl.burst
+	}
+	b.lastSeen = now
+
+	if b.tokens < 1 {
+		return false
+	}
+	b.tokens--
+	return true
+}
+
+// gc evicts buckets that haven't been touched recently. Cheap because we
+// hold the mutex anyway and the map fits in memory for any realistic
+// per-IP workload.
+func (rl *RateLimiter) gc(now time.Time) {
+	for k, b := range rl.buckets {
+		if now.Sub(b.lastSeen) > rl.idleTTL {
+			delete(rl.buckets, k)
+		}
+	}
+}
+
+// Middleware returns an http.Handler wrapper that 429s requests over budget.
+// Keying is by client IP (X-Forwarded-For aware via realIP).
+func (rl *RateLimiter) Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		key := realIP(r)
+		if !rl.allow(key) {
+			// Retry-After in seconds gives clients a hint without leaking
+			// our exact internal budget.
+			w.Header().Set("Retry-After", "60")
+			respond.Error(w, http.StatusTooManyRequests, "too many requests; please try again later")
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/api/middleware/security_headers.go
+++ b/internal/api/middleware/security_headers.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725 (Adaléa)
+
+package middleware
+
+import "net/http"
+
+// SecurityHeaders sets a conservative set of HTTP security response headers
+// on every response. Applied globally before routing so it covers both API
+// JSON responses and the docs / OpenAPI surfaces.
+//
+// Notes on header choices:
+//
+//   - HSTS forces TLS for clients that have ever seen an HTTPS response from
+//     this origin. We set 1y with includeSubDomains (no preload — operators
+//     should opt into hstspreload.org consciously). This is a no-op when the
+//     request arrives over plaintext, which is desired during local dev.
+//   - X-Content-Type-Options blocks MIME sniffing — important for the JSON
+//     API surface (responses are always application/json) and the cover
+//     proxy (which sets the right Content-Type but should not be overridden).
+//   - X-Frame-Options + frame-ancestors block clickjacking on the docs UI;
+//     the API itself never renders HTML so the browser-facing concern is the
+//     scalar UI at /api/docs.
+//   - The CSP is intentionally tight — `default-src 'self'` plus the inline
+//     allowances Scalar UI needs to render. If we ever serve a richer
+//     browser surface from this binary the CSP can be relaxed at that route.
+//   - Referrer-Policy keeps the path/query of any links out of cross-origin
+//     Referer headers; useful for any future deep-link surfaces.
+//   - Permissions-Policy turns off browser features we never legitimately
+//     use from API responses.
+func SecurityHeaders(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h := w.Header()
+		h.Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+		h.Set("X-Content-Type-Options", "nosniff")
+		h.Set("X-Frame-Options", "DENY")
+		h.Set("Referrer-Policy", "strict-origin-when-cross-origin")
+		h.Set("Permissions-Policy", "camera=(), microphone=(), geolocation=(), payment=()")
+		// Scalar UI (the OpenAPI viewer at /api/docs) loads its bundle from
+		// jsdelivr and renders inline styles, so loosen CSP only for that
+		// route. Everywhere else we ship a tight default-src 'self'.
+		if r.URL.Path == "/api/docs" {
+			h.Set("Content-Security-Policy",
+				"default-src 'self'; "+
+					"script-src 'self' https://cdn.jsdelivr.net 'unsafe-inline'; "+
+					"style-src 'self' https://cdn.jsdelivr.net 'unsafe-inline'; "+
+					"img-src 'self' data: https:; "+
+					"font-src 'self' data: https://cdn.jsdelivr.net; "+
+					"connect-src 'self'; "+
+					"frame-ancestors 'none'")
+		} else {
+			h.Set("Content-Security-Policy",
+				"default-src 'none'; frame-ancestors 'none'")
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -157,10 +157,17 @@ func NewRouter(ctx context.Context, db *pgxpool.Pool, cfg *config.Config, riverC
 	mux.HandleFunc("GET /api/v1/setup/status", setupHandler.Status)
 	mux.HandleFunc("POST /api/v1/setup/admin", setupHandler.BootstrapAdmin)
 
-	// Auth — public
-	mux.HandleFunc("POST /api/v1/auth/register", authHandler.Register)
-	mux.HandleFunc("POST /api/v1/auth/login", authHandler.Login)
-	mux.HandleFunc("POST /api/v1/auth/refresh", authHandler.Refresh)
+	// Auth — public, rate-limited per client IP. Generous bursts keep real
+	// clients with stuttery networks happy while still blocking
+	// credential-stuffing / refresh-grinding attempts at the binary layer.
+	// (Operators running multiple replicas should lift rate limiting to the
+	// proxy; this is a single-binary safety net.)
+	loginLimiter := middleware.NewRateLimiter(10, 10, time.Minute).Middleware
+	registerLimiter := middleware.NewRateLimiter(5, 5, time.Minute).Middleware
+	refreshLimiter := middleware.NewRateLimiter(30, 30, time.Minute).Middleware
+	mux.Handle("POST /api/v1/auth/register", registerLimiter(http.HandlerFunc(authHandler.Register)))
+	mux.Handle("POST /api/v1/auth/login", loginLimiter(http.HandlerFunc(authHandler.Login)))
+	mux.Handle("POST /api/v1/auth/refresh", refreshLimiter(http.HandlerFunc(authHandler.Refresh)))
 
 	// Auth — protected
 	mux.Handle("POST /api/v1/auth/logout", requireAuth(http.HandlerFunc(authHandler.Logout)))
@@ -430,5 +437,8 @@ func NewRouter(ctx context.Context, db *pgxpool.Pool, cfg *config.Config, riverC
 	mux.Handle("PUT /api/v1/genres/{genre_id}", requireAdmin(http.HandlerFunc(genreHandler.UpdateGenre)))
 	mux.Handle("DELETE /api/v1/genres/{genre_id}", requireAdmin(http.HandlerFunc(genreHandler.DeleteGenre)))
 
-	return middleware.Logger(mux, metrics)
+	// Security headers wrap the entire surface so they apply to docs, the
+	// OpenAPI spec, and every API response uniformly. Logger sits inside so
+	// it still records the same per-request data.
+	return middleware.SecurityHeaders(middleware.Logger(mux, metrics))
 }

--- a/internal/api/uploads/sniff.go
+++ b/internal/api/uploads/sniff.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725 (Adaléa)
+
+// Package uploads centralizes content-type detection for multipart file
+// uploads. The previous handlers trusted the client-supplied Content-Type
+// from the multipart header, which is trivially spoofed — a user could
+// upload an executable advertised as `image/png` and bypass the check.
+//
+// SniffImage / SniffEditionFile read the leading bytes of the actual upload,
+// run them through the standard library's content-type sniffer, and check
+// against an allowlist. Callers should use the returned MIME instead of any
+// client-provided value.
+package uploads
+
+import (
+	"errors"
+	"io"
+	"net/http"
+)
+
+// ErrUnsupportedType is returned when an upload's actual content does not
+// match the allowlist for that endpoint.
+var ErrUnsupportedType = errors.New("unsupported file type")
+
+// allowedImageTypes is the closed set of cover / contributor-photo MIME
+// types we accept. SVG is intentionally excluded — it can carry script.
+var allowedImageTypes = map[string]struct{}{
+	"image/png":  {},
+	"image/jpeg": {},
+	"image/gif":  {},
+	"image/webp": {},
+}
+
+// allowedEditionFileTypes is the closed set of ebook / audiobook MIME types
+// we accept on the edition-file upload endpoint. Generic application/zip is
+// allowed because EPUB/CBZ files are detected as zip by net/http; the
+// service layer pins format more narrowly via the explicit `format` field.
+var allowedEditionFileTypes = map[string]struct{}{
+	"application/pdf":  {},
+	"application/epub+zip": {},
+	"application/zip":  {},
+	"audio/mpeg":       {},
+	"audio/mp4":        {},
+	"audio/m4a":        {},
+	"audio/x-m4a":      {},
+	"audio/x-m4b":      {},
+	"audio/aac":        {},
+	"audio/ogg":        {},
+	"audio/flac":       {},
+	"audio/x-flac":     {},
+	"audio/wav":        {},
+	"audio/x-wav":      {},
+}
+
+// SniffImage validates that `r` is one of the allowed image types and
+// returns the canonical MIME plus the bytes it consumed during sniffing
+// (callers must use the returned `head`, then read the rest from `r`).
+func SniffImage(r io.Reader) (mime string, head []byte, err error) {
+	return sniff(r, allowedImageTypes)
+}
+
+// SniffEditionFile validates that `r` is one of the allowed ebook /
+// audiobook types and returns the canonical MIME plus consumed bytes.
+func SniffEditionFile(r io.Reader) (mime string, head []byte, err error) {
+	return sniff(r, allowedEditionFileTypes)
+}
+
+// sniff reads up to 512 bytes (net/http's documented sniff window),
+// classifies the content, and rejects anything outside the allowlist.
+// The consumed bytes are returned so callers can prepend them to the rest
+// of the stream when persisting.
+func sniff(r io.Reader, allowed map[string]struct{}) (string, []byte, error) {
+	head := make([]byte, 512)
+	n, err := io.ReadFull(r, head)
+	if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+		return "", nil, err
+	}
+	head = head[:n]
+	detected := http.DetectContentType(head)
+	// Strip parameters (e.g. "image/jpeg; charset=binary").
+	for i, c := range detected {
+		if c == ';' {
+			detected = detected[:i]
+			break
+		}
+	}
+	if _, ok := allowed[detected]; !ok {
+		return "", nil, ErrUnsupportedType
+	}
+	return detected, head, nil
+}

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -232,7 +232,14 @@ func (s *AuthService) Refresh(ctx context.Context, rawToken string) (*AuthRespon
 		return nil, err
 	}
 
+	// A revoked refresh token presented for refresh is a compromise
+	// signal: the token was already rotated once, and now an attacker
+	// (or — rarer — a buggy client) is trying to reuse it. Burn every
+	// outstanding refresh token for this user so the legitimate session
+	// has to re-authenticate. The legitimate user will see one annoying
+	// re-login; the attacker loses all tokens they may have stolen.
 	if rt.RevokedAt != nil {
+		_ = s.tokens.RevokeAllForUser(ctx, rt.UserID)
 		return nil, ErrTokenRevoked
 	}
 	if time.Now().After(rt.ExpiresAt) {


### PR DESCRIPTION
- **P0**: Fail-fast on empty `JWT_SECRET`, global security-headers middleware (HSTS/CSP/XCTO/XFO/Referrer/Permissions), rate limits on `/auth/login` (10/min), `/auth/register` (5/min), `/auth/refresh` (30/min).
- **P1**: `http.Server.MaxHeaderBytes = 1 MiB`; new `uploads.SniffImage`/`SniffEditionFile` validate uploads via magic bytes (cover/photo/edition-file handlers no longer trust the spoofable multipart Content-Type); refresh-token reuse now revokes every outstanding refresh token for that user (token-family compromise signal); `409` responses on register/profile-update no longer leak which field conflicted.
- **P2**: Structured `auth` events emitted via slog for register, login, logout, password change, PAT create/revoke. No client breaking changes — verified live against the local stack (HSTS + 429 trip at request 10 + auth events all visible in logs).