### PR TITLE
Filter cover-batch candidates to books that need a cover

### DIFF
--- a/internal/repository/books.go
+++ b/internal/repository/books.go
@@ -1398,6 +1398,40 @@ func (r *BookRepo) RecentlyFinished(ctx context.Context, userID uuid.UUID, limit
 	return out, rows.Err()
 }
 
+// BooksWithoutCover returns the subset of input book IDs that have no
+// primary cover image on file. Used by the import worker so a "fetch
+// covers" pass only queues books that actually need a cover lookup —
+// without this the post-import cover batch shows "0/1410" while every
+// row immediately no-ops, which reads as broken.
+func (r *BookRepo) BooksWithoutCover(ctx context.Context, bookIDs []uuid.UUID) ([]uuid.UUID, error) {
+	if len(bookIDs) == 0 {
+		return nil, nil
+	}
+	const q = `
+		SELECT b.id
+		FROM   unnest($1::uuid[]) AS b(id)
+		WHERE  NOT EXISTS (
+			SELECT 1 FROM cover_images ci
+			WHERE  ci.entity_type = 'book'
+			   AND ci.entity_id   = b.id
+			   AND ci.is_primary  = true
+		)`
+	rows, err := r.db.Query(ctx, q, bookIDs)
+	if err != nil {
+		return nil, fmt.Errorf("filtering books without cover: %w", err)
+	}
+	defer rows.Close()
+	out := make([]uuid.UUID, 0, len(bookIDs))
+	for rows.Next() {
+		var pgID pgtype.UUID
+		if err := rows.Scan(&pgID); err != nil {
+			return nil, fmt.Errorf("scanning book id: %w", err)
+		}
+		out = append(out, uuid.UUID(pgID.Bytes))
+	}
+	return out, rows.Err()
+}
+
 // SetBookTags replaces all tags for a book within the given transaction.
 func (r *BookRepo) SetBookTags(ctx context.Context, tx pgx.Tx, bookID uuid.UUID, tagIDs []uuid.UUID) error {
 	if _, err := tx.Exec(ctx, `DELETE FROM book_tags WHERE book_id = $1`, bookID); err != nil {

--- a/internal/workers/import_worker.go
+++ b/internal/workers/import_worker.go
@@ -175,17 +175,47 @@ func (w *ImportWorker) Work(ctx context.Context, job *river.Job[models.ImportJob
 // spawnEnrichmentBatch creates an EnrichmentBatch record + items in the database and
 // enqueues a single EnrichmentBatchJobArgs River job.  This makes the post-import
 // enrichment visible in the Jobs page and the River TUI.
+//
+// For cover batches, the candidate set is filtered to books that don't
+// already have a primary cover on disk — without this, importing into
+// a library where most edition-links already had covers from another
+// library produced a "0/1410" batch that read as broken even though
+// every per-book worker call was a correct no-op.
 func (w *ImportWorker) spawnEnrichmentBatch(
 	ctx context.Context,
 	importJob *models.ImportJob,
 	books []importedBook,
 	batchType models.EnrichmentBatchType,
 ) {
-	batchID := uuid.New()
 	bookIDs := make([]uuid.UUID, len(books))
 	for i, b := range books {
 		bookIDs[i] = b.id
 	}
+	if batchType == models.EnrichmentBatchTypeCover {
+		needCover, err := w.books.BooksWithoutCover(ctx, bookIDs)
+		if err != nil {
+			slog.Warn("filtering cover candidates failed; queueing all", "error", err)
+		} else {
+			needSet := make(map[uuid.UUID]struct{}, len(needCover))
+			for _, id := range needCover {
+				needSet[id] = struct{}{}
+			}
+			filtered := make([]importedBook, 0, len(needCover))
+			for _, b := range books {
+				if _, ok := needSet[b.id]; ok {
+					filtered = append(filtered, b)
+				}
+			}
+			books = filtered
+			bookIDs = needCover
+		}
+		if len(books) == 0 {
+			slog.Info("cover batch skipped — every imported book already has a cover",
+				"import_job_id", importJob.ID)
+			return
+		}
+	}
+	batchID := uuid.New()
 
 	libraryID := importJob.LibraryID
 	batch := &models.EnrichmentBatch{


### PR DESCRIPTION
- Adds \`BookRepo.BooksWithoutCover\` (single SQL, NOT EXISTS against \`cover_images\`) and filters the post-import cover batch's candidate set through it before creating the batch row.
- Skips batch creation entirely when every imported book already has a cover.
- Fixes a "0/1410" cover batch on imports where most books were just edition-links into the library and already had covers from elsewhere.