### PR TITLE
chore(docs): theme /api/docs with Scalar's purple preset + brand indigo

### DIFF
--- a/internal/api/handlers/docs.go
+++ b/internal/api/handlers/docs.go
@@ -23,6 +23,13 @@ func ServeOpenAPISpec(w http.ResponseWriter, r *http.Request) {
 }
 
 // ServeScalarUI serves the Scalar API reference UI.
+//
+// Themed with Scalar's `purple` preset, which matches the Librarium
+// marketing-site brand: slate backgrounds (`#15171c` family) with an
+// indigo accent (`#5469d4` — the closest preset match to the
+// `#6366f1` we use elsewhere). The accent CSS variable is overridden
+// to the exact brand colour so docs, web UI, and the marketing site
+// land on the same indigo.
 func ServeScalarUI(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Write([]byte(`<!doctype html>
@@ -31,10 +38,23 @@ func ServeScalarUI(w http.ResponseWriter, r *http.Request) {
     <title>Librarium API Reference</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <style>body { margin: 0; }</style>
+    <style>
+      body { margin: 0; }
+      /* Pin the Scalar accent to Librarium's exact brand indigo so
+         the docs, web UI, and marketing site share one identity. The
+         purple preset's default accent (#5469d4) is a hair off the
+         #6366f1 we use elsewhere. */
+      :root {
+        --scalar-color-accent: #6366f1;
+        --scalar-color-accent-light: #818cf81f;
+      }
+    </style>
   </head>
   <body>
-    <script id="api-reference" data-url="/api/openapi.json"></script>
+    <script
+      id="api-reference"
+      data-url="/api/openapi.json"
+      data-configuration='{"theme":"purple"}'></script>
     <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
   </body>
 </html>`))


### PR DESCRIPTION
- Switches the runtime `/api/docs` Scalar reference from default to the `purple` preset (slate backgrounds + indigo accent matching the marketing site).
- Overrides `--scalar-color-accent` to `#6366f1` via a CSS variable so docs, web UI, marketing site, and iOS land on the exact same indigo. Verified the served HTML carries the new theme + accent.