### PR TITLE
chore: issue templates, dependabot, security, codeql

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,87 @@
+name: Bug report
+description: Something isn't working as expected in the Librarium API
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Filling out the sections below helps us reproduce
+        and fix the issue quickly. The API version is required because most behaviour is driven by
+        the API release — you can find it in the web UI footer or by hitting `GET /health`.
+
+  - type: input
+    id: api_version
+    attributes:
+      label: API version
+      description: Shown in the web footer or `GET /health`
+      placeholder: "e.g. 26.4.2"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: deployment
+    attributes:
+      label: Deployment
+      description: How is the API running?
+      options:
+        - Docker Compose
+        - Kubernetes / Helm
+        - Bare metal / systemd
+        - Local dev (`go run`)
+        - Other / unsure
+    validations:
+      required: true
+
+  - type: input
+    id: db
+    attributes:
+      label: Postgres version
+      description: Output of `SELECT version();` or your container tag
+      placeholder: "e.g. 16.4-alpine"
+    validations:
+      required: false
+
+  - type: input
+    id: endpoint
+    attributes:
+      label: Affected endpoint(s)
+      description: HTTP method + path, if the bug is request-scoped
+      placeholder: "e.g. PUT /api/v1/me/taste-profile"
+    validations:
+      required: false
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: List the exact steps that trigger the bug.
+      placeholder: |
+        1. POST /api/v1/…
+        2. With body { … }
+        3. See response …
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or error output
+      description: Paste API logs, response body, or DB errors. Redact secrets.
+      render: text
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Cross-cutting / roadmap discussion
+    url: https://github.com/fireball1725/librarium/issues
+    about: For ideas that span api/web/ios/mcp, file on the umbrella librarium repo.
+  - name: API docs (Swagger / Scalar)
+    url: https://librarium.press/api-docs
+    about: Reference the live API spec before filing endpoint-shape issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,39 @@
+name: Feature request
+description: Suggest an API improvement or new endpoint
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Feature requests are welcome. Check existing issues + [PLAN.md](https://github.com/fireball1725/librarium/blob/main/PLAN.md) before submitting to avoid duplicates.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the use case or pain point.
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: New endpoint shape, behaviour change, or design sketch.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives you've considered
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Links to OpenAPI shape, similar APIs, screenshots from clients, etc.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,34 +1,11 @@
-## What does this PR do?
+<!--
+Title carries the weight — it feeds the auto-generated release notes.
+Body: 1–2 terse bullets explaining the why. No "Summary" / "Test plan"
+headers; the diff and the title speak for themselves.
 
-<!-- A brief description of the change. One paragraph is usually enough. -->
+CI requires DCO sign-off (`git commit -s`). Don't skip hooks.
+Don't hand-edit CHANGELOG — release notes are auto-generated.
+If request/response shapes changed, regenerate swagger (`make swagger`).
+-->
 
-## Type of change
-
-<!-- Check all that apply -->
-
-- [ ] Bug fix
-- [ ] New feature
-- [ ] Refactor / code improvement
-- [ ] Documentation
-- [ ] CI / build / tooling
-
-## How to test
-
-<!-- Steps a reviewer can follow to exercise the change. Include any relevant env vars, seed data, or curl commands. -->
-
-1.
-2.
-3.
-
-## Checklist
-
-- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
-- [ ] All commits are signed off under the [DCO](../DCO) (`git commit -s`)
-- [ ] `go vet ./...` and `go test ./...` pass
-- [ ] Swagger regenerated (`make swagger`) if request/response shapes changed
-- [ ] Migration added if a schema change is involved
-- [ ] `CHANGELOG.md` updated under `## [Unreleased]` for user-facing changes
-
-## Related issues
-
-<!-- Link issues this PR closes or is related to: "Closes #123" -->
+- 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+# Dependabot — automated dep update PRs.
+# Weekly cadence keeps the noise low while still catching security patches
+# in a reasonable window. Grouped updates land as one PR per ecosystem
+# instead of one PR per dependency.
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels: ["dependencies"]
+    groups:
+      go-deps:
+        patterns: ["*"]
+
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    labels: ["dependencies"]
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    labels: ["dependencies"]
+    groups:
+      ci-actions:
+        patterns: ["*"]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,43 @@
+# CodeQL — GitHub's static-analysis pass for security issues.
+# Runs on PRs to main and weekly on a schedule so newly-published rules
+# catch existing code even when nothing changes.
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "23 7 * * 1" # Mondays 07:23 UTC
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (Go)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+          cache: true
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: go
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:go"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,13 +11,15 @@ Thanks for your interest in contributing. This document covers how to submit cha
 
 ## Development setup
 
+The everyday dev stack lives in the umbrella [`librarium`](https://github.com/fireball1725/librarium) workspace under `local/docker-compose.yml` (api + web + db + mcp). After any code change to `api/`, rebuild and restart:
+
 ```bash
-git clone https://github.com/fireball1725/librarium-api.git
-cd librarium-api
-docker compose up -d --build
+cd local && docker compose up -d --build api
 ```
 
-You'll need Docker. For running Go tooling directly (`go test`, `go vet`), install Go 1.25.
+The standalone `api/docker-compose.yml` exists for api-only deployment scenarios but conflicts on host ports when the `local/` stack is running, so prefer `local/` for everyday development.
+
+For running Go tooling directly (`go test`, `go vet`), install Go 1.25.
 
 ## Making changes
 
@@ -36,7 +38,7 @@ Short, imperative, reference the scope: `feat(covers): accept HEIC uploads`, `fi
 - Rebase on `main` before opening the PR.
 - The PR description should explain the *why*, not just the *what* — link to the issue if there is one.
 - CI must pass before review.
-- For user-facing changes, add a line to `CHANGELOG.md` under `## [Unreleased]` (the release workflow moves it into a versioned section when cutting a release).
+- Don't hand-edit a `CHANGELOG.md` — release notes are auto-generated from PR titles by the release workflow. Write a clear, descriptive title.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,43 @@
+# Security policy
+
+## Reporting a vulnerability
+
+**Please report security issues privately**, not via public issues.
+
+Use GitHub's private vulnerability reporting on this repo:
+
+→ https://github.com/fireball1725/librarium-api/security/advisories/new
+
+That keeps the report visible only to maintainers until a fix is ready, and gives us a paper trail to coordinate disclosure on.
+
+## What's in scope
+
+Anything that lets an attacker:
+
+- Read or modify another user's data (including across libraries on a multi-tenant instance)
+- Bypass authentication, authorization, or the multi-server permission boundary
+- Execute code on the API host, or escape the Postgres / River boundaries
+- Smuggle data through CSV import, ISBN lookup, or cover fetching
+
+If you're not sure whether something counts, file it — we'd rather see a borderline report than miss a real one.
+
+## What's out of scope
+
+- Issues that require admin access on the same machine to exploit
+- Self-XSS that requires the user to paste attacker-supplied JS into their own console
+- Findings from automated scanners that aren't reproducible against a real deployment
+- DoS via volumetric traffic to a self-hosted instance
+
+## Response
+
+This is a small, self-hosted project run by a single maintainer. Best-effort response targets:
+
+- **Acknowledgement**: within 1 week
+- **Initial triage**: within 2 weeks
+- **Fix or mitigation plan**: within 4 weeks for high-severity issues
+
+We'll credit you in the release notes when the fix ships, unless you'd prefer to stay anonymous.
+
+## Disclosure
+
+We follow coordinated disclosure. Once a fix is released and operators have had a reasonable window to update (typically 14 days), the underlying issue can be discussed publicly.


### PR DESCRIPTION
- Bug + feature issue templates with API version required up front; dependabot weekly grouped updates; SECURITY.md routing private vuln reports; CodeQL Go scan; leaner PR template.
- CONTRIBUTING fixes: dev setup now points at the local/ stack; drops the stale CHANGELOG bullet (release notes are auto-generated).