### PR TITLE
chore(docs): darken Redoc response status rows

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,12 +33,21 @@ jobs:
           cp docs/swagger.json site/openapi.json
           # The Redoc community renderer auto-applies dark mode to the
           # main content + right code-samples panel via prefers-color-scheme,
-          # but the sidebar still ships hardcoded light colors. Override
-          # only the sidebar so the whole page is consistent.
+          # but the sidebar and the per-status response rows still ship
+          # hardcoded light colors. Override them so the whole page is
+          # uniformly dark.
           npx --yes @redocly/cli@latest build-docs site/openapi.json -o site/index.html \
             --theme.openapi.theme.sidebar.backgroundColor='#0f1115' \
             --theme.openapi.theme.sidebar.textColor='#e6e6e6' \
-            --theme.openapi.theme.sidebar.activeTextColor='#ffffff'
+            --theme.openapi.theme.sidebar.activeTextColor='#ffffff' \
+            --theme.openapi.theme.colors.responses.success.backgroundColor='rgba(46, 160, 67, 0.15)' \
+            --theme.openapi.theme.colors.responses.success.color='#7ee787' \
+            --theme.openapi.theme.colors.responses.error.backgroundColor='rgba(248, 81, 73, 0.15)' \
+            --theme.openapi.theme.colors.responses.error.color='#ff7b72' \
+            --theme.openapi.theme.colors.responses.redirect.backgroundColor='rgba(187, 128, 9, 0.15)' \
+            --theme.openapi.theme.colors.responses.redirect.color='#d29922' \
+            --theme.openapi.theme.colors.responses.info.backgroundColor='rgba(56, 139, 253, 0.15)' \
+            --theme.openapi.theme.colors.responses.info.color='#58a6ff'
           # Copy swagger.yaml as well so consumers can fetch either format.
           cp docs/swagger.yaml site/openapi.yaml
 


### PR DESCRIPTION
- Follow-up to #29: the per-status response sections (`204`, `400`, `401`, `403`, `404`, …) were still rendered with light pastel backgrounds. Override the per-status colors so they match the rest of the dark page.