### PR TITLE
feat(imports): import user-interaction fields (rating, review, status, dates)

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -6650,6 +6650,12 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
+                        "description": "User UUID to attribute reading data to (admin-only when not the caller)",
+                        "name": "attribute_to_user_id",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "string",
                         "description": "Enrich metadata after import",
                         "name": "enrich_metadata",
                         "in": "formData"
@@ -11286,6 +11292,9 @@ const docTemplate = `{
         "github_com_fireball1725_librarium-api_internal_models.ImportOptions": {
             "type": "object",
             "properties": {
+                "attribute_to_user_id": {
+                    "type": "string"
+                },
                 "default_format": {
                     "type": "string"
                 },

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -6632,8 +6632,14 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Skip duplicate ISBNs (default true)",
-                        "name": "skip_duplicates",
+                        "description": "On duplicate ISBN: bump copy count (default false)",
+                        "name": "duplicate_increment_count",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "string",
+                        "description": "On duplicate ISBN: refresh user-interaction fields from the CSV row (default false)",
+                        "name": "duplicate_update_from_csv",
                         "in": "formData"
                     },
                     {
@@ -11283,19 +11289,16 @@ const docTemplate = `{
                 "default_format": {
                     "type": "string"
                 },
+                "duplicate_increment_count": {
+                    "type": "boolean"
+                },
+                "duplicate_update_from_csv": {
+                    "type": "boolean"
+                },
                 "enrich_covers": {
                     "type": "boolean"
                 },
                 "enrich_metadata": {
-                    "type": "boolean"
-                },
-                "prefer_csv": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "boolean"
-                    }
-                },
-                "skip_duplicates": {
                     "type": "boolean"
                 }
             }

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -11796,6 +11796,13 @@ const docTemplate = `{
                 "kind": {
                     "type": "string"
                 },
+                "kind_id": {
+                    "description": "KindID is the per-kind detail row's primary key when one exists\n(import_jobs.id, enrichment_batches.id). Clients use it to deep-link\nthe umbrella row back to its detail endpoint, which is keyed by the\nper-kind id rather than the umbrella job id. Empty for kinds that\nhave no detail table (cover_backfill, ai_suggestions today).",
+                    "type": "string"
+                },
+                "library_id": {
+                    "type": "string"
+                },
                 "progress": {
                     "type": "array",
                     "items": {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -11803,6 +11803,9 @@ const docTemplate = `{
                 "library_id": {
                     "type": "string"
                 },
+                "library_name": {
+                    "type": "string"
+                },
                 "progress": {
                     "type": "array",
                     "items": {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -11833,6 +11833,10 @@ const docTemplate = `{
                 "status": {
                     "type": "string"
                 },
+                "subtype": {
+                    "description": "Subtype is the per-kind discriminator surfaced for UI badges.\nToday only enrichment uses it (\"metadata\" or \"cover\"); other\nkinds leave it empty and the client falls back to Kind alone.",
+                    "type": "string"
+                },
                 "triggered_by": {
                     "type": "string"
                 },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -11827,6 +11827,10 @@
                 "status": {
                     "type": "string"
                 },
+                "subtype": {
+                    "description": "Subtype is the per-kind discriminator surfaced for UI badges.\nToday only enrichment uses it (\"metadata\" or \"cover\"); other\nkinds leave it empty and the client falls back to Kind alone.",
+                    "type": "string"
+                },
                 "triggered_by": {
                     "type": "string"
                 },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -11790,6 +11790,13 @@
                 "kind": {
                     "type": "string"
                 },
+                "kind_id": {
+                    "description": "KindID is the per-kind detail row's primary key when one exists\n(import_jobs.id, enrichment_batches.id). Clients use it to deep-link\nthe umbrella row back to its detail endpoint, which is keyed by the\nper-kind id rather than the umbrella job id. Empty for kinds that\nhave no detail table (cover_backfill, ai_suggestions today).",
+                    "type": "string"
+                },
+                "library_id": {
+                    "type": "string"
+                },
                 "progress": {
                     "type": "array",
                     "items": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -6626,8 +6626,14 @@
                     },
                     {
                         "type": "string",
-                        "description": "Skip duplicate ISBNs (default true)",
-                        "name": "skip_duplicates",
+                        "description": "On duplicate ISBN: bump copy count (default false)",
+                        "name": "duplicate_increment_count",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "string",
+                        "description": "On duplicate ISBN: refresh user-interaction fields from the CSV row (default false)",
+                        "name": "duplicate_update_from_csv",
                         "in": "formData"
                     },
                     {
@@ -11277,19 +11283,16 @@
                 "default_format": {
                     "type": "string"
                 },
+                "duplicate_increment_count": {
+                    "type": "boolean"
+                },
+                "duplicate_update_from_csv": {
+                    "type": "boolean"
+                },
                 "enrich_covers": {
                     "type": "boolean"
                 },
                 "enrich_metadata": {
-                    "type": "boolean"
-                },
-                "prefer_csv": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "boolean"
-                    }
-                },
-                "skip_duplicates": {
                     "type": "boolean"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -11797,6 +11797,9 @@
                 "library_id": {
                     "type": "string"
                 },
+                "library_name": {
+                    "type": "string"
+                },
                 "progress": {
                     "type": "array",
                     "items": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -6644,6 +6644,12 @@
                     },
                     {
                         "type": "string",
+                        "description": "User UUID to attribute reading data to (admin-only when not the caller)",
+                        "name": "attribute_to_user_id",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "string",
                         "description": "Enrich metadata after import",
                         "name": "enrich_metadata",
                         "in": "formData"
@@ -11280,6 +11286,9 @@
         "github_com_fireball1725_librarium-api_internal_models.ImportOptions": {
             "type": "object",
             "properties": {
+                "attribute_to_user_id": {
+                    "type": "string"
+                },
                 "default_format": {
                     "type": "string"
                 },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -581,6 +581,12 @@ definitions:
         type: string
       status:
         type: string
+      subtype:
+        description: |-
+          Subtype is the per-kind discriminator surfaced for UI badges.
+          Today only enrichment uses it ("metadata" or "cover"); other
+          kinds leave it empty and the client falls back to Kind alone.
+        type: string
       triggered_by:
         type: string
       updated_at:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -208,15 +208,13 @@ definitions:
     properties:
       default_format:
         type: string
+      duplicate_increment_count:
+        type: boolean
+      duplicate_update_from_csv:
+        type: boolean
       enrich_covers:
         type: boolean
       enrich_metadata:
-        type: boolean
-      prefer_csv:
-        additionalProperties:
-          type: boolean
-        type: object
-      skip_duplicates:
         type: boolean
     type: object
   github_com_fireball1725_librarium-api_internal_models.SuggestionSteering:
@@ -5497,9 +5495,14 @@ paths:
         in: formData
         name: mapping
         type: string
-      - description: Skip duplicate ISBNs (default true)
+      - description: 'On duplicate ISBN: bump copy count (default false)'
         in: formData
-        name: skip_duplicates
+        name: duplicate_increment_count
+        type: string
+      - description: 'On duplicate ISBN: refresh user-interaction fields from the
+          CSV row (default false)'
+        in: formData
+        name: duplicate_update_from_csv
         type: string
       - description: Default edition format (default paperback)
         in: formData

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -559,6 +559,16 @@ definitions:
         type: string
       kind:
         type: string
+      kind_id:
+        description: |-
+          KindID is the per-kind detail row's primary key when one exists
+          (import_jobs.id, enrichment_batches.id). Clients use it to deep-link
+          the umbrella row back to its detail endpoint, which is keyed by the
+          per-kind id rather than the umbrella job id. Empty for kinds that
+          have no detail table (cover_backfill, ai_suggestions today).
+        type: string
+      library_id:
+        type: string
       progress:
         items:
           type: integer

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -206,6 +206,8 @@ definitions:
     - ImportJobCancelled
   github_com_fireball1725_librarium-api_internal_models.ImportOptions:
     properties:
+      attribute_to_user_id:
+        type: string
       default_format:
         type: string
       duplicate_increment_count:
@@ -5507,6 +5509,11 @@ paths:
       - description: Default edition format (default paperback)
         in: formData
         name: default_format
+        type: string
+      - description: User UUID to attribute reading data to (admin-only when not
+          the caller)
+        in: formData
+        name: attribute_to_user_id
         type: string
       - description: Enrich metadata after import
         in: formData

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -569,6 +569,8 @@ definitions:
         type: string
       library_id:
         type: string
+      library_name:
+        type: string
       progress:
         items:
           type: integer

--- a/internal/api/handlers/import.go
+++ b/internal/api/handlers/import.go
@@ -38,10 +38,11 @@ func NewImportHandler(svc *service.ImportService) *ImportHandler {
 // @Param       library_id       path      string  true   "Library UUID"
 // @Param       file             formData  file    true   "CSV file to import"
 // @Param       mapping          formData  string  false  "JSON column mapping {field_name: column_index}"
-// @Param       skip_duplicates  formData  string  false  "Skip duplicate ISBNs (default true)"
-// @Param       default_format   formData  string  false  "Default edition format (default paperback)"
-// @Param       enrich_metadata  formData  string  false  "Enrich metadata after import"
-// @Param       enrich_covers    formData  string  false  "Fetch covers after import"
+// @Param       duplicate_increment_count  formData  string  false  "On duplicate ISBN: bump copy count (default false)"
+// @Param       duplicate_update_from_csv  formData  string  false  "On duplicate ISBN: refresh user-interaction fields from the CSV row (default false)"
+// @Param       default_format             formData  string  false  "Default edition format (default paperback)"
+// @Param       enrich_metadata            formData  string  false  "Enrich metadata after import"
+// @Param       enrich_covers              formData  string  false  "Fetch covers after import"
 // @Success     201  {object}  models.ImportJob
 // @Failure     400  {object}  object{error=string}
 // @Failure     401  {object}  object{error=string}
@@ -86,18 +87,14 @@ func (h *ImportHandler) CreateImport(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Parse prefer_csv: JSON {"title": true, ...}
-	preferCSV := make(map[string]bool)
-	if preferStr := r.FormValue("prefer_csv"); preferStr != "" {
-		if err := json.Unmarshal([]byte(preferStr), &preferCSV); err != nil {
-			respond.Error(w, http.StatusBadRequest, "invalid prefer_csv JSON")
-			return
-		}
+	dupIncrement := false
+	if v := r.FormValue("duplicate_increment_count"); v != "" {
+		dupIncrement, _ = strconv.ParseBool(v)
 	}
 
-	skipDuplicates := true
-	if sd := r.FormValue("skip_duplicates"); sd != "" {
-		skipDuplicates, _ = strconv.ParseBool(sd)
+	dupUpdate := false
+	if v := r.FormValue("duplicate_update_from_csv"); v != "" {
+		dupUpdate, _ = strconv.ParseBool(v)
 	}
 
 	defaultFormat := r.FormValue("default_format")
@@ -116,15 +113,15 @@ func (h *ImportHandler) CreateImport(w http.ResponseWriter, r *http.Request) {
 	}
 
 	req := service.ImportRequest{
-		LibraryID:      libraryID,
-		CallerID:       caller.UserID,
-		CSVText:        string(csvBytes),
-		FieldMapping:   mapping,
-		SkipDuplicates: skipDuplicates,
-		DefaultFormat:  defaultFormat,
-		PreferCSV:      preferCSV,
-		EnrichMetadata: enrichMetadata,
-		EnrichCovers:   enrichCovers,
+		LibraryID:                   libraryID,
+		CallerID:                    caller.UserID,
+		CSVText:                     string(csvBytes),
+		FieldMapping:                mapping,
+		DuplicateIncrementCopyCount: dupIncrement,
+		DuplicateUpdateFromCSV:      dupUpdate,
+		DefaultFormat:               defaultFormat,
+		EnrichMetadata:              enrichMetadata,
+		EnrichCovers:                enrichCovers,
 	}
 
 	job, err := h.svc.StartImport(r.Context(), req)

--- a/internal/api/handlers/import.go
+++ b/internal/api/handlers/import.go
@@ -20,11 +20,12 @@ import (
 )
 
 type ImportHandler struct {
-	svc *service.ImportService
+	svc         *service.ImportService
+	memberships *repository.MembershipRepo
 }
 
-func NewImportHandler(svc *service.ImportService) *ImportHandler {
-	return &ImportHandler{svc: svc}
+func NewImportHandler(svc *service.ImportService, memberships *repository.MembershipRepo) *ImportHandler {
+	return &ImportHandler{svc: svc, memberships: memberships}
 }
 
 // CreateImport godoc
@@ -43,6 +44,7 @@ func NewImportHandler(svc *service.ImportService) *ImportHandler {
 // @Param       default_format             formData  string  false  "Default edition format (default paperback)"
 // @Param       enrich_metadata            formData  string  false  "Enrich metadata after import"
 // @Param       enrich_covers              formData  string  false  "Fetch covers after import"
+// @Param       attribute_to_user_id       formData  string  false  "User UUID to attribute reading data to (admin-only when not the caller)"
 // @Success     201  {object}  models.ImportJob
 // @Failure     400  {object}  object{error=string}
 // @Failure     401  {object}  object{error=string}
@@ -112,6 +114,35 @@ func (h *ImportHandler) CreateImport(w http.ResponseWriter, r *http.Request) {
 		enrichCovers, _ = strconv.ParseBool(ec)
 	}
 
+	// Optional attribution override — when set, the user-interaction
+	// fields land on this user instead of the caller. Only instance
+	// admins may attribute to someone else; everyone else either omits
+	// the field or sends their own user id (which is a no-op).
+	var attributeTo *uuid.UUID
+	if v := strings.TrimSpace(r.FormValue("attribute_to_user_id")); v != "" {
+		uid, err := uuid.Parse(v)
+		if err != nil {
+			respond.Error(w, http.StatusBadRequest, "invalid attribute_to_user_id")
+			return
+		}
+		if uid != caller.UserID {
+			if !caller.IsInstanceAdmin {
+				respond.Error(w, http.StatusForbidden, "only instance admins can attribute imports to other users")
+				return
+			}
+			isMember, err := h.memberships.IsMember(r.Context(), libraryID, uid)
+			if err != nil {
+				respond.ServerError(w, r, err)
+				return
+			}
+			if !isMember {
+				respond.Error(w, http.StatusBadRequest, "attribute_to_user_id is not a member of this library")
+				return
+			}
+			attributeTo = &uid
+		}
+	}
+
 	req := service.ImportRequest{
 		LibraryID:                   libraryID,
 		CallerID:                    caller.UserID,
@@ -122,6 +153,7 @@ func (h *ImportHandler) CreateImport(w http.ResponseWriter, r *http.Request) {
 		DefaultFormat:               defaultFormat,
 		EnrichMetadata:              enrichMetadata,
 		EnrichCovers:                enrichCovers,
+		AttributeToUserID:           attributeTo,
 	}
 
 	job, err := h.svc.StartImport(r.Context(), req)

--- a/internal/api/handlers/jobs_admin.go
+++ b/internal/api/handlers/jobs_admin.go
@@ -31,12 +31,14 @@ var cronParser = cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month 
 // Jobs page keeps working until the web PR lands on these unified
 // endpoints.
 type UnifiedJobsHandler struct {
-	jobs     *repository.JobRepo
-	registry *jobs.Registry
+	jobs        *repository.JobRepo
+	registry    *jobs.Registry
+	importJobs  *repository.ImportJobRepo
+	enrichments *repository.EnrichmentBatchRepo
 }
 
-func NewUnifiedJobsHandler(jr *repository.JobRepo, registry *jobs.Registry) *UnifiedJobsHandler {
-	return &UnifiedJobsHandler{jobs: jr, registry: registry}
+func NewUnifiedJobsHandler(jr *repository.JobRepo, registry *jobs.Registry, importJobs *repository.ImportJobRepo, enrichments *repository.EnrichmentBatchRepo) *UnifiedJobsHandler {
+	return &UnifiedJobsHandler{jobs: jr, registry: registry, importJobs: importJobs, enrichments: enrichments}
 }
 
 // JobView is the wire-shape for one unified job row. Progress is a
@@ -55,6 +57,13 @@ type JobView struct {
 	FinishedAt  *time.Time      `json:"finished_at,omitempty"`
 	CreatedAt   time.Time       `json:"created_at"`
 	UpdatedAt   time.Time       `json:"updated_at"`
+	// KindID is the per-kind detail row's primary key when one exists
+	// (import_jobs.id, enrichment_batches.id). Clients use it to deep-link
+	// the umbrella row back to its detail endpoint, which is keyed by the
+	// per-kind id rather than the umbrella job id. Empty for kinds that
+	// have no detail table (cover_backfill, ai_suggestions today).
+	KindID    *string `json:"kind_id,omitempty"`
+	LibraryID *string `json:"library_id,omitempty"`
 }
 
 func toJobView(j *models.Job) JobView {
@@ -130,9 +139,52 @@ func (h *UnifiedJobsHandler) History(w http.ResponseWriter, r *http.Request) {
 		respond.ServerError(w, r, err)
 		return
 	}
+
+	// Collect umbrella ids per kind so the per-kind detail tables can be
+	// resolved in a single query each. The unified row carries no detail
+	// pointer of its own — the web needs (kind_id, library_id) to call
+	// the existing per-kind GET endpoints, and without these the items
+	// list silently renders as "No items".
+	var importIDs, enrichIDs []uuid.UUID
+	for _, j := range items {
+		switch j.Kind {
+		case "import":
+			importIDs = append(importIDs, j.ID)
+		case "enrichment":
+			enrichIDs = append(enrichIDs, j.ID)
+		}
+	}
+	importRefs, err := h.importJobs.LookupByJobIDs(r.Context(), importIDs)
+	if err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
+	enrichRefs, err := h.enrichments.LookupByJobIDs(r.Context(), enrichIDs)
+	if err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
+
 	out := make([]JobView, 0, len(items))
 	for _, j := range items {
-		out = append(out, toJobView(j))
+		v := toJobView(j)
+		var ref repository.JobRef
+		var ok bool
+		switch j.Kind {
+		case "import":
+			ref, ok = importRefs[j.ID]
+		case "enrichment":
+			ref, ok = enrichRefs[j.ID]
+		}
+		if ok {
+			id := ref.ID.String()
+			v.KindID = &id
+			if ref.LibraryID != (uuid.UUID{}) {
+				lid := ref.LibraryID.String()
+				v.LibraryID = &lid
+			}
+		}
+		out = append(out, v)
 	}
 	respond.JSON(w, http.StatusOK, map[string]any{"items": out, "total": total})
 }

--- a/internal/api/handlers/jobs_admin.go
+++ b/internal/api/handlers/jobs_admin.go
@@ -65,6 +65,10 @@ type JobView struct {
 	KindID      *string `json:"kind_id,omitempty"`
 	LibraryID   *string `json:"library_id,omitempty"`
 	LibraryName *string `json:"library_name,omitempty"`
+	// Subtype is the per-kind discriminator surfaced for UI badges.
+	// Today only enrichment uses it ("metadata" or "cover"); other
+	// kinds leave it empty and the client falls back to Kind alone.
+	Subtype *string `json:"subtype,omitempty"`
 }
 
 func toJobView(j *models.Job) JobView {
@@ -187,6 +191,10 @@ func (h *UnifiedJobsHandler) History(w http.ResponseWriter, r *http.Request) {
 			if ref.LibraryName != "" {
 				name := ref.LibraryName
 				v.LibraryName = &name
+			}
+			if ref.Subtype != "" {
+				st := ref.Subtype
+				v.Subtype = &st
 			}
 		}
 		out = append(out, v)

--- a/internal/api/handlers/jobs_admin.go
+++ b/internal/api/handlers/jobs_admin.go
@@ -62,8 +62,9 @@ type JobView struct {
 	// the umbrella row back to its detail endpoint, which is keyed by the
 	// per-kind id rather than the umbrella job id. Empty for kinds that
 	// have no detail table (cover_backfill, ai_suggestions today).
-	KindID    *string `json:"kind_id,omitempty"`
-	LibraryID *string `json:"library_id,omitempty"`
+	KindID      *string `json:"kind_id,omitempty"`
+	LibraryID   *string `json:"library_id,omitempty"`
+	LibraryName *string `json:"library_name,omitempty"`
 }
 
 func toJobView(j *models.Job) JobView {
@@ -182,6 +183,10 @@ func (h *UnifiedJobsHandler) History(w http.ResponseWriter, r *http.Request) {
 			if ref.LibraryID != (uuid.UUID{}) {
 				lid := ref.LibraryID.String()
 				v.LibraryID = &lid
+			}
+			if ref.LibraryName != "" {
+				name := ref.LibraryName
+				v.LibraryName = &name
 			}
 		}
 		out = append(out, v)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -114,7 +114,7 @@ func NewRouter(ctx context.Context, db *pgxpool.Pool, cfg *config.Config, riverC
 	shelfHandler := handlers.NewShelfHandler(shelfSvc)
 	loanHandler := handlers.NewLoanHandler(loanSvc)
 	seriesHandler := handlers.NewSeriesHandler(seriesSvc, releaseSyncSvc)
-	importHandler := handlers.NewImportHandler(importSvc)
+	importHandler := handlers.NewImportHandler(importSvc, membershipRepo)
 	genreHandler := handlers.NewGenreHandler(genreRepo)
 	mediaTypeHandler := handlers.NewMediaTypeHandler(mediaTypeRepo)
 	enrichmentHandler := handlers.NewEnrichmentBatchHandler(enrichmentBatchRepo)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -103,7 +103,7 @@ func NewRouter(ctx context.Context, db *pgxpool.Pool, cfg *config.Config, riverC
 	aiHandler := handlers.NewAIHandler(aiSvc)
 	aiUserHandler := handlers.NewAIUserHandler(aiUserSvc)
 	jobsHandler := handlers.NewJobsHandler(jobSvc)
-	unifiedJobsHandler := handlers.NewUnifiedJobsHandler(repository.NewJobRepo(db), deps.JobRegistry)
+	unifiedJobsHandler := handlers.NewUnifiedJobsHandler(repository.NewJobRepo(db), deps.JobRegistry, importJobRepo, enrichmentBatchRepo)
 	aiSuggestionsHandler := handlers.NewAISuggestionsHandler(aiSuggestionsRepo, riverClient, jobSvc, aiSvc)
 
 	authHandler := handlers.NewAuthHandler(authSvc, preferencesRepo)

--- a/internal/imports/normalize.go
+++ b/internal/imports/normalize.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725 (Adaléa)
+
+// Package normalize collects pure-function CSV-to-Librarium converters
+// shared between the import service and worker. Lives outside the
+// worker package so it can be unit-tested without spinning up Postgres
+// or River.
+//
+// Source-aware mapping is intentionally absent: the normalizers are
+// broad whitelists that recognise values from Goodreads, StoryGraph,
+// and Libib in a single pass. Their value sets are mostly disjoint
+// (Libib uses Title-Case English; Goodreads uses kebab-case shelf
+// names) so disambiguation falls out for free, and the importer
+// doesn't need a source hint at this layer.
+package imports
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// ReadStatus maps a CSV value to one of Librarium's canonical
+// `user_book_interactions.read_status` values: `unread`, `reading`,
+// `read`, `did_not_finish`. Returns "" when the input doesn't match
+// any known status — caller should treat that as "leave existing
+// status alone" rather than overwriting with an empty value.
+func ReadStatus(raw string) string {
+	v := strings.ToLower(strings.TrimSpace(raw))
+	if v == "" {
+		return ""
+	}
+	switch v {
+	// ── Read / completed ──────────────────────────────────────────
+	// Goodreads + StoryGraph: "read"
+	// Libib: "Completed", and historically the user-rating-only rows
+	// implicitly meant "completed", though that decision is left to
+	// the caller (we only mark `read` when the field is explicit).
+	case "read", "completed", "finished":
+		return "read"
+
+	// ── Currently reading ─────────────────────────────────────────
+	// Goodreads + StoryGraph: "currently-reading"
+	// Libib: "In Progress"
+	case "reading", "currently-reading", "currently reading", "in progress":
+		return "reading"
+
+	// ── Did not finish ────────────────────────────────────────────
+	// StoryGraph: "did-not-finish"
+	// Libib: "Abandoned"
+	case "did_not_finish", "did-not-finish", "abandoned", "dnf":
+		return "did_not_finish"
+
+	// ── Unread / to-read / on hold ────────────────────────────────
+	// Goodreads + StoryGraph: "to-read"
+	// Libib: "Not Begun", "On Hold"
+	// All collapse to `unread` — Librarium tracks "want to read" via
+	// shelves rather than a distinct status. Importers that want to
+	// preserve "want to read" should also create a shelf and add the
+	// book to it; that's a layer above this normalizer.
+	case "unread", "to-read", "to read", "not begun", "want to read", "on hold":
+		return "unread"
+	}
+	return ""
+}
+
+// Rating converts a CSV rating to Librarium's 1–10 integer scale.
+// Sources differ: Libib uses 0–5 with half-step precision (`5.0`,
+// `4.5`), Goodreads uses 1–5 whole, StoryGraph 1–5 quarter-step
+// (`3.25`). We accept any numeric in [0, 5] and double + round to
+// produce 1–10. Returns (value, true) on success; (0, false) when
+// the input is empty, unparseable, or out of range. A rating of 0
+// is also treated as "no rating" since both Libib and StoryGraph use
+// 0 to mean "unrated" rather than literal zero stars.
+func Rating(raw string) (int, bool) {
+	v := strings.TrimSpace(raw)
+	if v == "" {
+		return 0, false
+	}
+	// Strip a trailing " stars" / "/5" if a source ever emits one.
+	v = strings.TrimSuffix(v, " stars")
+	v = strings.TrimSuffix(v, "/5")
+	v = strings.TrimSpace(v)
+
+	var f float64
+	if _, err := fmt.Sscanf(v, "%f", &f); err != nil {
+		return 0, false
+	}
+	if f <= 0 || f > 5 {
+		return 0, false
+	}
+	// Round half-up to the nearest 0.5, then double to get 1–10.
+	half := int((f * 2) + 0.5)
+	if half < 1 || half > 10 {
+		return 0, false
+	}
+	return half, true
+}
+
+// Date parses a CSV date in any of the formats the three target
+// trackers emit. Goodreads writes `2024/03/15`; StoryGraph writes
+// `2024-03-15`; Libib uses `2024-03-15` and sometimes `2024-03` for
+// month-only entries. Year-only is also accepted because "added"
+// timestamps in older exports can degrade to that.
+func Date(raw string) (time.Time, bool) {
+	v := strings.TrimSpace(raw)
+	if v == "" {
+		return time.Time{}, false
+	}
+	// Goodreads' format uses `/` separators; everything else is `-`.
+	v = strings.ReplaceAll(v, "/", "-")
+	for _, layout := range []string{
+		"2006-01-02",
+		"2006-01-02 15:04:05",
+		"2006-01",
+		"2006",
+		"January 2, 2006",
+		"Jan 2, 2006",
+	} {
+		if t, err := time.Parse(layout, v); err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
+}
+
+// Bool maps common CSV truthy/falsy values to a Go bool. Returns
+// (value, true) when recognised, (false, false) when unparseable.
+// Used for the optional `is_favorite` import field — Goodreads and
+// StoryGraph don't emit one, but a generic CSV authored against
+// Librarium's own export could.
+func Bool(raw string) (bool, bool) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "true", "yes", "y", "1", "favorite", "favourite":
+		return true, true
+	case "false", "no", "n", "0", "":
+		// Empty string is "no" rather than "unspecified" because the
+		// CSV column simply not having a marker in a row is the
+		// universal way of saying "not a favourite".
+		return false, true
+	}
+	return false, false
+}
+

--- a/internal/imports/normalize_test.go
+++ b/internal/imports/normalize_test.go
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725 (Adaléa)
+
+package imports
+
+import (
+	"testing"
+	"time"
+)
+
+func TestReadStatus(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		// ── Read / completed ──────────────────────────────────────
+		{"goodreads/storygraph: read", "read", "read"},
+		{"libib: Completed", "Completed", "read"},
+		{"capitalised + extra whitespace: Finished", "  FINISHED  ", "read"},
+
+		// ── Currently reading ─────────────────────────────────────
+		{"goodreads: currently-reading", "currently-reading", "reading"},
+		{"storygraph: currently-reading", "currently-reading", "reading"},
+		{"libib: In Progress", "In Progress", "reading"},
+		{"libib: in progress (lowercase)", "in progress", "reading"},
+
+		// ── Did not finish ────────────────────────────────────────
+		{"storygraph: did-not-finish", "did-not-finish", "did_not_finish"},
+		{"libib: Abandoned", "Abandoned", "did_not_finish"},
+		{"shorthand: dnf", "DNF", "did_not_finish"},
+
+		// ── Unread / to-read / on hold ────────────────────────────
+		{"goodreads: to-read", "to-read", "unread"},
+		{"libib: Not Begun", "Not Begun", "unread"},
+		{"libib: On Hold", "On Hold", "unread"},
+
+		// ── Empty / unrecognised → "" ─────────────────────────────
+		{"empty", "", ""},
+		{"whitespace only", "   ", ""},
+		{"unknown value", "in flight", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := ReadStatus(c.in)
+			if got != c.want {
+				t.Errorf("ReadStatus(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestRating(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		in        string
+		wantValue int
+		wantOK    bool
+	}{
+		// ── Libib (0–5 with halves) — the actual values from the
+		// user's Libib export ──────────────────────────────────────
+		{"libib 5.0", "5.0", 10, true},
+		{"libib 4.5", "4.5", 9, true},
+		{"libib 3.0", "3.0", 6, true},
+		{"libib 1.5", "1.5", 3, true},
+		{"libib 0.5", "0.5", 1, true},
+
+		// ── Goodreads (1–5 whole stars) ───────────────────────────
+		{"goodreads 5", "5", 10, true},
+		{"goodreads 1", "1", 2, true},
+
+		// ── StoryGraph (1–5 quarter precision) — round half-up ───
+		{"storygraph 3.25 → rounds to 3.5 → 7", "3.25", 7, true},
+		{"storygraph 4.75 → rounds to 5 → 10", "4.75", 10, true},
+
+		// ── Empty / zero / out-of-range → no rating ──────────────
+		{"empty", "", 0, false},
+		{"zero (unrated)", "0", 0, false},
+		{"zero with decimal", "0.0", 0, false},
+		{"out of range high", "5.5", 0, false},
+		{"out of range negative", "-1", 0, false},
+		{"non-numeric", "not-a-number", 0, false},
+
+		// ── Format quirks ─────────────────────────────────────────
+		{"with whitespace", "  4.0  ", 8, true},
+		{"with stars suffix", "3.0 stars", 6, true},
+		{"with /5 suffix", "4/5", 8, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, ok := Rating(c.in)
+			if ok != c.wantOK || got != c.wantValue {
+				t.Errorf("Rating(%q) = (%d, %v), want (%d, %v)",
+					c.in, got, ok, c.wantValue, c.wantOK)
+			}
+		})
+	}
+}
+
+func TestDate(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		in     string
+		wantOK bool
+		// We don't pin the exact time.Time on success — just check
+		// the parsed Y/M/D matches expectations to keep timezone
+		// noise out.
+		wantY, wantM, wantD int
+	}{
+		// ── Libib (ISO 8601, full date) — actual format from the
+		// user's export. ──────────────────────────────────────────
+		{"libib 2022-04-11", "2022-04-11", true, 2022, 4, 11},
+		{"libib 2005-11-01 (publish_date sample)", "2005-11-01", true, 2005, 11, 1},
+
+		// ── Goodreads (slashes) ───────────────────────────────────
+		{"goodreads 2024/03/15", "2024/03/15", true, 2024, 3, 15},
+
+		// ── StoryGraph (also ISO) ─────────────────────────────────
+		{"storygraph 2024-03-15", "2024-03-15", true, 2024, 3, 15},
+
+		// ── Month-only / year-only fallbacks ──────────────────────
+		{"month-only 2017-09", "2017-09", true, 2017, 9, 1},
+		{"year-only 2005", "2005", true, 2005, 1, 1},
+
+		// ── ISO datetime (some exports include time) ──────────────
+		{"datetime", "2024-03-15 10:30:00", true, 2024, 3, 15},
+
+		// ── Long-form English ─────────────────────────────────────
+		{"long form", "March 15, 2024", true, 2024, 3, 15},
+
+		// ── Unparseable / empty ───────────────────────────────────
+		{"empty", "", false, 0, 0, 0},
+		{"garbage", "not a date", false, 0, 0, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, ok := Date(c.in)
+			if ok != c.wantOK {
+				t.Fatalf("Date(%q) ok = %v, want %v", c.in, ok, c.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if got.Year() != c.wantY || int(got.Month()) != c.wantM || got.Day() != c.wantD {
+				t.Errorf("Date(%q) = %v, want %d-%02d-%02d",
+					c.in, got.Format(time.RFC3339), c.wantY, c.wantM, c.wantD)
+			}
+		})
+	}
+}
+
+func TestBool(t *testing.T) {
+	t.Parallel()
+
+	for _, in := range []string{"true", "TRUE", "yes", "Yes", "y", "1", "favorite", "favourite"} {
+		got, ok := Bool(in)
+		if !ok || !got {
+			t.Errorf("Bool(%q) = (%v, %v), want (true, true)", in, got, ok)
+		}
+	}
+	for _, in := range []string{"false", "no", "n", "0", ""} {
+		got, ok := Bool(in)
+		if !ok || got {
+			t.Errorf("Bool(%q) = (%v, %v), want (false, true)", in, got, ok)
+		}
+	}
+	// Unrecognised values are reported as "couldn't parse" so callers
+	// can decide whether to default-true or default-false themselves.
+	got, ok := Bool("maybe")
+	if ok || got {
+		t.Errorf("Bool(\"maybe\") = (%v, %v), want (false, false)", got, ok)
+	}
+}

--- a/internal/models/import_job.go
+++ b/internal/models/import_job.go
@@ -36,13 +36,21 @@ const (
 	ImportItemFailed   ImportItemStatus = "failed"
 )
 
-// ImportOptions holds per-import configuration stored in the DB.
+// ImportOptions holds per-import configuration stored in the DB. The
+// duplicate_* flags replace the older skip_duplicates toggle: with both
+// off (the default) a duplicate ISBN is left untouched; turn either on
+// to opt into bumping the copy count or refreshing the user-interaction
+// fields from the CSV row. They compose, so both can be on at once.
+//
+// EnrichMetadata is fill-in-the-blanks only — the post-import enrichment
+// run never overwrites a populated CSV field, so there is no per-field
+// "prefer CSV" knob to keep here.
 type ImportOptions struct {
-	SkipDuplicates  bool            `json:"skip_duplicates"`
-	DefaultFormat   string          `json:"default_format"`
-	PreferCSV       map[string]bool `json:"prefer_csv"`
-	EnrichMetadata  bool            `json:"enrich_metadata"`
-	EnrichCovers    bool            `json:"enrich_covers"`
+	DuplicateIncrementCopyCount bool   `json:"duplicate_increment_count"`
+	DuplicateUpdateFromCSV      bool   `json:"duplicate_update_from_csv"`
+	DefaultFormat               string `json:"default_format"`
+	EnrichMetadata              bool   `json:"enrich_metadata"`
+	EnrichCovers                bool   `json:"enrich_covers"`
 }
 
 // MetadataEnrichmentJobArgs is the River job payload for async metadata enrichment.

--- a/internal/models/import_job.go
+++ b/internal/models/import_job.go
@@ -45,12 +45,19 @@ const (
 // EnrichMetadata is fill-in-the-blanks only — the post-import enrichment
 // run never overwrites a populated CSV field, so there is no per-field
 // "prefer CSV" knob to keep here.
+//
+// AttributeToUserID redirects the user-interaction fields (read status,
+// rating, review, dates, favourite) to a specific library member. When
+// nil, the worker falls back to ImportJob.CreatedBy so a self-import
+// behaves the same as before. Only instance admins may set a value
+// other than the caller — the handler enforces that.
 type ImportOptions struct {
-	DuplicateIncrementCopyCount bool   `json:"duplicate_increment_count"`
-	DuplicateUpdateFromCSV      bool   `json:"duplicate_update_from_csv"`
-	DefaultFormat               string `json:"default_format"`
-	EnrichMetadata              bool   `json:"enrich_metadata"`
-	EnrichCovers                bool   `json:"enrich_covers"`
+	DuplicateIncrementCopyCount bool       `json:"duplicate_increment_count"`
+	DuplicateUpdateFromCSV      bool       `json:"duplicate_update_from_csv"`
+	DefaultFormat               string     `json:"default_format"`
+	EnrichMetadata              bool       `json:"enrich_metadata"`
+	EnrichCovers                bool       `json:"enrich_covers"`
+	AttributeToUserID           *uuid.UUID `json:"attribute_to_user_id,omitempty"`
 }
 
 // MetadataEnrichmentJobArgs is the River job payload for async metadata enrichment.

--- a/internal/repository/editions.go
+++ b/internal/repository/editions.go
@@ -295,6 +295,60 @@ func (r *EditionRepo) UpsertInteraction(ctx context.Context, userID, editionID u
 	return i, nil
 }
 
+// MergeInteraction is the import-safe variant of UpsertInteraction:
+// every argument is a pointer (or nullable any) and a nil value
+// preserves whatever the existing row holds. The full-overwrite
+// version is correct for the manual edit flow (the client always sends
+// the complete record), but is destructive for CSV imports where a
+// blank column means "no data" rather than "set to empty".
+//
+// String columns treat empty as no-input via NULLIF; nullable columns
+// treat nil the same way. is_favorite has to be tri-state, so it
+// takes a *bool — pass nil to leave the existing flag alone.
+func (r *EditionRepo) MergeInteraction(
+	ctx context.Context,
+	userID, editionID uuid.UUID,
+	readStatus *string,
+	rating any,
+	notes, review *string,
+	dateStarted, dateFinished any,
+	isFavorite *bool,
+) (*models.UserBookInteraction, error) {
+	const q = `
+		INSERT INTO user_book_interactions
+			(id, user_id, book_edition_id, read_status, rating, notes, review, date_started, date_finished, is_favorite)
+		VALUES
+			($1, $2, $3, COALESCE(NULLIF($4,''),''), $5, NULLIF($6,''), NULLIF($7,''), $8, $9, COALESCE($10, false))
+		ON CONFLICT (user_id, book_edition_id) DO UPDATE
+		SET read_status   = COALESCE(NULLIF(EXCLUDED.read_status,''), user_book_interactions.read_status),
+		    rating        = COALESCE(EXCLUDED.rating, user_book_interactions.rating),
+		    notes         = COALESCE(EXCLUDED.notes, user_book_interactions.notes),
+		    review        = COALESCE(EXCLUDED.review, user_book_interactions.review),
+		    date_started  = COALESCE(EXCLUDED.date_started, user_book_interactions.date_started),
+		    date_finished = COALESCE(EXCLUDED.date_finished, user_book_interactions.date_finished),
+		    is_favorite   = COALESCE($10, user_book_interactions.is_favorite),
+		    updated_at    = NOW()
+		RETURNING ` + interactionColumns
+
+	rs := ""
+	if readStatus != nil {
+		rs = *readStatus
+	}
+	nt := ""
+	if notes != nil {
+		nt = *notes
+	}
+	rv := ""
+	if review != nil {
+		rv = *review
+	}
+	i, err := scanInteraction(r.db.QueryRow(ctx, q, uuid.New(), userID, editionID, rs, rating, nt, rv, dateStarted, dateFinished, isFavorite))
+	if err != nil {
+		return nil, fmt.Errorf("merging interaction: %w", err)
+	}
+	return i, nil
+}
+
 func (r *EditionRepo) DeleteInteraction(ctx context.Context, userID, editionID uuid.UUID) error {
 	result, err := r.db.Exec(ctx,
 		`DELETE FROM user_book_interactions WHERE user_id = $1 AND book_edition_id = $2`,

--- a/internal/repository/enrichment_batches.go
+++ b/internal/repository/enrichment_batches.go
@@ -263,7 +263,9 @@ func (r *EnrichmentBatchRepo) UpdateStatus(ctx context.Context, id uuid.UUID, st
 
 // IncrementProcessed atomically increments the processed/failed/skipped counters.
 // Never overwrites a 'cancelled' status. Returns the updated processed, failed, and
-// total counts so the caller can determine if the batch is complete.
+// total counts so the caller can determine if the batch is complete. Also mirrors
+// the new counters to the umbrella jobs.progress so the unified history's progress
+// bar advances per-book instead of jumping from 0 to total at the very end.
 func (r *EnrichmentBatchRepo) IncrementProcessed(ctx context.Context, id uuid.UUID, failed, skipped bool) (processed, failedCount, total int, err error) {
 	var q string
 	switch {
@@ -274,7 +276,7 @@ func (r *EnrichmentBatchRepo) IncrementProcessed(ctx context.Context, id uuid.UU
 			       processed_books = processed_books + 1,
 			       updated_at      = now()
 			WHERE  id = $1 AND status != 'cancelled'
-			RETURNING processed_books, failed_books, total_books`
+			RETURNING processed_books, failed_books, skipped_books, total_books, job_id`
 	case skipped:
 		q = `
 			UPDATE enrichment_batches
@@ -282,21 +284,37 @@ func (r *EnrichmentBatchRepo) IncrementProcessed(ctx context.Context, id uuid.UU
 			       processed_books = processed_books + 1,
 			       updated_at      = now()
 			WHERE  id = $1 AND status != 'cancelled'
-			RETURNING processed_books, failed_books, total_books`
+			RETURNING processed_books, failed_books, skipped_books, total_books, job_id`
 	default:
 		q = `
 			UPDATE enrichment_batches
 			SET    processed_books = processed_books + 1,
 			       updated_at      = now()
 			WHERE  id = $1 AND status != 'cancelled'
-			RETURNING processed_books, failed_books, total_books`
+			RETURNING processed_books, failed_books, skipped_books, total_books, job_id`
 	}
-	err = r.db.QueryRow(ctx, q, id).Scan(&processed, &failedCount, &total)
+	var (
+		skippedCount int
+		pgJobID      pgtype.UUID
+	)
+	err = r.db.QueryRow(ctx, q, id).Scan(&processed, &failedCount, &skippedCount, &total, &pgJobID)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return 0, 0, 0, ErrNotFound
 	}
 	if err != nil {
 		return 0, 0, 0, fmt.Errorf("incrementing processed count: %w", err)
+	}
+	if pgJobID.Valid {
+		const updProgress = `
+			UPDATE jobs
+			   SET progress = jsonb_build_object('processed', $2::int, 'failed', $3::int, 'skipped', $4::int, 'total', $5::int)
+			 WHERE id = $1`
+		if _, perr := r.db.Exec(ctx, updProgress, uuid.UUID(pgJobID.Bytes), processed, failedCount, skippedCount, total); perr != nil {
+			// Counters in the per-kind row are authoritative; a missed
+			// mirror just means the unified bar trails by one tick.
+			// Don't fail the worker over a UI counter.
+			return processed, failedCount, total, nil
+		}
 	}
 	return processed, failedCount, total, nil
 }
@@ -328,18 +346,37 @@ func (r *EnrichmentBatchRepo) ListByUser(ctx context.Context, userID uuid.UUID) 
 	return out, rows.Err()
 }
 
-// Cancel marks a pending or processing batch as cancelled.
+// Cancel marks a pending or processing batch as cancelled. Also mirrors
+// the cancellation to the umbrella jobs row so the unified history flips
+// out of "Processing" — without this the worker eventually picks up the
+// per-kind cancellation and stops, but the UI keeps spinning until the
+// job naturally finishes.
 func (r *EnrichmentBatchRepo) Cancel(ctx context.Context, batchID, userID uuid.UUID) error {
 	const q = `
 		UPDATE enrichment_batches
 		SET    status = 'cancelled', updated_at = now()
-		WHERE  id = $1 AND created_by = $2 AND status IN ('pending', 'processing')`
-	tag, err := r.db.Exec(ctx, q, batchID, userID)
-	if err != nil {
+		WHERE  id = $1 AND created_by = $2 AND status IN ('pending', 'processing')
+		RETURNING job_id, processed_books, failed_books, skipped_books, total_books`
+	var (
+		pgJobID                            pgtype.UUID
+		processed, failed, skipped, total  int
+	)
+	if err := r.db.QueryRow(ctx, q, batchID, userID).Scan(&pgJobID, &processed, &failed, &skipped, &total); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrNotFound
+		}
 		return fmt.Errorf("cancelling enrichment batch: %w", err)
 	}
-	if tag.RowsAffected() == 0 {
-		return ErrNotFound
+	if pgJobID.Valid {
+		const updJob = `
+			UPDATE jobs
+			   SET status      = 'cancelled',
+			       progress    = jsonb_build_object('processed', $2::int, 'failed', $3::int, 'skipped', $4::int, 'total', $5::int),
+			       finished_at = COALESCE(finished_at, NOW())
+			 WHERE id = $1`
+		if _, err := r.db.Exec(ctx, updJob, uuid.UUID(pgJobID.Bytes), processed, failed, skipped, total); err != nil {
+			return fmt.Errorf("mirroring cancel to umbrella job: %w", err)
+		}
 	}
 	return nil
 }
@@ -420,7 +457,7 @@ func (r *EnrichmentBatchRepo) LookupByJobIDs(ctx context.Context, jobIDs []uuid.
 		return out, nil
 	}
 	const q = `
-		SELECT eb.id, eb.library_id, eb.job_id, l.name
+		SELECT eb.id, eb.library_id, eb.job_id, l.name, eb.type
 		FROM   enrichment_batches eb
 		LEFT JOIN libraries l ON l.id = eb.library_id
 		WHERE  eb.job_id = ANY($1)`
@@ -432,10 +469,14 @@ func (r *EnrichmentBatchRepo) LookupByJobIDs(ctx context.Context, jobIDs []uuid.
 	for rows.Next() {
 		var pgID, pgLibraryID, pgJobID pgtype.UUID
 		var libName *string
-		if err := rows.Scan(&pgID, &pgLibraryID, &pgJobID, &libName); err != nil {
+		var batchType string
+		if err := rows.Scan(&pgID, &pgLibraryID, &pgJobID, &libName, &batchType); err != nil {
 			return nil, fmt.Errorf("scanning batch ref: %w", err)
 		}
-		ref := JobRef{ID: uuid.UUID(pgID.Bytes)}
+		ref := JobRef{
+			ID:      uuid.UUID(pgID.Bytes),
+			Subtype: batchType,
+		}
 		if pgLibraryID.Valid {
 			ref.LibraryID = uuid.UUID(pgLibraryID.Bytes)
 		}

--- a/internal/repository/enrichment_batches.go
+++ b/internal/repository/enrichment_batches.go
@@ -410,6 +410,38 @@ func scanBatch(s batchScanner) (*models.EnrichmentBatch, error) {
 	return &b, nil
 }
 
+// LookupByJobIDs maps umbrella job_id → (enrichment_batches.id, library_id)
+// for every input id with a matching row. library_id is nullable for
+// enrichment batches (post-000009 migration); a missing/null value yields
+// the zero UUID. Missing rows are silently absent from the returned map.
+func (r *EnrichmentBatchRepo) LookupByJobIDs(ctx context.Context, jobIDs []uuid.UUID) (map[uuid.UUID]JobRef, error) {
+	out := make(map[uuid.UUID]JobRef, len(jobIDs))
+	if len(jobIDs) == 0 {
+		return out, nil
+	}
+	const q = `
+		SELECT id, library_id, job_id
+		FROM   enrichment_batches
+		WHERE  job_id = ANY($1)`
+	rows, err := r.db.Query(ctx, q, jobIDs)
+	if err != nil {
+		return nil, fmt.Errorf("looking up enrichment batches by job_id: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var pgID, pgLibraryID, pgJobID pgtype.UUID
+		if err := rows.Scan(&pgID, &pgLibraryID, &pgJobID); err != nil {
+			return nil, fmt.Errorf("scanning batch ref: %w", err)
+		}
+		ref := JobRef{ID: uuid.UUID(pgID.Bytes)}
+		if pgLibraryID.Valid {
+			ref.LibraryID = uuid.UUID(pgLibraryID.Bytes)
+		}
+		out[uuid.UUID(pgJobID.Bytes)] = ref
+	}
+	return out, rows.Err()
+}
+
 func scanBatchWithLibraryName(s batchScanner) (*models.EnrichmentBatch, error) {
 	var (
 		pgID        pgtype.UUID

--- a/internal/repository/enrichment_batches.go
+++ b/internal/repository/enrichment_batches.go
@@ -410,19 +410,20 @@ func scanBatch(s batchScanner) (*models.EnrichmentBatch, error) {
 	return &b, nil
 }
 
-// LookupByJobIDs maps umbrella job_id → (enrichment_batches.id, library_id)
-// for every input id with a matching row. library_id is nullable for
-// enrichment batches (post-000009 migration); a missing/null value yields
-// the zero UUID. Missing rows are silently absent from the returned map.
+// LookupByJobIDs maps umbrella job_id → JobRef for every input id with a
+// matching enrichment_batches row. library_id is nullable post-000009;
+// when null the LEFT JOIN leaves library_name empty and LibraryID is the
+// zero UUID. Missing rows are silently absent.
 func (r *EnrichmentBatchRepo) LookupByJobIDs(ctx context.Context, jobIDs []uuid.UUID) (map[uuid.UUID]JobRef, error) {
 	out := make(map[uuid.UUID]JobRef, len(jobIDs))
 	if len(jobIDs) == 0 {
 		return out, nil
 	}
 	const q = `
-		SELECT id, library_id, job_id
-		FROM   enrichment_batches
-		WHERE  job_id = ANY($1)`
+		SELECT eb.id, eb.library_id, eb.job_id, l.name
+		FROM   enrichment_batches eb
+		LEFT JOIN libraries l ON l.id = eb.library_id
+		WHERE  eb.job_id = ANY($1)`
 	rows, err := r.db.Query(ctx, q, jobIDs)
 	if err != nil {
 		return nil, fmt.Errorf("looking up enrichment batches by job_id: %w", err)
@@ -430,12 +431,16 @@ func (r *EnrichmentBatchRepo) LookupByJobIDs(ctx context.Context, jobIDs []uuid.
 	defer rows.Close()
 	for rows.Next() {
 		var pgID, pgLibraryID, pgJobID pgtype.UUID
-		if err := rows.Scan(&pgID, &pgLibraryID, &pgJobID); err != nil {
+		var libName *string
+		if err := rows.Scan(&pgID, &pgLibraryID, &pgJobID, &libName); err != nil {
 			return nil, fmt.Errorf("scanning batch ref: %w", err)
 		}
 		ref := JobRef{ID: uuid.UUID(pgID.Bytes)}
 		if pgLibraryID.Valid {
 			ref.LibraryID = uuid.UUID(pgLibraryID.Bytes)
+		}
+		if libName != nil {
+			ref.LibraryName = *libName
 		}
 		out[uuid.UUID(pgJobID.Bytes)] = ref
 	}

--- a/internal/repository/import_jobs.go
+++ b/internal/repository/import_jobs.go
@@ -378,3 +378,40 @@ func scanImportItem(s scanner) (*models.ImportJobItem, error) {
 	}
 	return &item, nil
 }
+
+// JobRef is the lightweight (id, library_id) pair the unified jobs view
+// needs to deep-link an umbrella job_id back to the per-kind detail row.
+type JobRef struct {
+	ID        uuid.UUID
+	LibraryID uuid.UUID
+}
+
+// LookupByJobIDs maps umbrella job_id → (import_jobs.id, library_id) for
+// every input id that has a matching import_jobs row. Missing rows are
+// silently absent from the returned map.
+func (r *ImportJobRepo) LookupByJobIDs(ctx context.Context, jobIDs []uuid.UUID) (map[uuid.UUID]JobRef, error) {
+	out := make(map[uuid.UUID]JobRef, len(jobIDs))
+	if len(jobIDs) == 0 {
+		return out, nil
+	}
+	const q = `
+		SELECT id, library_id, job_id
+		FROM   import_jobs
+		WHERE  job_id = ANY($1)`
+	rows, err := r.db.Query(ctx, q, jobIDs)
+	if err != nil {
+		return nil, fmt.Errorf("looking up import jobs by job_id: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var pgID, pgLibraryID, pgJobID pgtype.UUID
+		if err := rows.Scan(&pgID, &pgLibraryID, &pgJobID); err != nil {
+			return nil, fmt.Errorf("scanning job ref: %w", err)
+		}
+		out[uuid.UUID(pgJobID.Bytes)] = JobRef{
+			ID:        uuid.UUID(pgID.Bytes),
+			LibraryID: uuid.UUID(pgLibraryID.Bytes),
+		}
+	}
+	return out, rows.Err()
+}

--- a/internal/repository/import_jobs.go
+++ b/internal/repository/import_jobs.go
@@ -379,14 +379,17 @@ func scanImportItem(s scanner) (*models.ImportJobItem, error) {
 	return &item, nil
 }
 
-// JobRef is the lightweight (id, library_id, library_name) tuple the
-// unified jobs view needs to deep-link an umbrella job_id back to its
-// per-kind detail row. LibraryName is the JOIN-loaded display label —
-// without it the unified row falls back to the raw library UUID.
+// JobRef is the lightweight (id, library_id, library_name, subtype)
+// tuple the unified jobs view needs to deep-link an umbrella job_id
+// back to its per-kind detail row. LibraryName is the JOIN-loaded
+// display label — without it the unified row falls back to the raw
+// library UUID. Subtype is per-kind specific: enrichment batches use
+// "metadata" / "cover" so the unified row can render the right badge.
 type JobRef struct {
 	ID          uuid.UUID
 	LibraryID   uuid.UUID
 	LibraryName string
+	Subtype     string
 }
 
 // LookupByJobIDs maps umbrella job_id → JobRef for every input id with a

--- a/internal/repository/import_jobs.go
+++ b/internal/repository/import_jobs.go
@@ -379,25 +379,28 @@ func scanImportItem(s scanner) (*models.ImportJobItem, error) {
 	return &item, nil
 }
 
-// JobRef is the lightweight (id, library_id) pair the unified jobs view
-// needs to deep-link an umbrella job_id back to the per-kind detail row.
+// JobRef is the lightweight (id, library_id, library_name) tuple the
+// unified jobs view needs to deep-link an umbrella job_id back to its
+// per-kind detail row. LibraryName is the JOIN-loaded display label —
+// without it the unified row falls back to the raw library UUID.
 type JobRef struct {
-	ID        uuid.UUID
-	LibraryID uuid.UUID
+	ID          uuid.UUID
+	LibraryID   uuid.UUID
+	LibraryName string
 }
 
-// LookupByJobIDs maps umbrella job_id → (import_jobs.id, library_id) for
-// every input id that has a matching import_jobs row. Missing rows are
-// silently absent from the returned map.
+// LookupByJobIDs maps umbrella job_id → JobRef for every input id with a
+// matching import_jobs row. Missing rows are silently absent.
 func (r *ImportJobRepo) LookupByJobIDs(ctx context.Context, jobIDs []uuid.UUID) (map[uuid.UUID]JobRef, error) {
 	out := make(map[uuid.UUID]JobRef, len(jobIDs))
 	if len(jobIDs) == 0 {
 		return out, nil
 	}
 	const q = `
-		SELECT id, library_id, job_id
-		FROM   import_jobs
-		WHERE  job_id = ANY($1)`
+		SELECT ij.id, ij.library_id, ij.job_id, l.name
+		FROM   import_jobs ij
+		JOIN   libraries  l ON l.id = ij.library_id
+		WHERE  ij.job_id = ANY($1)`
 	rows, err := r.db.Query(ctx, q, jobIDs)
 	if err != nil {
 		return nil, fmt.Errorf("looking up import jobs by job_id: %w", err)
@@ -405,12 +408,14 @@ func (r *ImportJobRepo) LookupByJobIDs(ctx context.Context, jobIDs []uuid.UUID) 
 	defer rows.Close()
 	for rows.Next() {
 		var pgID, pgLibraryID, pgJobID pgtype.UUID
-		if err := rows.Scan(&pgID, &pgLibraryID, &pgJobID); err != nil {
+		var libName string
+		if err := rows.Scan(&pgID, &pgLibraryID, &pgJobID, &libName); err != nil {
 			return nil, fmt.Errorf("scanning job ref: %w", err)
 		}
 		out[uuid.UUID(pgJobID.Bytes)] = JobRef{
-			ID:        uuid.UUID(pgID.Bytes),
-			LibraryID: uuid.UUID(pgLibraryID.Bytes),
+			ID:          uuid.UUID(pgID.Bytes),
+			LibraryID:   uuid.UUID(pgLibraryID.Bytes),
+			LibraryName: libName,
 		}
 	}
 	return out, rows.Err()

--- a/internal/repository/memberships.go
+++ b/internal/repository/memberships.go
@@ -99,6 +99,18 @@ func (r *MembershipRepo) UpdateRole(ctx context.Context, libraryID, userID, role
 	return nil
 }
 
+// IsMember reports whether the given user has any role in the library.
+// Cheap point lookup used by handlers that need to validate cross-user
+// references (e.g. import attribution) without loading the full member list.
+func (r *MembershipRepo) IsMember(ctx context.Context, libraryID, userID uuid.UUID) (bool, error) {
+	const q = `SELECT EXISTS(SELECT 1 FROM library_memberships WHERE library_id = $1 AND user_id = $2)`
+	var ok bool
+	if err := r.db.QueryRow(ctx, q, libraryID, userID).Scan(&ok); err != nil {
+		return false, fmt.Errorf("checking membership: %w", err)
+	}
+	return ok, nil
+}
+
 func (r *MembershipRepo) Remove(ctx context.Context, libraryID, userID uuid.UUID) error {
 	result, err := r.db.Exec(ctx,
 		`DELETE FROM library_memberships WHERE library_id = $1 AND user_id = $2`,

--- a/internal/service/import.go
+++ b/internal/service/import.go
@@ -37,6 +37,7 @@ type ImportRequest struct {
 	DefaultFormat               string
 	EnrichMetadata              bool
 	EnrichCovers                bool
+	AttributeToUserID           *uuid.UUID // nil → attribute to caller
 }
 
 // StartImport parses the CSV, stores the job + items, and enqueues a River job.
@@ -62,6 +63,7 @@ func (s *ImportService) StartImport(ctx context.Context, req ImportRequest) (*mo
 			DefaultFormat:               models.NormalizeEditionFormat(req.DefaultFormat),
 			EnrichMetadata:              req.EnrichMetadata,
 			EnrichCovers:                req.EnrichCovers,
+			AttributeToUserID:           req.AttributeToUserID,
 		},
 	}
 

--- a/internal/service/import.go
+++ b/internal/service/import.go
@@ -28,15 +28,15 @@ func NewImportService(importJobs *repository.ImportJobRepo, riverClient *river.C
 
 // ImportRequest carries the parsed CSV and options sent by the frontend.
 type ImportRequest struct {
-	LibraryID     uuid.UUID
-	CallerID      uuid.UUID
-	CSVText       string
-	FieldMapping  map[string]int // field name → CSV column index
-	SkipDuplicates bool
-	DefaultFormat  string
-	PreferCSV       map[string]bool
-	EnrichMetadata  bool
-	EnrichCovers    bool
+	LibraryID                   uuid.UUID
+	CallerID                    uuid.UUID
+	CSVText                     string
+	FieldMapping                map[string]int // field name → CSV column index
+	DuplicateIncrementCopyCount bool
+	DuplicateUpdateFromCSV      bool
+	DefaultFormat               string
+	EnrichMetadata              bool
+	EnrichCovers                bool
 }
 
 // StartImport parses the CSV, stores the job + items, and enqueues a River job.
@@ -57,11 +57,11 @@ func (s *ImportService) StartImport(ctx context.Context, req ImportRequest) (*mo
 		Status:    models.ImportJobPending,
 		TotalRows: len(rows),
 		Options: models.ImportOptions{
-			SkipDuplicates: req.SkipDuplicates,
-			DefaultFormat:  models.NormalizeEditionFormat(req.DefaultFormat),
-			PreferCSV:      req.PreferCSV,
-			EnrichMetadata: req.EnrichMetadata,
-			EnrichCovers:   req.EnrichCovers,
+			DuplicateIncrementCopyCount: req.DuplicateIncrementCopyCount,
+			DuplicateUpdateFromCSV:      req.DuplicateUpdateFromCSV,
+			DefaultFormat:               models.NormalizeEditionFormat(req.DefaultFormat),
+			EnrichMetadata:              req.EnrichMetadata,
+			EnrichCovers:                req.EnrichCovers,
 		},
 	}
 

--- a/internal/workers/import_worker.go
+++ b/internal/workers/import_worker.go
@@ -237,25 +237,49 @@ func (w *ImportWorker) processItem(
 	}
 
 	// ── Duplicate check (ISBN deduplication at edition level) ─────────────────
-	// Under M2M, an edition with a given ISBN exists globally at most once.
-	// If we already have one, add this library to its junction and bump the
-	// copy count there — no duplicate book/edition rows created.
+	// Editions are globally unique by ISBN under M2M. If one already
+	// exists, the duplicate-handling options decide whether to bump the
+	// copy count and/or refresh user-interaction fields. A book that
+	// exists globally but isn't yet in this library is not a duplicate
+	// from the user's perspective — we always link it and let the
+	// update-from-CSV option carry the row's user-interaction data.
 	if isbn != "" {
 		existing, err := w.editions.FindByISBN(ctx, isbn)
 		if err == nil && existing != nil {
-			if addErr := w.libraryBooks.AddBookToLibrary(ctx, nil, job.LibraryID, existing.BookID, &job.CreatedBy); addErr != nil {
-				return models.ImportItemFailed, fmt.Sprintf("adding book to library: %v", addErr), nil
+			inLibrary, ierr := w.libraryBooks.IsBookInLibrary(ctx, job.LibraryID, existing.BookID)
+			if ierr != nil {
+				return models.ImportItemFailed, fmt.Sprintf("checking library membership: %v", ierr), nil
 			}
-			if incrErr := w.editions.IncrementCopyCount(ctx, job.LibraryID, existing.ID); incrErr != nil {
-				return models.ImportItemFailed, fmt.Sprintf("increment copy count: %v", incrErr), nil
-			}
-			// User-interaction fields (rating, review, status, dates)
-			// also need to flow through on dedup — otherwise migrating
-			// from a tracker where the same book shows up across shelves
-			// would lose the per-row metadata on every row past the first.
-			w.applyInteraction(ctx, existing.ID, job.CreatedBy, row)
 			bookID := existing.BookID
-			return models.ImportItemDone, fmt.Sprintf("duplicate ISBN %s — copy count incremented", isbn), &bookID
+
+			if !inLibrary {
+				// First time this library is seeing the edition — add it
+				// and seed the user-interaction fields from the CSV row.
+				if addErr := w.libraryBooks.AddBookToLibrary(ctx, nil, job.LibraryID, bookID, &job.CreatedBy); addErr != nil {
+					return models.ImportItemFailed, fmt.Sprintf("adding book to library: %v", addErr), nil
+				}
+				w.applyInteraction(ctx, existing.ID, job.CreatedBy, row)
+				return models.ImportItemDone, fmt.Sprintf("linked existing edition (ISBN %s) into this library", isbn), &bookID
+			}
+
+			// True duplicate — book is already in this library. Apply the
+			// user's duplicate-handling preferences. Default (both off) is
+			// a no-op skip so re-running an import is idempotent.
+			actions := make([]string, 0, 2)
+			if opts.DuplicateIncrementCopyCount {
+				if incrErr := w.editions.IncrementCopyCount(ctx, job.LibraryID, existing.ID); incrErr != nil {
+					return models.ImportItemFailed, fmt.Sprintf("increment copy count: %v", incrErr), nil
+				}
+				actions = append(actions, "copy count incremented")
+			}
+			if opts.DuplicateUpdateFromCSV {
+				w.applyInteraction(ctx, existing.ID, job.CreatedBy, row)
+				actions = append(actions, "user fields updated")
+			}
+			if len(actions) == 0 {
+				return models.ImportItemSkipped, fmt.Sprintf("duplicate ISBN %s — skipped", isbn), &bookID
+			}
+			return models.ImportItemDone, fmt.Sprintf("duplicate ISBN %s — %s", isbn, strings.Join(actions, ", ")), &bookID
 		}
 	}
 

--- a/internal/workers/import_worker.go
+++ b/internal/workers/import_worker.go
@@ -513,8 +513,7 @@ func (w *ImportWorker) applyInteraction(ctx context.Context, editionID, userID u
 	isFavorite, hasFavorite := imports.Bool(row["is_favorite"])
 
 	// Bail when nothing interaction-shaped is present — most generic
-	// CSVs won't carry any of these and we don't want to overwrite
-	// established interactions with a no-op upsert.
+	// CSVs won't carry any of these and we don't want to touch the row.
 	if readStatus == "" && !hasRating && review == "" && notes == "" &&
 		!hasStarted && !hasFinished && !hasFavorite {
 		return
@@ -527,12 +526,25 @@ func (w *ImportWorker) applyInteraction(ctx context.Context, editionID, userID u
 		readStatus = "read"
 	}
 
-	// UpsertInteraction's signature accepts `any` for the optional
-	// numeric/date fields so the repo can pass nil for SQL NULL when
-	// the import didn't supply them.
+	// MergeInteraction preserves whatever the existing row holds for
+	// any field the CSV didn't populate. The previous Upsert variant
+	// did an unconditional overwrite, which silently wiped manually
+	// entered ratings/reviews on every re-import.
+	var readStatusArg *string
+	if readStatus != "" {
+		readStatusArg = &readStatus
+	}
 	var ratingArg any
 	if hasRating {
 		ratingArg = rating
+	}
+	var notesArg *string
+	if notes != "" {
+		notesArg = &notes
+	}
+	var reviewArg *string
+	if review != "" {
+		reviewArg = &review
 	}
 	var startedArg any
 	if hasStarted {
@@ -542,19 +554,19 @@ func (w *ImportWorker) applyInteraction(ctx context.Context, editionID, userID u
 	if hasFinished {
 		finishedArg = finishedAt
 	}
-	favorite := false
+	var favoriteArg *bool
 	if hasFavorite {
-		favorite = isFavorite
+		favoriteArg = &isFavorite
 	}
 
-	if _, err := w.editions.UpsertInteraction(
+	if _, err := w.editions.MergeInteraction(
 		ctx, userID, editionID,
-		readStatus, ratingArg,
-		notes, review,
+		readStatusArg, ratingArg,
+		notesArg, reviewArg,
 		startedArg, finishedArg,
-		favorite,
+		favoriteArg,
 	); err != nil {
-		slog.Warn("import: applying user interaction failed",
+		slog.Warn("import: merging user interaction failed",
 			"user_id", userID, "edition_id", editionID, "error", err)
 	}
 }

--- a/internal/workers/import_worker.go
+++ b/internal/workers/import_worker.go
@@ -114,18 +114,21 @@ func (w *ImportWorker) Work(ctx context.Context, job *river.Job[models.ImportJob
 			return nil
 		}
 
-		status, msg, bookID, isNewBook := w.processItem(ctx, importJob, &item, tagCache, allGenres)
+		status, msg, bookID, addedToLibrary := w.processItem(ctx, importJob, &item, tagCache, allGenres)
 		_ = w.importJobs.UpdateItemStatus(ctx, item.ID, status, msg, bookID)
 
 		switch status {
 		case models.ImportItemDone:
 			processed++
-			// Only books freshly created by this run are queued for
-			// post-import enrichment. Skips duplicates that took an
-			// action (count bump / interaction refresh) and edition
-			// links from other libraries, both of which already have
-			// metadata + covers from their original import.
-			if isNewBook && bookID != nil && item.Title != "" {
+			// Books newly added to *this* library (fresh creates and
+			// links of an edition that lived in another library) are
+			// queued for post-import enrichment. Pure in-library
+			// duplicates that took an action (count bump or
+			// interaction refresh) are excluded — those have already
+			// been enriched on a prior run. The cover/metadata workers
+			// short-circuit when the data is already present, so a
+			// library-link with a cover already on disk is a cheap no-op.
+			if addedToLibrary && bookID != nil && item.Title != "" {
 				newBooks = append(newBooks, importedBook{id: *bookID, title: item.Title})
 			}
 		case models.ImportItemFailed:
@@ -221,11 +224,12 @@ func (w *ImportWorker) spawnEnrichmentBatch(
 	}
 }
 
-// processItem returns the per-row outcome plus an isNewBook flag the
-// caller uses to gate post-import enrichment fan-out. "New" means the
-// row created a fresh book + edition in this run — links into existing
-// global editions and duplicate-handling branches return false so we
-// don't re-enrich books whose metadata already exists.
+// processItem returns the per-row outcome plus an addedToLibrary flag
+// the caller uses to gate post-import enrichment fan-out. The flag is
+// true for any row that newly placed a book into the target library
+// (true creates AND links of editions from other libraries) — both
+// are "added" from the user's perspective. It's false for pure
+// in-library duplicates and skipped rows.
 func (w *ImportWorker) processItem(
 	ctx context.Context,
 	job *models.ImportJob,
@@ -277,9 +281,13 @@ func (w *ImportWorker) processItem(
 					return models.ImportItemFailed, fmt.Sprintf("adding book to library: %v", addErr), nil, false
 				}
 				w.applyInteraction(ctx, existing.ID, interactionUserID, row)
-				// isNewBook=false: the book + edition already had metadata
-				// from whichever library originally imported it.
-				return models.ImportItemDone, fmt.Sprintf("linked existing edition (ISBN %s) into this library", isbn), &bookID, false
+				// addedToLibrary=true: the book is new to *this* library
+				// even though the edition row pre-existed globally. Queue
+				// it for enrichment so missing covers/metadata get filled
+				// in if the original-library import skipped that step.
+				// The metadata and cover workers no-op when the data is
+				// already present.
+				return models.ImportItemDone, fmt.Sprintf("linked existing edition (ISBN %s) into this library", isbn), &bookID, true
 			}
 
 			// True duplicate — book is already in this library. Apply the
@@ -481,11 +489,9 @@ func (w *ImportWorker) processItem(
 	// rolling back the whole row.
 	w.applyInteraction(ctx, editionID, interactionUserID, row)
 
-	// isNewBook=true: this is the only path where a fresh book + edition
-	// row was created in this run. The caller uses this to scope the
-	// post-import metadata/cover enrichment fan-out to truly-new books,
-	// instead of also enriching books linked from other libraries or
-	// duplicates that just got their copy count bumped.
+	// addedToLibrary=true: a fresh book + edition row was created in
+	// this run and added to the target library. Always queue for
+	// post-import enrichment.
 	return models.ImportItemDone, fmt.Sprintf("imported %q", finalTitle), &bookID, true
 }
 

--- a/internal/workers/import_worker.go
+++ b/internal/workers/import_worker.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/fireball1725/librarium-api/internal/imports"
 	"github.com/fireball1725/librarium-api/internal/models"
 	"github.com/fireball1725/librarium-api/internal/repository"
 	"github.com/fireball1725/librarium-api/internal/service"
@@ -248,6 +249,11 @@ func (w *ImportWorker) processItem(
 			if incrErr := w.editions.IncrementCopyCount(ctx, job.LibraryID, existing.ID); incrErr != nil {
 				return models.ImportItemFailed, fmt.Sprintf("increment copy count: %v", incrErr), nil
 			}
+			// User-interaction fields (rating, review, status, dates)
+			// also need to flow through on dedup — otherwise migrating
+			// from a tracker where the same book shows up across shelves
+			// would lose the per-row metadata on every row past the first.
+			w.applyInteraction(ctx, existing.ID, job.CreatedBy, row)
 			bookID := existing.BookID
 			return models.ImportItemDone, fmt.Sprintf("duplicate ISBN %s — copy count incremented", isbn), &bookID
 		}
@@ -424,7 +430,78 @@ func (w *ImportWorker) processItem(
 		return models.ImportItemFailed, fmt.Sprintf("commit: %v", err), nil
 	}
 
+	// User-interaction fields are applied after the book/edition is
+	// committed so that a per-user `user_book_interactions` row points
+	// at a real `book_edition_id`. Failures here are non-fatal — the
+	// book is already imported, so we log and move on rather than
+	// rolling back the whole row.
+	w.applyInteraction(ctx, editionID, job.CreatedBy, row)
+
 	return models.ImportItemDone, fmt.Sprintf("imported %q", finalTitle), &bookID
+}
+
+// applyInteraction reads the user-interaction columns out of an import
+// row and upserts a `user_book_interactions` record for the importing
+// user against the given edition. Idempotent — re-running the same
+// import on a row whose values haven't changed produces no-op writes.
+//
+// Skips the upsert entirely when none of the interaction fields are
+// present. We don't want to clobber an existing rating/review just
+// because the user re-ran an import that didn't carry user-data.
+func (w *ImportWorker) applyInteraction(ctx context.Context, editionID, userID uuid.UUID, row map[string]string) {
+	readStatus := imports.ReadStatus(row["read_status"])
+	rating, hasRating := imports.Rating(row["rating"])
+	review := strings.TrimSpace(row["review"])
+	notes := strings.TrimSpace(row["notes"])
+	startedAt, hasStarted := imports.Date(row["date_started"])
+	finishedAt, hasFinished := imports.Date(row["date_finished"])
+	isFavorite, hasFavorite := imports.Bool(row["is_favorite"])
+
+	// Bail when nothing interaction-shaped is present — most generic
+	// CSVs won't carry any of these and we don't want to overwrite
+	// established interactions with a no-op upsert.
+	if readStatus == "" && !hasRating && review == "" && notes == "" &&
+		!hasStarted && !hasFinished && !hasFavorite {
+		return
+	}
+
+	// If we have a finish date but no explicit status, infer "read".
+	// Mirrors the behaviour every external tracker assumes — if you
+	// finished a book on a date, you read it.
+	if readStatus == "" && hasFinished {
+		readStatus = "read"
+	}
+
+	// UpsertInteraction's signature accepts `any` for the optional
+	// numeric/date fields so the repo can pass nil for SQL NULL when
+	// the import didn't supply them.
+	var ratingArg any
+	if hasRating {
+		ratingArg = rating
+	}
+	var startedArg any
+	if hasStarted {
+		startedArg = startedAt
+	}
+	var finishedArg any
+	if hasFinished {
+		finishedArg = finishedAt
+	}
+	favorite := false
+	if hasFavorite {
+		favorite = isFavorite
+	}
+
+	if _, err := w.editions.UpsertInteraction(
+		ctx, userID, editionID,
+		readStatus, ratingArg,
+		notes, review,
+		startedArg, finishedArg,
+		favorite,
+	); err != nil {
+		slog.Warn("import: applying user interaction failed",
+			"user_id", userID, "edition_id", editionID, "error", err)
+	}
 }
 
 func (w *ImportWorker) findOrCreateContributor(ctx context.Context, name string) (*models.Contributor, error) {

--- a/internal/workers/import_worker.go
+++ b/internal/workers/import_worker.go
@@ -114,13 +114,18 @@ func (w *ImportWorker) Work(ctx context.Context, job *river.Job[models.ImportJob
 			return nil
 		}
 
-		status, msg, bookID := w.processItem(ctx, importJob, &item, tagCache, allGenres)
+		status, msg, bookID, isNewBook := w.processItem(ctx, importJob, &item, tagCache, allGenres)
 		_ = w.importJobs.UpdateItemStatus(ctx, item.ID, status, msg, bookID)
 
 		switch status {
 		case models.ImportItemDone:
 			processed++
-			if bookID != nil && item.Title != "" {
+			// Only books freshly created by this run are queued for
+			// post-import enrichment. Skips duplicates that took an
+			// action (count bump / interaction refresh) and edition
+			// links from other libraries, both of which already have
+			// metadata + covers from their original import.
+			if isNewBook && bookID != nil && item.Title != "" {
 				newBooks = append(newBooks, importedBook{id: *bookID, title: item.Title})
 			}
 		case models.ImportItemFailed:
@@ -216,19 +221,32 @@ func (w *ImportWorker) spawnEnrichmentBatch(
 	}
 }
 
+// processItem returns the per-row outcome plus an isNewBook flag the
+// caller uses to gate post-import enrichment fan-out. "New" means the
+// row created a fresh book + edition in this run — links into existing
+// global editions and duplicate-handling branches return false so we
+// don't re-enrich books whose metadata already exists.
 func (w *ImportWorker) processItem(
 	ctx context.Context,
 	job *models.ImportJob,
 	item *models.ImportJobItem,
 	tagCache map[string]uuid.UUID,
 	allGenres []*models.Genre,
-) (models.ImportItemStatus, string, *uuid.UUID) {
+) (models.ImportItemStatus, string, *uuid.UUID, bool) {
 	opts := job.Options
 	row := item.RawData
 
+	// Reading data is normally attributed to the importer; admins can
+	// retarget the whole job to another library member via the
+	// attribute_to_user_id option.
+	interactionUserID := job.CreatedBy
+	if opts.AttributeToUserID != nil {
+		interactionUserID = *opts.AttributeToUserID
+	}
+
 	title := strings.TrimSpace(row["title"])
 	if title == "" {
-		return models.ImportItemSkipped, "no title", nil
+		return models.ImportItemSkipped, "no title", nil, false
 	}
 
 	isbn := strings.TrimSpace(row["isbn_13"])
@@ -248,7 +266,7 @@ func (w *ImportWorker) processItem(
 		if err == nil && existing != nil {
 			inLibrary, ierr := w.libraryBooks.IsBookInLibrary(ctx, job.LibraryID, existing.BookID)
 			if ierr != nil {
-				return models.ImportItemFailed, fmt.Sprintf("checking library membership: %v", ierr), nil
+				return models.ImportItemFailed, fmt.Sprintf("checking library membership: %v", ierr), nil, false
 			}
 			bookID := existing.BookID
 
@@ -256,10 +274,12 @@ func (w *ImportWorker) processItem(
 				// First time this library is seeing the edition — add it
 				// and seed the user-interaction fields from the CSV row.
 				if addErr := w.libraryBooks.AddBookToLibrary(ctx, nil, job.LibraryID, bookID, &job.CreatedBy); addErr != nil {
-					return models.ImportItemFailed, fmt.Sprintf("adding book to library: %v", addErr), nil
+					return models.ImportItemFailed, fmt.Sprintf("adding book to library: %v", addErr), nil, false
 				}
-				w.applyInteraction(ctx, existing.ID, job.CreatedBy, row)
-				return models.ImportItemDone, fmt.Sprintf("linked existing edition (ISBN %s) into this library", isbn), &bookID
+				w.applyInteraction(ctx, existing.ID, interactionUserID, row)
+				// isNewBook=false: the book + edition already had metadata
+				// from whichever library originally imported it.
+				return models.ImportItemDone, fmt.Sprintf("linked existing edition (ISBN %s) into this library", isbn), &bookID, false
 			}
 
 			// True duplicate — book is already in this library. Apply the
@@ -268,18 +288,18 @@ func (w *ImportWorker) processItem(
 			actions := make([]string, 0, 2)
 			if opts.DuplicateIncrementCopyCount {
 				if incrErr := w.editions.IncrementCopyCount(ctx, job.LibraryID, existing.ID); incrErr != nil {
-					return models.ImportItemFailed, fmt.Sprintf("increment copy count: %v", incrErr), nil
+					return models.ImportItemFailed, fmt.Sprintf("increment copy count: %v", incrErr), nil, false
 				}
 				actions = append(actions, "copy count incremented")
 			}
 			if opts.DuplicateUpdateFromCSV {
-				w.applyInteraction(ctx, existing.ID, job.CreatedBy, row)
+				w.applyInteraction(ctx, existing.ID, interactionUserID, row)
 				actions = append(actions, "user fields updated")
 			}
 			if len(actions) == 0 {
-				return models.ImportItemSkipped, fmt.Sprintf("duplicate ISBN %s — skipped", isbn), &bookID
+				return models.ImportItemSkipped, fmt.Sprintf("duplicate ISBN %s — skipped", isbn), &bookID, false
 			}
-			return models.ImportItemDone, fmt.Sprintf("duplicate ISBN %s — %s", isbn, strings.Join(actions, ", ")), &bookID
+			return models.ImportItemDone, fmt.Sprintf("duplicate ISBN %s — %s", isbn, strings.Join(actions, ", ")), &bookID, false
 		}
 	}
 
@@ -306,7 +326,7 @@ func (w *ImportWorker) processItem(
 	// ── Media type ────────────────────────────────────────────────────────────
 	mediaTypes, err := w.books.ListMediaTypes(ctx)
 	if err != nil {
-		return models.ImportItemFailed, fmt.Sprintf("loading media types: %v", err), nil
+		return models.ImportItemFailed, fmt.Sprintf("loading media types: %v", err), nil, false
 	}
 	mediaTypeID := findMediaTypeID(mediaTypes, row["media_type"])
 	if mediaTypeID == uuid.Nil {
@@ -383,7 +403,7 @@ func (w *ImportWorker) processItem(
 	bookID := uuid.New()
 	tx, err := w.pool.Begin(ctx)
 	if err != nil {
-		return models.ImportItemFailed, fmt.Sprintf("begin tx: %v", err), nil
+		return models.ImportItemFailed, fmt.Sprintf("begin tx: %v", err), nil, false
 	}
 	defer tx.Rollback(ctx)
 
@@ -391,28 +411,28 @@ func (w *ImportWorker) processItem(
 		finalTitle, finalSubtitle, mediaTypeID,
 		finalDescription,
 	); err != nil {
-		return models.ImportItemFailed, fmt.Sprintf("creating book: %v", err), nil
+		return models.ImportItemFailed, fmt.Sprintf("creating book: %v", err), nil, false
 	}
 
 	if err := w.libraryBooks.AddBookToLibrary(ctx, tx, job.LibraryID, bookID, &job.CreatedBy); err != nil {
-		return models.ImportItemFailed, fmt.Sprintf("adding book to library: %v", err), nil
+		return models.ImportItemFailed, fmt.Sprintf("adding book to library: %v", err), nil, false
 	}
 
 	if len(contribs) > 0 {
 		if err := w.books.SetContributors(ctx, tx, bookID, contribs); err != nil {
-			return models.ImportItemFailed, fmt.Sprintf("setting contributors: %v", err), nil
+			return models.ImportItemFailed, fmt.Sprintf("setting contributors: %v", err), nil, false
 		}
 	}
 
 	if len(tagIDs) > 0 {
 		if err := w.tags.SetBookTags(ctx, tx, bookID, tagIDs); err != nil {
-			return models.ImportItemFailed, fmt.Sprintf("setting tags: %v", err), nil
+			return models.ImportItemFailed, fmt.Sprintf("setting tags: %v", err), nil, false
 		}
 	}
 
 	if len(genreIDs) > 0 {
 		if err := w.genres.SetBookGenres(ctx, tx, bookID, genreIDs); err != nil {
-			return models.ImportItemFailed, fmt.Sprintf("setting genres: %v", err), nil
+			return models.ImportItemFailed, fmt.Sprintf("setting genres: %v", err), nil, false
 		}
 	}
 
@@ -438,7 +458,7 @@ func (w *ImportWorker) processItem(
 		publishDate, finalISBN10, finalISBN13, finalDescription,
 		nil, pageCount, true, nil,
 	); err != nil {
-		return models.ImportItemFailed, fmt.Sprintf("creating edition: %v", err), nil
+		return models.ImportItemFailed, fmt.Sprintf("creating edition: %v", err), nil, false
 	}
 	// Record this library's copy of the new edition.
 	var acq *any
@@ -447,11 +467,11 @@ func (w *ImportWorker) processItem(
 		acq = &v
 	}
 	if err := w.libraryBooks.SetEditionCopyCount(ctx, tx, job.LibraryID, editionID, 1, acq); err != nil {
-		return models.ImportItemFailed, fmt.Sprintf("setting library copy count: %v", err), nil
+		return models.ImportItemFailed, fmt.Sprintf("setting library copy count: %v", err), nil, false
 	}
 
 	if err := tx.Commit(ctx); err != nil {
-		return models.ImportItemFailed, fmt.Sprintf("commit: %v", err), nil
+		return models.ImportItemFailed, fmt.Sprintf("commit: %v", err), nil, false
 	}
 
 	// User-interaction fields are applied after the book/edition is
@@ -459,9 +479,14 @@ func (w *ImportWorker) processItem(
 	// at a real `book_edition_id`. Failures here are non-fatal — the
 	// book is already imported, so we log and move on rather than
 	// rolling back the whole row.
-	w.applyInteraction(ctx, editionID, job.CreatedBy, row)
+	w.applyInteraction(ctx, editionID, interactionUserID, row)
 
-	return models.ImportItemDone, fmt.Sprintf("imported %q", finalTitle), &bookID
+	// isNewBook=true: this is the only path where a fresh book + edition
+	// row was created in this run. The caller uses this to scope the
+	// post-import metadata/cover enrichment fan-out to truly-new books,
+	// instead of also enriching books linked from other libraries or
+	// duplicates that just got their copy count bumped.
+	return models.ImportItemDone, fmt.Sprintf("imported %q", finalTitle), &bookID, true
 }
 
 // applyInteraction reads the user-interaction columns out of an import

--- a/internal/workers/metadata_worker.go
+++ b/internal/workers/metadata_worker.go
@@ -108,7 +108,11 @@ func (w *MetadataWorker) ProcessBook(ctx context.Context, bookID, callerID uuid.
 		}
 	}
 
-	// Fetch cover if the book has none, or when force/cover_only is set.
+	// Fetch cover if the book has none, or when force is set. cover_only
+	// no longer forces a refetch — a book that already has a cover is
+	// left alone in any post-import / batch enrichment, matching the
+	// "fill missing data only" contract the import UI advertises.
+	// Only an explicit Force=true (e.g. a manual re-fetch) overrides.
 	if len(merged.Covers) == 0 {
 		if coverOnly {
 			return ErrNoUpdate // nothing to do for a cover-only job
@@ -120,7 +124,13 @@ func (w *MetadataWorker) ProcessBook(ctx context.Context, bookID, callerID uuid.
 	if _, _, err := w.bookSvc.GetBookCoverPath(ctx, bookID); err == nil {
 		hasCover = true
 	}
-	if !hasCover || force || coverOnly {
+	if hasCover && !force {
+		if coverOnly {
+			return ErrNoUpdate // already has a cover; cover-only batch is a no-op
+		}
+		return nil
+	}
+	if !hasCover || force {
 		// Try covers in priority order until one downloads successfully —
 		// the top-priority URL (e.g. Google Books thumbnail) can 403/404, and
 		// falling through to the next provider is better than giving up.


### PR DESCRIPTION
- New `internal/imports` package with shared normalizers (read status / 0–5 rating → 1–10 / dates / bool) covering Goodreads, StoryGraph, and Libib values in a single broad-whitelist pass; full unit-test coverage against the actual values from a real 2,534-row Libib export.
- `ImportWorker.applyInteraction` upserts `user_book_interactions` after both freshly-created and ISBN-deduplicated edition paths, infers `read` when only a finish date is present, and skips the write entirely when no interaction-shaped fields are in the row so vanilla "just the books" imports don't clobber existing data. Web-side preset dropdown that auto-fills these mappings is the follow-up PR.