### PR TITLE
chore: bootstrap golangci-lint + tests for the security middleware

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       # staticcheck, ineffassign, unused, bodyclose, misspell). The
       # action handles tool install + cache.
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: v2.11.4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,13 @@ jobs:
           go-version: "1.25"
           cache: true
 
-      - name: go vet
-        run: go vet ./...
+      # golangci-lint subsumes `go vet` (it runs vet plus errcheck,
+      # staticcheck, ineffassign, unused, bodyclose, misspell). The
+      # action handles tool install + cache.
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v2.11.4
 
       - name: go test
         run: go test -race -count=1 ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,59 @@
+# golangci-lint v2 configuration for librarium-api.
+#
+# First-pass baseline — establishes a quiet floor so CI stays green and
+# new code doesn't drift. Tighten later by re-enabling rules below as the
+# codebase warrants. Adding rules to a quiet tree is easy; opening a PR
+# with 50 new findings isn't.
+#
+# What's enabled:
+#
+#   standard set: errcheck, govet, ineffassign, staticcheck, unused
+#   bodyclose:    HTTP response body leaks bleed file descriptors in prod
+#   misspell:     typos in user-facing strings, doc comments, errors
+#
+# What's disabled (and why):
+#
+#   gocritic    — useful but currently flags ~6 stylistic issues across
+#                 the codebase (appendAssign on common idioms, ifElseChain
+#                 / singleCaseSwitch suggestions). Re-enable in a focused
+#                 cleanup PR.
+version: "2"
+
+run:
+  timeout: 3m
+  tests: true
+
+linters:
+  default: standard
+  enable:
+    - bodyclose
+    - misspell
+  settings:
+    errcheck:
+      # Conventional patterns where the unchecked error is intentional:
+      #   - `defer tx.Rollback(ctx)` after a successful `Commit` is a
+      #     documented pgx pattern; the second call returns
+      #     ErrTxClosed and we don't care.
+      #   - `defer rows.Close()` is the canonical pgx idiom.
+      #   - `w.Write(...)` on response writers — middleware downstream
+      #     of us handles the actual I/O failure path.
+      exclude-functions:
+        - (github.com/jackc/pgx/v5.Tx).Rollback
+        - (github.com/jackc/pgx/v5.Rows).Close
+        - (net/http.ResponseWriter).Write
+        # Deferred Close on file handles, response bodies, and other
+        # io.Closer implementations — convention is to ignore the close
+        # error, the read/write path already surfaced anything fatal.
+        - (io.Closer).Close
+        # JSON encoders here write directly to the ResponseWriter; an
+        # I/O failure surfaces via the writer, not the encoder return.
+        - (*encoding/json.Encoder).Encode
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+# Generated code is covered by its generator's own quality bar (swag for
+# docs/, etc.) — keep it out of the linter's scope.
+exclusions:
+  generated: lax

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,6 +28,10 @@ linters:
   enable:
     - bodyclose
     - misspell
+  # Generated code is covered by its generator's own quality bar (swag for
+  # docs/, etc.) — keep it out of the linter's scope.
+  exclusions:
+    generated: lax
   settings:
     errcheck:
       # Conventional patterns where the unchecked error is intentional:
@@ -52,8 +56,3 @@ linters:
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
-
-# Generated code is covered by its generator's own quality bar (swag for
-# docs/, etc.) — keep it out of the linter's scope.
-exclusions:
-  generated: lax

--- a/internal/ai/osaurus.go
+++ b/internal/ai/osaurus.go
@@ -232,7 +232,7 @@ func (p *OsaurusProvider) ListModels(ctx context.Context) ([]OsaurusModel, error
 
 	out := make([]OsaurusModel, 0, len(decoded.Data))
 	for _, m := range decoded.Data {
-		out = append(out, OsaurusModel{ID: m.ID, OwnedBy: m.OwnedBy, Created: m.Created})
+		out = append(out, OsaurusModel(m))
 	}
 	return out, nil
 }

--- a/internal/api/handlers/ai.go
+++ b/internal/api/handlers/ai.go
@@ -7,23 +7,10 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/fireball1725/librarium-api/internal/ai"
 	"github.com/fireball1725/librarium-api/internal/api/middleware"
 	"github.com/fireball1725/librarium-api/internal/api/respond"
 	"github.com/fireball1725/librarium-api/internal/service"
 )
-
-// ollamaModelsResponse wraps the Ollama /api/tags models list. Named for
-// swag — inline object{models=[]ai.OllamaModel} can't resolve the package.
-type ollamaModelsResponse struct {
-	Models []ai.OllamaModel `json:"models"`
-}
-
-// osaurusModelsResponse wraps the Osaurus /v1/models list. Same rationale
-// as ollamaModelsResponse.
-type osaurusModelsResponse struct {
-	Models []ai.OsaurusModel `json:"models"`
-}
 
 // AIHandler groups admin-side AI endpoints: provider CRUD, test, active
 // selection, and permissions policy. User-scoped endpoints (opt-in, taste

--- a/internal/api/handlers/jobs_admin.go
+++ b/internal/api/handlers/jobs_admin.go
@@ -333,7 +333,7 @@ func (h *UnifiedJobsHandler) RunNow(w http.ResponseWriter, r *http.Request) {
 	}
 	// Look up the schedule's config (if any) — admin-run uses whatever
 	// the kind has stored. Missing schedule = empty config.
-	var cfg json.RawMessage = json.RawMessage("{}")
+	cfg := json.RawMessage("{}")
 	if s, err := h.jobs.GetSchedule(r.Context(), kind); err == nil && s != nil {
 		if len(s.Config) > 0 {
 			cfg = s.Config

--- a/internal/api/middleware/rate_limit_test.go
+++ b/internal/api/middleware/rate_limit_test.go
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725 (Adaléa)
+
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// TestRateLimiter_BurstThenBlocks asserts the bucket allows exactly
+// `burst` requests in quick succession, then 429s every subsequent
+// request. This is the load-bearing behaviour for protecting
+// /auth/login from brute-force, so it gets a literal assertion.
+func TestRateLimiter_BurstThenBlocks(t *testing.T) {
+	t.Parallel()
+
+	rl := NewRateLimiter(5, 5, time.Minute)
+	handler := rl.Middleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	for i := 0; i < 5; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/auth/login", nil)
+		req.RemoteAddr = "10.0.0.1:1234"
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("request %d: status = %d, want 200", i+1, rr.Code)
+		}
+	}
+
+	// The 6th call exhausts the burst.
+	req := httptest.NewRequest(http.MethodPost, "/auth/login", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusTooManyRequests {
+		t.Errorf("over-budget request: status = %d, want 429", rr.Code)
+	}
+	if rr.Header().Get("Retry-After") == "" {
+		t.Error("over-budget response missing Retry-After header")
+	}
+}
+
+// TestRateLimiter_PerKeyIsolation verifies that one client running into
+// the limit doesn't affect a different client IP. Without per-key
+// isolation the limiter would amount to a global brake on the auth
+// endpoints — useless against credential stuffing.
+func TestRateLimiter_PerKeyIsolation(t *testing.T) {
+	t.Parallel()
+
+	rl := NewRateLimiter(2, 2, time.Minute)
+	handler := rl.Middleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// Drain client A.
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/auth/login", nil)
+		req.RemoteAddr = "10.0.0.1:1234"
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("clientA req %d: status = %d", i+1, rr.Code)
+		}
+	}
+	// Confirm A is now blocked.
+	{
+		req := httptest.NewRequest(http.MethodPost, "/auth/login", nil)
+		req.RemoteAddr = "10.0.0.1:1234"
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		if rr.Code != http.StatusTooManyRequests {
+			t.Fatalf("clientA over-budget: status = %d, want 429", rr.Code)
+		}
+	}
+	// Client B comes in fresh and gets full burst.
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/auth/login", nil)
+		req.RemoteAddr = "10.0.0.2:5678"
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Errorf("clientB req %d: status = %d, want 200 (per-key isolation broken)", i+1, rr.Code)
+		}
+	}
+}
+
+// TestRateLimiter_XForwardedFor exercises the realIP path that the
+// limiter shares with the logger middleware. Without it the limiter
+// would key every request to the proxy's IP behind Traefik, which is
+// effectively a global rate limit.
+func TestRateLimiter_XForwardedFor(t *testing.T) {
+	t.Parallel()
+
+	rl := NewRateLimiter(1, 1, time.Minute)
+	handler := rl.Middleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	send := func(xff string) int {
+		req := httptest.NewRequest(http.MethodPost, "/auth/login", nil)
+		req.RemoteAddr = "10.0.0.99:1111" // proxy
+		req.Header.Set("X-Forwarded-For", xff)
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		return rr.Code
+	}
+
+	if s := send("203.0.113.10"); s != http.StatusOK {
+		t.Fatalf("first req from 203.0.113.10: status = %d, want 200", s)
+	}
+	if s := send("203.0.113.10"); s != http.StatusTooManyRequests {
+		t.Errorf("second req from 203.0.113.10: status = %d, want 429", s)
+	}
+	// A different real IP behind the same proxy still gets its budget.
+	if s := send("203.0.113.20"); s != http.StatusOK {
+		t.Errorf("first req from 203.0.113.20: status = %d, want 200 (XFF not honoured)", s)
+	}
+}
+
+// TestRateLimiter_Refills locks in the refill behaviour so a slow
+// trickle of requests over the configured window doesn't trip 429.
+// Uses a tight interval to keep the test fast.
+func TestRateLimiter_Refills(t *testing.T) {
+	t.Parallel()
+
+	// burst=1 with 1 token / 50ms refill — easy to exercise without
+	// flaky sleeps.
+	rl := NewRateLimiter(1, 1, 50*time.Millisecond)
+	handler := rl.Middleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	send := func() int {
+		req := httptest.NewRequest(http.MethodPost, "/auth/login", nil)
+		req.RemoteAddr = "10.0.0.1:1234"
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		return rr.Code
+	}
+
+	if s := send(); s != http.StatusOK {
+		t.Fatalf("first req: status = %d, want 200", s)
+	}
+	if s := send(); s != http.StatusTooManyRequests {
+		t.Fatalf("second req (no wait): status = %d, want 429", s)
+	}
+	time.Sleep(80 * time.Millisecond)
+	if s := send(); s != http.StatusOK {
+		t.Errorf("third req (after refill): status = %d, want 200", s)
+	}
+}

--- a/internal/api/middleware/security_headers_test.go
+++ b/internal/api/middleware/security_headers_test.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725 (Adaléa)
+
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestSecurityHeaders_BasicSet asserts that every response carries the
+// fixed set of security headers — HSTS, X-Content-Type-Options,
+// X-Frame-Options, Referrer-Policy, Permissions-Policy. A regression in
+// any of these would silently relax browser-side protections, so this
+// test is deliberately literal.
+func TestSecurityHeaders_BasicSet(t *testing.T) {
+	t.Parallel()
+
+	handler := SecurityHeaders(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	want := map[string]string{
+		"Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+		"X-Content-Type-Options":    "nosniff",
+		"X-Frame-Options":           "DENY",
+		"Referrer-Policy":           "strict-origin-when-cross-origin",
+		"Permissions-Policy":        "camera=(), microphone=(), geolocation=(), payment=()",
+	}
+	for k, v := range want {
+		if got := rr.Header().Get(k); got != v {
+			t.Errorf("header %q = %q, want %q", k, got, v)
+		}
+	}
+}
+
+// TestSecurityHeaders_CSPDefault verifies that non-docs routes get the
+// tight `default-src 'none'` CSP. Anything looser on an API surface that
+// only returns JSON would be a real regression.
+func TestSecurityHeaders_CSPDefault(t *testing.T) {
+	t.Parallel()
+
+	handler := SecurityHeaders(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/libraries", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	csp := rr.Header().Get("Content-Security-Policy")
+	if !strings.Contains(csp, "default-src 'none'") {
+		t.Errorf("CSP %q missing default-src 'none'", csp)
+	}
+	if !strings.Contains(csp, "frame-ancestors 'none'") {
+		t.Errorf("CSP %q missing frame-ancestors 'none'", csp)
+	}
+	// Make sure docs-only relaxations didn't leak into the default.
+	if strings.Contains(csp, "cdn.jsdelivr.net") {
+		t.Errorf("CSP %q should not include the docs-route allowances", csp)
+	}
+}
+
+// TestSecurityHeaders_CSPDocs documents the deliberate relaxation at the
+// `/api/docs` route — Scalar UI loads its bundle from jsdelivr and emits
+// inline styles. If the docs surface ever moves, this test surfaces the
+// drop in CSP coverage so the fallback is intentional.
+func TestSecurityHeaders_CSPDocs(t *testing.T) {
+	t.Parallel()
+
+	handler := SecurityHeaders(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/docs", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	csp := rr.Header().Get("Content-Security-Policy")
+	for _, want := range []string{
+		"default-src 'self'",
+		"https://cdn.jsdelivr.net",
+		"frame-ancestors 'none'",
+	} {
+		if !strings.Contains(csp, want) {
+			t.Errorf("docs CSP %q missing %q", csp, want)
+		}
+	}
+}

--- a/internal/api/uploads/sniff_test.go
+++ b/internal/api/uploads/sniff_test.go
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725 (Adaléa)
+
+package uploads
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// pngHeader is the canonical 8-byte PNG signature followed by enough
+// bytes to round out the sniff window without depending on a real PNG.
+var pngHeader = []byte{0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n'}
+
+// jpegHeader / gifHeader / webpHeader / pdfHeader / zipHeader are
+// minimal magic-byte prefixes that net/http.DetectContentType
+// recognises. They mirror the formats SniffImage / SniffEditionFile
+// accept so the tests don't reach for external fixture files.
+var jpegHeader = []byte{0xFF, 0xD8, 0xFF, 0xE0, 0, 16, 'J', 'F', 'I', 'F', 0}
+var gifHeader = []byte("GIF89a")
+
+// webpHeader needs the VP8L (or VP8 ) sub-chunk after the WEBP marker
+// for http.DetectContentType to recognise it; an empty RIFF/WEBP
+// envelope alone returns application/octet-stream.
+var webpHeader = append([]byte("RIFF\x00\x00\x00\x00WEBPVP8L"), make([]byte, 32)...)
+var pdfHeader = []byte("%PDF-1.4\n")
+var zipHeader = []byte("PK\x03\x04")
+
+// mp3Header uses an ID3v2 prefix because that's what real MP3 files
+// almost always start with — bare frame headers (0xFF 0xFB ...) fall
+// through DetectContentType to application/octet-stream.
+var mp3Header = append([]byte("ID3\x03\x00\x00\x00\x00\x00\x00"), make([]byte, 64)...)
+
+func TestSniffImage_AcceptsAllowedTypes(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string][]byte{
+		"image/png":  pngHeader,
+		"image/jpeg": jpegHeader,
+		"image/gif":  gifHeader,
+		"image/webp": webpHeader,
+	}
+	for wantMime, head := range cases {
+		t.Run(wantMime, func(t *testing.T) {
+			got, _, err := SniffImage(bytes.NewReader(head))
+			if err != nil {
+				t.Fatalf("SniffImage(%s): unexpected error %v", wantMime, err)
+			}
+			if got != wantMime {
+				t.Errorf("SniffImage: got %q, want %q", got, wantMime)
+			}
+		})
+	}
+}
+
+// TestSniffImage_RejectsSpoofedContentType is the load-bearing
+// assertion: the previous handlers trusted the multipart Content-Type
+// header, so a `Content-Type: image/png` upload of a PDF would slip
+// through. SniffImage looks at the leading bytes; this guards against
+// regressing back to header-trust.
+func TestSniffImage_RejectsSpoofedContentType(t *testing.T) {
+	t.Parallel()
+
+	// A PDF dressed up as anything still sniffs as application/pdf.
+	_, _, err := SniffImage(bytes.NewReader(pdfHeader))
+	if !errors.Is(err, ErrUnsupportedType) {
+		t.Errorf("SniffImage(PDF bytes): err = %v, want ErrUnsupportedType", err)
+	}
+}
+
+func TestSniffImage_RejectsExecutable(t *testing.T) {
+	t.Parallel()
+
+	// MZ header — Windows PE executables.
+	_, _, err := SniffImage(bytes.NewReader([]byte("MZ\x90\x00\x03")))
+	if !errors.Is(err, ErrUnsupportedType) {
+		t.Errorf("SniffImage(PE bytes): err = %v, want ErrUnsupportedType", err)
+	}
+}
+
+// TestSniffImage_RejectsSVG documents the explicit decision to leave
+// SVG out of the image allowlist — SVG can carry script and would be a
+// stored-XSS vector if served back from the cover proxy.
+func TestSniffImage_RejectsSVG(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := SniffImage(strings.NewReader(`<svg xmlns="http://www.w3.org/2000/svg"></svg>`))
+	if !errors.Is(err, ErrUnsupportedType) {
+		t.Errorf("SniffImage(SVG): err = %v, want ErrUnsupportedType", err)
+	}
+}
+
+// TestSniffImage_HeadReturnsConsumedBytes makes sure callers can
+// reconstruct the original stream from the returned head + remaining
+// reader. The cover handlers depend on this — they prepend `head` to
+// the rest of the multipart body before persisting.
+func TestSniffImage_HeadReturnsConsumedBytes(t *testing.T) {
+	t.Parallel()
+
+	// Pad past 512 to force a full sniff read.
+	body := append([]byte{}, pngHeader...)
+	body = append(body, bytes.Repeat([]byte{0x00}, 600)...)
+
+	_, head, err := SniffImage(bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("SniffImage: unexpected error %v", err)
+	}
+	if len(head) != 512 {
+		t.Fatalf("head length = %d, want 512", len(head))
+	}
+	if !bytes.HasPrefix(head, pngHeader) {
+		t.Error("head doesn't start with the PNG signature")
+	}
+}
+
+func TestSniffEditionFile_AcceptsAllowedTypes(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string][]byte{
+		"application/pdf": pdfHeader,
+		// EPUB and CBZ files arrive as application/zip from
+		// http.DetectContentType — the service layer pins format more
+		// narrowly via the explicit `format` field.
+		"application/zip": zipHeader,
+		"audio/mpeg":      mp3Header,
+	}
+	for wantMime, head := range cases {
+		t.Run(wantMime, func(t *testing.T) {
+			got, _, err := SniffEditionFile(bytes.NewReader(head))
+			if err != nil {
+				t.Fatalf("SniffEditionFile(%s): unexpected error %v", wantMime, err)
+			}
+			if got != wantMime {
+				t.Errorf("SniffEditionFile: got %q, want %q", got, wantMime)
+			}
+		})
+	}
+}
+
+func TestSniffEditionFile_RejectsImage(t *testing.T) {
+	t.Parallel()
+
+	// An image being uploaded as an "edition file" is malformed input
+	// — the cover endpoint exists for that.
+	_, _, err := SniffEditionFile(bytes.NewReader(pngHeader))
+	if !errors.Is(err, ErrUnsupportedType) {
+		t.Errorf("SniffEditionFile(PNG): err = %v, want ErrUnsupportedType", err)
+	}
+}

--- a/internal/service/edition_files.go
+++ b/internal/service/edition_files.go
@@ -216,7 +216,7 @@ func (s *EditionFileService) UploadEditionFile(ctx context.Context, edition *mod
 	if err != nil {
 		return nil, fmt.Errorf("creating file: %w", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	written, err := io.Copy(f, reader)
 	if err != nil {


### PR DESCRIPTION
- Adds `.golangci.yml` (v2) with the standard set + bodyclose + misspell, wires it into CI via `golangci/golangci-lint-action@v6`, and clears the four genuinely-fixable issues (two dead types, two staticcheck nits, one unchecked `defer Close`) so the linter runs at zero findings.
- New unit tests for the security middleware: response-header presence + differential CSP, token-bucket rate limiter (burst, per-key isolation, X-Forwarded-For, refills), and magic-byte upload sniffing including the load-bearing "spoofed Content-Type is rejected" assertion.