### PR TITLE
Admin set-password endpoint

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1594,6 +1594,106 @@ const docTemplate = `{
                 }
             }
         },
+        "/admin/users/{id}/password": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Overwrites the target user's local password without the current-password challenge. Instance admin only. Used for admin-driven resets when the user has lost access. Fails with 404 if the target has no local identity (e.g. an external SSO-only account).",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Set a user's password (admin)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "New password",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "password": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "message": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/admin/users/{id}": {
             "delete": {
                 "security": [

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1588,6 +1588,106 @@
                 }
             }
         },
+        "/admin/users/{id}/password": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Overwrites the target user's local password without the current-password challenge. Instance admin only. Used for admin-driven resets when the user has lost access. Fails with 404 if the target has no local identity (e.g. an external SSO-only account).",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Set a user's password (admin)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "New password",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "password": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "message": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/admin/users/{id}": {
             "delete": {
                 "security": [

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2277,6 +2277,72 @@ paths:
       summary: Create a user (admin)
       tags:
       - admin
+  /admin/users/{id}/password:
+    put:
+      consumes:
+      - application/json
+      description: Overwrites the target user's local password without the current-password
+        challenge. Instance admin only. Used for admin-driven resets when the user
+        has lost access. Fails with 404 if the target has no local identity (e.g.
+        an external SSO-only account).
+      parameters:
+      - description: User UUID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: New password
+        in: body
+        name: body
+        required: true
+        schema:
+          properties:
+            password:
+              type: string
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            properties:
+              message:
+                type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+        "403":
+          description: Forbidden
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Set a user's password (admin)
+      tags:
+      - admin
   /admin/users/{id}:
     delete:
       description: Permanently deletes a user account. Instance admin only. Cannot

--- a/internal/api/handlers/admin.go
+++ b/internal/api/handlers/admin.go
@@ -225,6 +225,69 @@ func (h *AdminHandler) DeleteUser(w http.ResponseWriter, r *http.Request) {
 	respond.JSON(w, http.StatusOK, map[string]string{"message": "user deleted"})
 }
 
+// SetUserPassword godoc
+//
+// @Summary     Set a user's password (admin)
+// @Description Overwrites the target user's local password without the
+// @Description current-password challenge. Instance admin only. Used for
+// @Description admin-driven resets when the user has lost access. Fails
+// @Description with 404 if the target has no local identity (e.g. an
+// @Description external SSO-only account).
+// @Tags        admin
+// @Accept      json
+// @Produce     json
+// @Security    BearerAuth
+// @Param       id    path      string                          true  "User UUID"
+// @Param       body  body      object{password=string}         true  "New password"
+// @Success     200   {object}  object{message=string}
+// @Failure     400   {object}  object{error=string}
+// @Failure     401   {object}  object{error=string}
+// @Failure     403   {object}  object{error=string}
+// @Failure     404   {object}  object{error=string}
+// @Router      /admin/users/{id}/password [put]
+func (h *AdminHandler) SetUserPassword(w http.ResponseWriter, r *http.Request) {
+	targetID, err := uuid.Parse(r.PathValue("id"))
+	if err != nil {
+		respond.Error(w, http.StatusBadRequest, "invalid user id")
+		return
+	}
+
+	var req struct {
+		Password string `json:"password"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		respond.Error(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	// Match the policy used by setup + create-user: non-empty only.
+	// Length/complexity rules belong in a separate, opt-in policy and
+	// would need to be retroactively applied to existing accounts to
+	// avoid surprise lockouts.
+	if req.Password == "" {
+		respond.Error(w, http.StatusBadRequest, "password is required")
+		return
+	}
+
+	callerID := uuid.Nil
+	if claims := middleware.ClaimsFromContext(r.Context()); claims != nil {
+		callerID = claims.UserID
+	}
+
+	if err := h.svc.AdminSetPassword(r.Context(), callerID, targetID, req.Password); err != nil {
+		switch {
+		case errors.Is(err, service.ErrSelfPasswordReset):
+			respond.Error(w, http.StatusBadRequest, err.Error())
+		case errors.Is(err, repository.ErrNotFound):
+			respond.Error(w, http.StatusNotFound, "user not found or has no local password to reset")
+		default:
+			respond.ServerError(w, r, err)
+		}
+		return
+	}
+
+	respond.JSON(w, http.StatusOK, map[string]string{"message": "password updated"})
+}
+
 func adminUserBody(u *models.User) map[string]any {
 	return map[string]any{
 		"id":                u.ID,

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -270,6 +270,7 @@ func NewRouter(ctx context.Context, db *pgxpool.Pool, cfg *config.Config, riverC
 	mux.Handle("POST /api/v1/admin/users", requireAdmin(http.HandlerFunc(adminHandler.CreateUser)))
 	mux.Handle("PATCH /api/v1/admin/users/{id}", requireAdmin(http.HandlerFunc(adminHandler.UpdateUser)))
 	mux.Handle("DELETE /api/v1/admin/users/{id}", requireAdmin(http.HandlerFunc(adminHandler.DeleteUser)))
+	mux.Handle("PUT /api/v1/admin/users/{id}/password", requireAdmin(http.HandlerFunc(adminHandler.SetUserPassword)))
 
 	// Users — search (any authenticated user)
 	mux.Handle("GET /api/v1/users", requireAuth(http.HandlerFunc(authHandler.SearchUsers)))

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -307,12 +307,37 @@ func (s *AuthService) UpdatePassword(ctx context.Context, userID uuid.UUID, curr
 	return s.identities.UpdateLocalPassword(ctx, userID, newHash)
 }
 
+// AdminSetPassword overwrites a target user's local password without
+// the current-password challenge that UpdatePassword enforces. Intended
+// for admin-driven password resets where the user has lost access. The
+// caller must already be an instance admin — that's gated at the route
+// layer. Self-targeting is rejected with ErrSelfPasswordReset: the
+// admin should use the self-serve UpdatePassword flow (with the
+// current-password challenge) for their own account, not the bypass
+// endpoint. Returns repository.ErrNotFound when the target has no
+// local identity (e.g. an OIDC-only user) so the handler can surface
+// a useful error.
+func (s *AuthService) AdminSetPassword(ctx context.Context, callerID, targetUserID uuid.UUID, newPassword string) error {
+	if callerID == targetUserID {
+		return ErrSelfPasswordReset
+	}
+	if _, err := s.identities.GetLocalPasswordHash(ctx, targetUserID); err != nil {
+		return err
+	}
+	newHash, err := auth.HashPassword(newPassword)
+	if err != nil {
+		return err
+	}
+	return s.identities.UpdateLocalPassword(ctx, targetUserID, newHash)
+}
+
 // ─── Admin user management ────────────────────────────────────────────────────
 
 var (
-	ErrSelfDelete     = errors.New("cannot delete your own account")
-	ErrSelfDeactivate = errors.New("cannot deactivate your own account")
-	ErrSelfDemote     = errors.New("cannot remove your own admin privileges")
+	ErrSelfDelete        = errors.New("cannot delete your own account")
+	ErrSelfDeactivate    = errors.New("cannot deactivate your own account")
+	ErrSelfDemote        = errors.New("cannot remove your own admin privileges")
+	ErrSelfPasswordReset = errors.New("cannot reset your own password from the admin panel; use the change-password flow")
 )
 
 // UserPatch holds optional fields for an admin PATCH operation.


### PR DESCRIPTION
- New \`PUT /api/v1/admin/users/{id}/password\` for admin-driven resets, no current-password challenge.
- Self-target rejected; admins use the self-serve flow for their own password.
- 404 when the target has no local identity (SSO-only account).