### PR TITLE
chore: align README + OpenAPI metadata with the rest of the stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,20 @@
 # librarium-api
 
-The backend service for [Librarium](https://github.com/fireball1725) — a self-hosted personal library tracker for books, manga, and other print media.
+The backend service for **[Librarium](https://librarium.press)** — a self-hosted, privacy-focused tracker for your physical book, manga, and comic collection. A self-hosted alternative to Libib and similar cloud catalog services.
 
 Go 1.25 · PostgreSQL 16 · [River](https://riverqueue.com) for background jobs · Swagger-generated OpenAPI docs.
+
+> ⚠︎ **Early beta.** Things are changing fast, some edges are rough, and self-hosters should expect to read release notes before upgrading.
+
+Part of the Librarium stack:
+
+| Repo                                                                              | Role                                                                       |
+| --------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| [`librarium`](https://github.com/fireball1725/librarium)                          | Marketing site at [librarium.press](https://librarium.press), planning docs |
+| [`librarium-api`](https://github.com/fireball1725/librarium-api) ← **you are here** | Backend · Go · Postgres · River jobs                                     |
+| [`librarium-web`](https://github.com/fireball1725/librarium-web)                  | Web client · React · TypeScript · Tailwind · Vite                          |
+| [`librarium-ios`](https://github.com/fireball1725/librarium-ios)                  | Native iOS client · SwiftUI · iOS 26+ (TestFlight)                         |
+| [`librarium-mcp`](https://github.com/fireball1725/librarium-mcp)                  | MCP server · Go · chat with your library from Claude / Cursor / etc.       |
 
 ## Quickstart (development)
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -3,11 +3,11 @@
 
 // @title           Librarium API
 // @version         26.4.0
-// @description     Self-hosted library tracking API. All protected endpoints require a Bearer JWT in the Authorization header.
-// @termsOfService  http://localhost/
+// @description     Backend API for Librarium — a self-hosted, privacy-focused tracker for your physical book, manga, and comic collection. All protected endpoints require a Bearer JWT (or `lbrm_pat_*` personal access token) in the Authorization header.
+// @termsOfService  https://librarium.press
 
 // @contact.name   Librarium
-// @contact.url    https://github.com/fireball1725/librarium
+// @contact.url    https://librarium.press
 
 // @license.name  AGPL-3.0
 // @license.url   https://www.gnu.org/licenses/agpl-3.0.html

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -9,10 +9,10 @@ const docTemplate = `{
     "info": {
         "description": "{{escape .Description}}",
         "title": "{{.Title}}",
-        "termsOfService": "http://localhost/",
+        "termsOfService": "https://librarium.press",
         "contact": {
             "name": "Librarium",
-            "url": "https://github.com/fireball1725/librarium"
+            "url": "https://librarium.press"
         },
         "license": {
             "name": "AGPL-3.0",
@@ -929,6 +929,60 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/internal_api_handlers.ScheduleView"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/jobs/schedules/{kind}/run": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Fires the kind's Enqueue hook immediately, bypassing the\ncron. Creates an umbrella jobs row with triggered_by=admin\nso the run shows up in history as admin-triggered.",
+                "tags": [
+                    "admin",
+                    "jobs"
+                ],
+                "summary": "Run a scheduled job once, now",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "job kind",
+                        "name": "kind",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "$ref": "#/definitions/internal_api_handlers.JobView"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
                         }
                     }
                 }
@@ -9736,6 +9790,124 @@ const docTemplate = `{
                 }
             }
         },
+        "/me/api-tokens": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns every personal access token minted by the caller, including revoked ones, newest first. Raw token values are never returned; only metadata plus a four-character suffix.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "me",
+                    "api-tokens"
+                ],
+                "summary": "List the caller's API tokens",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/internal_api_handlers.tokenView"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Creates a personal access token for the caller. The raw token value is returned in this response exactly once; the server stores only a sha256 hash and cannot retrieve it again. Lost tokens must be revoked and remintered.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "me",
+                    "api-tokens"
+                ],
+                "summary": "Mint a new personal access token",
+                "parameters": [
+                    {
+                        "description": "Token metadata",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_api_handlers.createTokenRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/internal_api_handlers.createTokenResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/me/api-tokens/{id}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Soft-deletes the token. Revocation takes effect immediately; subsequent auth attempts with the revoked token 401.",
+                "tags": [
+                    "me",
+                    "api-tokens"
+                ],
+                "summary": "Revoke one of the caller's API tokens",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Token UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/me/series": {
             "get": {
                 "security": [
@@ -11763,6 +11935,9 @@ const docTemplate = `{
                 "steering": {
                     "$ref": "#/definitions/internal_api_handlers.SteeringView"
                 },
+                "suggestion_count": {
+                    "type": "integer"
+                },
                 "tokens_in": {
                     "type": "integer"
                 },
@@ -11805,6 +11980,9 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "last_fired_at": {
+                    "type": "string"
+                },
+                "next_fire_at": {
                     "type": "string"
                 }
             }
@@ -11882,6 +12060,58 @@ const docTemplate = `{
                 }
             }
         },
+        "internal_api_handlers.createTokenRequest": {
+            "type": "object",
+            "properties": {
+                "expires_at": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "scopes": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "internal_api_handlers.createTokenResponse": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "expires_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "last_used_at": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "revoked_at": {
+                    "type": "string"
+                },
+                "scopes": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "token": {
+                    "type": "string"
+                },
+                "token_suffix": {
+                    "type": "string"
+                }
+            }
+        },
         "internal_api_handlers.ollamaModelsResponse": {
             "type": "object",
             "properties": {
@@ -11901,6 +12131,38 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_ai.OsaurusModel"
                     }
+                }
+            }
+        },
+        "internal_api_handlers.tokenView": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "expires_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "last_used_at": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "revoked_at": {
+                    "type": "string"
+                },
+                "scopes": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "token_suffix": {
+                    "type": "string"
                 }
             }
         },
@@ -12568,7 +12830,7 @@ var SwaggerInfo = &swag.Spec{
 	BasePath:         "/api/v1",
 	Schemes:          []string{},
 	Title:            "Librarium API",
-	Description:      "Self-hosted library tracking API. All protected endpoints require a Bearer JWT in the Authorization header.",
+	Description:      "Backend API for Librarium — a self-hosted, privacy-focused tracker for your physical book, manga, and comic collection. All protected endpoints require a Bearer JWT (or `lbrm_pat_*` personal access token) in the Authorization header.",
 	InfoInstanceName: "swagger",
 	SwaggerTemplate:  docTemplate,
 	LeftDelim:        "{{",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1,12 +1,12 @@
 {
     "swagger": "2.0",
     "info": {
-        "description": "Self-hosted library tracking API. All protected endpoints require a Bearer JWT in the Authorization header.",
+        "description": "Backend API for Librarium — a self-hosted, privacy-focused tracker for your physical book, manga, and comic collection. All protected endpoints require a Bearer JWT (or `lbrm_pat_*` personal access token) in the Authorization header.",
         "title": "Librarium API",
-        "termsOfService": "http://localhost/",
+        "termsOfService": "https://librarium.press",
         "contact": {
             "name": "Librarium",
-            "url": "https://github.com/fireball1725/librarium"
+            "url": "https://librarium.press"
         },
         "license": {
             "name": "AGPL-3.0",
@@ -923,6 +923,60 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/internal_api_handlers.ScheduleView"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/jobs/schedules/{kind}/run": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Fires the kind's Enqueue hook immediately, bypassing the\ncron. Creates an umbrella jobs row with triggered_by=admin\nso the run shows up in history as admin-triggered.",
+                "tags": [
+                    "admin",
+                    "jobs"
+                ],
+                "summary": "Run a scheduled job once, now",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "job kind",
+                        "name": "kind",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "$ref": "#/definitions/internal_api_handlers.JobView"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
                         }
                     }
                 }
@@ -9730,6 +9784,124 @@
                 }
             }
         },
+        "/me/api-tokens": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns every personal access token minted by the caller, including revoked ones, newest first. Raw token values are never returned; only metadata plus a four-character suffix.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "me",
+                    "api-tokens"
+                ],
+                "summary": "List the caller's API tokens",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/internal_api_handlers.tokenView"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Creates a personal access token for the caller. The raw token value is returned in this response exactly once; the server stores only a sha256 hash and cannot retrieve it again. Lost tokens must be revoked and remintered.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "me",
+                    "api-tokens"
+                ],
+                "summary": "Mint a new personal access token",
+                "parameters": [
+                    {
+                        "description": "Token metadata",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_api_handlers.createTokenRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/internal_api_handlers.createTokenResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/me/api-tokens/{id}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Soft-deletes the token. Revocation takes effect immediately; subsequent auth attempts with the revoked token 401.",
+                "tags": [
+                    "me",
+                    "api-tokens"
+                ],
+                "summary": "Revoke one of the caller's API tokens",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Token UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/me/series": {
             "get": {
                 "security": [
@@ -11757,6 +11929,9 @@
                 "steering": {
                     "$ref": "#/definitions/internal_api_handlers.SteeringView"
                 },
+                "suggestion_count": {
+                    "type": "integer"
+                },
                 "tokens_in": {
                     "type": "integer"
                 },
@@ -11799,6 +11974,9 @@
                     "type": "string"
                 },
                 "last_fired_at": {
+                    "type": "string"
+                },
+                "next_fire_at": {
                     "type": "string"
                 }
             }
@@ -11876,6 +12054,58 @@
                 }
             }
         },
+        "internal_api_handlers.createTokenRequest": {
+            "type": "object",
+            "properties": {
+                "expires_at": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "scopes": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "internal_api_handlers.createTokenResponse": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "expires_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "last_used_at": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "revoked_at": {
+                    "type": "string"
+                },
+                "scopes": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "token": {
+                    "type": "string"
+                },
+                "token_suffix": {
+                    "type": "string"
+                }
+            }
+        },
         "internal_api_handlers.ollamaModelsResponse": {
             "type": "object",
             "properties": {
@@ -11895,6 +12125,38 @@
                     "items": {
                         "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_ai.OsaurusModel"
                     }
+                }
+            }
+        },
+        "internal_api_handlers.tokenView": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "expires_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "last_used_at": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "revoked_at": {
+                    "type": "string"
+                },
+                "scopes": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "token_suffix": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -653,6 +653,8 @@ definitions:
         type: string
       steering:
         $ref: '#/definitions/internal_api_handlers.SteeringView'
+      suggestion_count:
+        type: integer
       tokens_in:
         type: integer
       tokens_out:
@@ -681,6 +683,8 @@ definitions:
       kind:
         type: string
       last_fired_at:
+        type: string
+      next_fire_at:
         type: string
     type: object
   internal_api_handlers.SteeringView:
@@ -731,6 +735,40 @@ definitions:
       type:
         type: string
     type: object
+  internal_api_handlers.createTokenRequest:
+    properties:
+      expires_at:
+        type: string
+      name:
+        type: string
+      scopes:
+        items:
+          type: string
+        type: array
+    type: object
+  internal_api_handlers.createTokenResponse:
+    properties:
+      created_at:
+        type: string
+      expires_at:
+        type: string
+      id:
+        type: string
+      last_used_at:
+        type: string
+      name:
+        type: string
+      revoked_at:
+        type: string
+      scopes:
+        items:
+          type: string
+        type: array
+      token:
+        type: string
+      token_suffix:
+        type: string
+    type: object
   internal_api_handlers.ollamaModelsResponse:
     properties:
       models:
@@ -744,6 +782,27 @@ definitions:
         items:
           $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_ai.OsaurusModel'
         type: array
+    type: object
+  internal_api_handlers.tokenView:
+    properties:
+      created_at:
+        type: string
+      expires_at:
+        type: string
+      id:
+        type: string
+      last_used_at:
+        type: string
+      name:
+        type: string
+      revoked_at:
+        type: string
+      scopes:
+        items:
+          type: string
+        type: array
+      token_suffix:
+        type: string
     type: object
   responses.BookResponse:
     properties:
@@ -1176,13 +1235,14 @@ host: localhost:8080
 info:
   contact:
     name: Librarium
-    url: https://github.com/fireball1725/librarium
-  description: Self-hosted library tracking API. All protected endpoints require a
-    Bearer JWT in the Authorization header.
+    url: https://librarium.press
+  description: Backend API for Librarium — a self-hosted, privacy-focused tracker
+    for your physical book, manga, and comic collection. All protected endpoints require
+    a Bearer JWT (or `lbrm_pat_*` personal access token) in the Authorization header.
   license:
     name: AGPL-3.0
     url: https://www.gnu.org/licenses/agpl-3.0.html
-  termsOfService: http://localhost/
+  termsOfService: https://librarium.press
   title: Librarium API
   version: 26.4.0
 paths:
@@ -1815,6 +1875,43 @@ paths:
       security:
       - BearerAuth: []
       summary: Upsert a job schedule
+      tags:
+      - admin
+      - jobs
+  /admin/jobs/schedules/{kind}/run:
+    post:
+      description: |-
+        Fires the kind's Enqueue hook immediately, bypassing the
+        cron. Creates an umbrella jobs row with triggered_by=admin
+        so the run shows up in history as admin-triggered.
+      parameters:
+      - description: job kind
+        in: path
+        name: kind
+        required: true
+        type: string
+      responses:
+        "202":
+          description: Accepted
+          schema:
+            $ref: '#/definitions/internal_api_handlers.JobView'
+        "400":
+          description: Bad Request
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Run a scheduled job once, now
       tags:
       - admin
       - jobs
@@ -7417,6 +7514,85 @@ paths:
       tags:
       - me
       - ai
+  /me/api-tokens:
+    get:
+      description: Returns every personal access token minted by the caller, including
+        revoked ones, newest first. Raw token values are never returned; only metadata
+        plus a four-character suffix.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/internal_api_handlers.tokenView'
+            type: array
+      security:
+      - BearerAuth: []
+      summary: List the caller's API tokens
+      tags:
+      - me
+      - api-tokens
+    post:
+      consumes:
+      - application/json
+      description: Creates a personal access token for the caller. The raw token value
+        is returned in this response exactly once; the server stores only a sha256
+        hash and cannot retrieve it again. Lost tokens must be revoked and remintered.
+      parameters:
+      - description: Token metadata
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/internal_api_handlers.createTokenRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/internal_api_handlers.createTokenResponse'
+        "400":
+          description: Bad Request
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Mint a new personal access token
+      tags:
+      - me
+      - api-tokens
+  /me/api-tokens/{id}:
+    delete:
+      description: Soft-deletes the token. Revocation takes effect immediately; subsequent
+        auth attempts with the revoked token 401.
+      parameters:
+      - description: Token UUID
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+        "404":
+          description: Not Found
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Revoke one of the caller's API tokens
+      tags:
+      - me
+      - api-tokens
   /me/series:
     get:
       description: Returns series from every library the caller can access, filtered


### PR DESCRIPTION
- README intro picks up the canonical personal-collection / Libib-alternative framing, the early-beta warning, and the standard cross-repo table with a "← you are here" marker.
- Swagger annotations (`@title` / `@description` / `@contact` / `@termsOfService`) updated to match canonical voice; `docs/` regenerated. GitHub repo description and topics set so the Librarium repos cluster in topic search.