### PR TITLE
feat(series): cleanup and refactor

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -216,7 +216,15 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_api_handlers.ollamaModelsResponse"
+                            "type": "object",
+                            "properties": {
+                                "models": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object"
+                                    }
+                                }
+                            }
                         }
                     },
                     "503": {
@@ -256,7 +264,15 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_api_handlers.osaurusModelsResponse"
+                            "type": "object",
+                            "properties": {
+                                "models": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object"
+                                    }
+                                }
+                            }
                         }
                     },
                     "503": {
@@ -1594,106 +1610,6 @@ const docTemplate = `{
                 }
             }
         },
-        "/admin/users/{id}/password": {
-            "put": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Overwrites the target user's local password without the current-password challenge. Instance admin only. Used for admin-driven resets when the user has lost access. Fails with 404 if the target has no local identity (e.g. an external SSO-only account).",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "admin"
-                ],
-                "summary": "Set a user's password (admin)",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "User UUID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "New password",
-                        "name": "body",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "type": "object",
-                            "properties": {
-                                "password": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "object",
-                            "properties": {
-                                "message": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "object",
-                            "properties": {
-                                "error": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "type": "object",
-                            "properties": {
-                                "error": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "type": "object",
-                            "properties": {
-                                "error": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "type": "object",
-                            "properties": {
-                                "error": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
         "/admin/users/{id}": {
             "delete": {
                 "security": [
@@ -1852,6 +1768,106 @@ const docTemplate = `{
                                     "type": "string"
                                 },
                                 "username": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/users/{id}/password": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Overwrites the target user's local password without the\ncurrent-password challenge. Instance admin only. Used for\nadmin-driven resets when the user has lost access. Fails\nwith 404 if the target has no local identity (e.g. an\nexternal SSO-only account).",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Set a user's password (admin)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "New password",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "password": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "message": {
                                     "type": "string"
                                 }
                             }
@@ -6750,12 +6766,6 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "User UUID to attribute reading data to (admin-only when not the caller)",
-                        "name": "attribute_to_user_id",
-                        "in": "formData"
-                    },
-                    {
-                        "type": "string",
                         "description": "Enrich metadata after import",
                         "name": "enrich_metadata",
                         "in": "formData"
@@ -6764,6 +6774,12 @@ const docTemplate = `{
                         "type": "string",
                         "description": "Fetch covers after import",
                         "name": "enrich_covers",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "string",
+                        "description": "User UUID to attribute reading data to (admin-only when not the caller)",
+                        "name": "attribute_to_user_id",
                         "in": "formData"
                     }
                 ],
@@ -8126,6 +8142,411 @@ const docTemplate = `{
                 }
             }
         },
+        "/libraries/{library_id}/series/{series_id}/arcs": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the named arcs defined for a series, ordered by position.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "series"
+                ],
+                "summary": "List arcs for a series",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Library UUID",
+                        "name": "library_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Series UUID",
+                        "name": "series_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "book_count": {
+                                        "type": "integer"
+                                    },
+                                    "created_at": {
+                                        "type": "string"
+                                    },
+                                    "description": {
+                                        "type": "string"
+                                    },
+                                    "id": {
+                                        "type": "string"
+                                    },
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "position": {
+                                        "type": "number"
+                                    },
+                                    "series_id": {
+                                        "type": "string"
+                                    },
+                                    "updated_at": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Adds a new named arc to the series.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "series"
+                ],
+                "summary": "Create an arc within a series",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Library UUID",
+                        "name": "library_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Series UUID",
+                        "name": "series_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Arc details",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "description": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                },
+                                "position": {
+                                    "type": "number"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "book_count": {
+                                    "type": "integer"
+                                },
+                                "created_at": {
+                                    "type": "string"
+                                },
+                                "description": {
+                                    "type": "string"
+                                },
+                                "id": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                },
+                                "position": {
+                                    "type": "number"
+                                },
+                                "series_id": {
+                                    "type": "string"
+                                },
+                                "updated_at": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/libraries/{library_id}/series/{series_id}/arcs/{arc_id}": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Renames or repositions an arc.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "series"
+                ],
+                "summary": "Update an arc",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Library UUID",
+                        "name": "library_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Series UUID",
+                        "name": "series_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Arc UUID",
+                        "name": "arc_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Arc details",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "description": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                },
+                                "position": {
+                                    "type": "number"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "book_count": {
+                                    "type": "integer"
+                                },
+                                "created_at": {
+                                    "type": "string"
+                                },
+                                "description": {
+                                    "type": "string"
+                                },
+                                "id": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                },
+                                "position": {
+                                    "type": "number"
+                                },
+                                "series_id": {
+                                    "type": "string"
+                                },
+                                "updated_at": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Deletes an arc. Books that were in the arc remain in the series; their arc assignment is cleared.",
+                "tags": [
+                    "series"
+                ],
+                "summary": "Delete an arc",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Library UUID",
+                        "name": "library_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Series UUID",
+                        "name": "series_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Arc UUID",
+                        "name": "arc_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/libraries/{library_id}/series/{series_id}/books": {
             "get": {
                 "security": [
@@ -8197,7 +8618,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Sets the position of a book within a series (insert or update).",
+                "description": "Sets the position of a book within a series (insert or update). When ` + "`" + `arc_id` + "`" + ` is present in the body the book is also assigned to that arc; pass an empty string to clear an existing arc assignment without changing it implicitly.",
                 "consumes": [
                     "application/json"
                 ],
@@ -8221,13 +8642,16 @@ const docTemplate = `{
                         "required": true
                     },
                     {
-                        "description": "Book position",
+                        "description": "Book position and optional arc",
                         "name": "body",
                         "in": "body",
                         "required": true,
                         "schema": {
                             "type": "object",
                             "properties": {
+                                "arc_id": {
+                                    "type": "string"
+                                },
                                 "book_id": {
                                     "type": "string"
                                 },
@@ -11100,46 +11524,6 @@ const docTemplate = `{
         }
     },
     "definitions": {
-        "github_com_fireball1725_librarium-api_internal_ai.OllamaModel": {
-            "type": "object",
-            "properties": {
-                "digest": {
-                    "type": "string"
-                },
-                "family": {
-                    "type": "string"
-                },
-                "modified": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "parameter_size": {
-                    "type": "string"
-                },
-                "quantization": {
-                    "type": "string"
-                },
-                "size": {
-                    "type": "integer"
-                }
-            }
-        },
-        "github_com_fireball1725_librarium-api_internal_ai.OsaurusModel": {
-            "type": "object",
-            "properties": {
-                "created": {
-                    "type": "integer"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "owned_by": {
-                    "type": "string"
-                }
-            }
-        },
         "github_com_fireball1725_librarium-api_internal_models.EnrichmentBatch": {
             "type": "object",
             "properties": {
@@ -12235,28 +12619,6 @@ const docTemplate = `{
                 },
                 "token_suffix": {
                     "type": "string"
-                }
-            }
-        },
-        "internal_api_handlers.ollamaModelsResponse": {
-            "type": "object",
-            "properties": {
-                "models": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_ai.OllamaModel"
-                    }
-                }
-            }
-        },
-        "internal_api_handlers.osaurusModelsResponse": {
-            "type": "object",
-            "properties": {
-                "models": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_ai.OsaurusModel"
-                    }
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -210,7 +210,15 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_api_handlers.ollamaModelsResponse"
+                            "type": "object",
+                            "properties": {
+                                "models": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object"
+                                    }
+                                }
+                            }
                         }
                     },
                     "503": {
@@ -250,7 +258,15 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_api_handlers.osaurusModelsResponse"
+                            "type": "object",
+                            "properties": {
+                                "models": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object"
+                                    }
+                                }
+                            }
                         }
                     },
                     "503": {
@@ -1588,106 +1604,6 @@
                 }
             }
         },
-        "/admin/users/{id}/password": {
-            "put": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Overwrites the target user's local password without the current-password challenge. Instance admin only. Used for admin-driven resets when the user has lost access. Fails with 404 if the target has no local identity (e.g. an external SSO-only account).",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "admin"
-                ],
-                "summary": "Set a user's password (admin)",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "User UUID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "New password",
-                        "name": "body",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "type": "object",
-                            "properties": {
-                                "password": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "object",
-                            "properties": {
-                                "message": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "object",
-                            "properties": {
-                                "error": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "type": "object",
-                            "properties": {
-                                "error": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "type": "object",
-                            "properties": {
-                                "error": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "type": "object",
-                            "properties": {
-                                "error": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
         "/admin/users/{id}": {
             "delete": {
                 "security": [
@@ -1846,6 +1762,106 @@
                                     "type": "string"
                                 },
                                 "username": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/users/{id}/password": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Overwrites the target user's local password without the\ncurrent-password challenge. Instance admin only. Used for\nadmin-driven resets when the user has lost access. Fails\nwith 404 if the target has no local identity (e.g. an\nexternal SSO-only account).",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Set a user's password (admin)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "New password",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "password": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "message": {
                                     "type": "string"
                                 }
                             }
@@ -6744,12 +6760,6 @@
                     },
                     {
                         "type": "string",
-                        "description": "User UUID to attribute reading data to (admin-only when not the caller)",
-                        "name": "attribute_to_user_id",
-                        "in": "formData"
-                    },
-                    {
-                        "type": "string",
                         "description": "Enrich metadata after import",
                         "name": "enrich_metadata",
                         "in": "formData"
@@ -6758,6 +6768,12 @@
                         "type": "string",
                         "description": "Fetch covers after import",
                         "name": "enrich_covers",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "string",
+                        "description": "User UUID to attribute reading data to (admin-only when not the caller)",
+                        "name": "attribute_to_user_id",
                         "in": "formData"
                     }
                 ],
@@ -8120,6 +8136,411 @@
                 }
             }
         },
+        "/libraries/{library_id}/series/{series_id}/arcs": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the named arcs defined for a series, ordered by position.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "series"
+                ],
+                "summary": "List arcs for a series",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Library UUID",
+                        "name": "library_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Series UUID",
+                        "name": "series_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "book_count": {
+                                        "type": "integer"
+                                    },
+                                    "created_at": {
+                                        "type": "string"
+                                    },
+                                    "description": {
+                                        "type": "string"
+                                    },
+                                    "id": {
+                                        "type": "string"
+                                    },
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "position": {
+                                        "type": "number"
+                                    },
+                                    "series_id": {
+                                        "type": "string"
+                                    },
+                                    "updated_at": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Adds a new named arc to the series.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "series"
+                ],
+                "summary": "Create an arc within a series",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Library UUID",
+                        "name": "library_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Series UUID",
+                        "name": "series_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Arc details",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "description": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                },
+                                "position": {
+                                    "type": "number"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "book_count": {
+                                    "type": "integer"
+                                },
+                                "created_at": {
+                                    "type": "string"
+                                },
+                                "description": {
+                                    "type": "string"
+                                },
+                                "id": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                },
+                                "position": {
+                                    "type": "number"
+                                },
+                                "series_id": {
+                                    "type": "string"
+                                },
+                                "updated_at": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/libraries/{library_id}/series/{series_id}/arcs/{arc_id}": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Renames or repositions an arc.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "series"
+                ],
+                "summary": "Update an arc",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Library UUID",
+                        "name": "library_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Series UUID",
+                        "name": "series_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Arc UUID",
+                        "name": "arc_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Arc details",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "description": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                },
+                                "position": {
+                                    "type": "number"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "book_count": {
+                                    "type": "integer"
+                                },
+                                "created_at": {
+                                    "type": "string"
+                                },
+                                "description": {
+                                    "type": "string"
+                                },
+                                "id": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                },
+                                "position": {
+                                    "type": "number"
+                                },
+                                "series_id": {
+                                    "type": "string"
+                                },
+                                "updated_at": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Deletes an arc. Books that were in the arc remain in the series; their arc assignment is cleared.",
+                "tags": [
+                    "series"
+                ],
+                "summary": "Delete an arc",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Library UUID",
+                        "name": "library_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Series UUID",
+                        "name": "series_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Arc UUID",
+                        "name": "arc_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/libraries/{library_id}/series/{series_id}/books": {
             "get": {
                 "security": [
@@ -8191,7 +8612,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Sets the position of a book within a series (insert or update).",
+                "description": "Sets the position of a book within a series (insert or update). When `arc_id` is present in the body the book is also assigned to that arc; pass an empty string to clear an existing arc assignment without changing it implicitly.",
                 "consumes": [
                     "application/json"
                 ],
@@ -8215,13 +8636,16 @@
                         "required": true
                     },
                     {
-                        "description": "Book position",
+                        "description": "Book position and optional arc",
                         "name": "body",
                         "in": "body",
                         "required": true,
                         "schema": {
                             "type": "object",
                             "properties": {
+                                "arc_id": {
+                                    "type": "string"
+                                },
                                 "book_id": {
                                     "type": "string"
                                 },
@@ -11094,46 +11518,6 @@
         }
     },
     "definitions": {
-        "github_com_fireball1725_librarium-api_internal_ai.OllamaModel": {
-            "type": "object",
-            "properties": {
-                "digest": {
-                    "type": "string"
-                },
-                "family": {
-                    "type": "string"
-                },
-                "modified": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "parameter_size": {
-                    "type": "string"
-                },
-                "quantization": {
-                    "type": "string"
-                },
-                "size": {
-                    "type": "integer"
-                }
-            }
-        },
-        "github_com_fireball1725_librarium-api_internal_ai.OsaurusModel": {
-            "type": "object",
-            "properties": {
-                "created": {
-                    "type": "integer"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "owned_by": {
-                    "type": "string"
-                }
-            }
-        },
         "github_com_fireball1725_librarium-api_internal_models.EnrichmentBatch": {
             "type": "object",
             "properties": {
@@ -12229,28 +12613,6 @@
                 },
                 "token_suffix": {
                     "type": "string"
-                }
-            }
-        },
-        "internal_api_handlers.ollamaModelsResponse": {
-            "type": "object",
-            "properties": {
-                "models": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_ai.OllamaModel"
-                    }
-                }
-            }
-        },
-        "internal_api_handlers.osaurusModelsResponse": {
-            "type": "object",
-            "properties": {
-                "models": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_ai.OsaurusModel"
-                    }
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,31 +1,5 @@
 basePath: /api/v1
 definitions:
-  github_com_fireball1725_librarium-api_internal_ai.OllamaModel:
-    properties:
-      digest:
-        type: string
-      family:
-        type: string
-      modified:
-        type: string
-      name:
-        type: string
-      parameter_size:
-        type: string
-      quantization:
-        type: string
-      size:
-        type: integer
-    type: object
-  github_com_fireball1725_librarium-api_internal_ai.OsaurusModel:
-    properties:
-      created:
-        type: integer
-      id:
-        type: string
-      owned_by:
-        type: string
-    type: object
   github_com_fireball1725_librarium-api_internal_models.EnrichmentBatch:
     properties:
       book_ids:
@@ -787,20 +761,6 @@ definitions:
       token_suffix:
         type: string
     type: object
-  internal_api_handlers.ollamaModelsResponse:
-    properties:
-      models:
-        items:
-          $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_ai.OllamaModel'
-        type: array
-    type: object
-  internal_api_handlers.osaurusModelsResponse:
-    properties:
-      models:
-        items:
-          $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_ai.OsaurusModel'
-        type: array
-    type: object
   internal_api_handlers.tokenView:
     properties:
       created_at:
@@ -1459,7 +1419,12 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_api_handlers.ollamaModelsResponse'
+            properties:
+              models:
+                items:
+                  type: object
+                type: array
+            type: object
         "503":
           description: Service Unavailable
           schema:
@@ -1487,7 +1452,12 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_api_handlers.osaurusModelsResponse'
+            properties:
+              models:
+                items:
+                  type: object
+                type: array
+            type: object
         "503":
           description: Service Unavailable
           schema:
@@ -2277,72 +2247,6 @@ paths:
       summary: Create a user (admin)
       tags:
       - admin
-  /admin/users/{id}/password:
-    put:
-      consumes:
-      - application/json
-      description: Overwrites the target user's local password without the current-password
-        challenge. Instance admin only. Used for admin-driven resets when the user
-        has lost access. Fails with 404 if the target has no local identity (e.g.
-        an external SSO-only account).
-      parameters:
-      - description: User UUID
-        in: path
-        name: id
-        required: true
-        type: string
-      - description: New password
-        in: body
-        name: body
-        required: true
-        schema:
-          properties:
-            password:
-              type: string
-          type: object
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            properties:
-              message:
-                type: string
-            type: object
-        "400":
-          description: Bad Request
-          schema:
-            properties:
-              error:
-                type: string
-            type: object
-        "401":
-          description: Unauthorized
-          schema:
-            properties:
-              error:
-                type: string
-            type: object
-        "403":
-          description: Forbidden
-          schema:
-            properties:
-              error:
-                type: string
-            type: object
-        "404":
-          description: Not Found
-          schema:
-            properties:
-              error:
-                type: string
-            type: object
-      security:
-      - BearerAuth: []
-      summary: Set a user's password (admin)
-      tags:
-      - admin
   /admin/users/{id}:
     delete:
       description: Permanently deletes a user account. Instance admin only. Cannot
@@ -2476,6 +2380,74 @@ paths:
       security:
       - BearerAuth: []
       summary: Update a user (admin)
+      tags:
+      - admin
+  /admin/users/{id}/password:
+    put:
+      consumes:
+      - application/json
+      description: |-
+        Overwrites the target user's local password without the
+        current-password challenge. Instance admin only. Used for
+        admin-driven resets when the user has lost access. Fails
+        with 404 if the target has no local identity (e.g. an
+        external SSO-only account).
+      parameters:
+      - description: User UUID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: New password
+        in: body
+        name: body
+        required: true
+        schema:
+          properties:
+            password:
+              type: string
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            properties:
+              message:
+                type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+        "403":
+          description: Forbidden
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Set a user's password (admin)
       tags:
       - admin
   /auth/login:
@@ -5582,11 +5554,6 @@ paths:
         in: formData
         name: default_format
         type: string
-      - description: User UUID to attribute reading data to (admin-only when not
-          the caller)
-        in: formData
-        name: attribute_to_user_id
-        type: string
       - description: Enrich metadata after import
         in: formData
         name: enrich_metadata
@@ -5594,6 +5561,11 @@ paths:
       - description: Fetch covers after import
         in: formData
         name: enrich_covers
+        type: string
+      - description: User UUID to attribute reading data to (admin-only when not the
+          caller)
+        in: formData
+        name: attribute_to_user_id
         type: string
       produces:
       - application/json
@@ -6370,6 +6342,268 @@ paths:
       summary: Update a series
       tags:
       - series
+  /libraries/{library_id}/series/{series_id}/arcs:
+    get:
+      description: Returns the named arcs defined for a series, ordered by position.
+      parameters:
+      - description: Library UUID
+        in: path
+        name: library_id
+        required: true
+        type: string
+      - description: Series UUID
+        in: path
+        name: series_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              properties:
+                book_count:
+                  type: integer
+                created_at:
+                  type: string
+                description:
+                  type: string
+                id:
+                  type: string
+                name:
+                  type: string
+                position:
+                  type: number
+                series_id:
+                  type: string
+                updated_at:
+                  type: string
+              type: object
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: List arcs for a series
+      tags:
+      - series
+    post:
+      consumes:
+      - application/json
+      description: Adds a new named arc to the series.
+      parameters:
+      - description: Library UUID
+        in: path
+        name: library_id
+        required: true
+        type: string
+      - description: Series UUID
+        in: path
+        name: series_id
+        required: true
+        type: string
+      - description: Arc details
+        in: body
+        name: body
+        required: true
+        schema:
+          properties:
+            description:
+              type: string
+            name:
+              type: string
+            position:
+              type: number
+          type: object
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            properties:
+              book_count:
+                type: integer
+              created_at:
+                type: string
+              description:
+                type: string
+              id:
+                type: string
+              name:
+                type: string
+              position:
+                type: number
+              series_id:
+                type: string
+              updated_at:
+                type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Create an arc within a series
+      tags:
+      - series
+  /libraries/{library_id}/series/{series_id}/arcs/{arc_id}:
+    delete:
+      description: Deletes an arc. Books that were in the arc remain in the series;
+        their arc assignment is cleared.
+      parameters:
+      - description: Library UUID
+        in: path
+        name: library_id
+        required: true
+        type: string
+      - description: Series UUID
+        in: path
+        name: series_id
+        required: true
+        type: string
+      - description: Arc UUID
+        in: path
+        name: arc_id
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Delete an arc
+      tags:
+      - series
+    put:
+      consumes:
+      - application/json
+      description: Renames or repositions an arc.
+      parameters:
+      - description: Library UUID
+        in: path
+        name: library_id
+        required: true
+        type: string
+      - description: Series UUID
+        in: path
+        name: series_id
+        required: true
+        type: string
+      - description: Arc UUID
+        in: path
+        name: arc_id
+        required: true
+        type: string
+      - description: Arc details
+        in: body
+        name: body
+        required: true
+        schema:
+          properties:
+            description:
+              type: string
+            name:
+              type: string
+            position:
+              type: number
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            properties:
+              book_count:
+                type: integer
+              created_at:
+                type: string
+              description:
+                type: string
+              id:
+                type: string
+              name:
+                type: string
+              position:
+                type: number
+              series_id:
+                type: string
+              updated_at:
+                type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Update an arc
+      tags:
+      - series
   /libraries/{library_id}/series/{series_id}/books:
     get:
       description: Returns all books in a series with their position.
@@ -6416,6 +6650,9 @@ paths:
       consumes:
       - application/json
       description: Sets the position of a book within a series (insert or update).
+        When `arc_id` is present in the body the book is also assigned to that arc;
+        pass an empty string to clear an existing arc assignment without changing
+        it implicitly.
       parameters:
       - description: Library UUID
         in: path
@@ -6427,12 +6664,14 @@ paths:
         name: series_id
         required: true
         type: string
-      - description: Book position
+      - description: Book position and optional arc
         in: body
         name: body
         required: true
         schema:
           properties:
+            arc_id:
+              type: string
             book_id:
               type: string
             position:

--- a/internal/api/handlers/ai.go
+++ b/internal/api/handlers/ai.go
@@ -178,7 +178,7 @@ func (h *AIHandler) SetPermissions(w http.ResponseWriter, r *http.Request) {
 //	@Tags        admin,ai
 //	@Produce     json
 //	@Security    BearerAuth
-//	@Success     200  {object}  ollamaModelsResponse
+//	@Success     200  {object}  object{models=[]object}
 //	@Failure     503  {object}  object{error=string,reachable=boolean}
 //	@Router      /admin/connections/ai/ollama/models [get]
 func (h *AIHandler) ListOllamaModels(w http.ResponseWriter, r *http.Request) {
@@ -200,7 +200,7 @@ func (h *AIHandler) ListOllamaModels(w http.ResponseWriter, r *http.Request) {
 //	@Tags        admin,ai
 //	@Produce     json
 //	@Security    BearerAuth
-//	@Success     200  {object}  osaurusModelsResponse
+//	@Success     200  {object}  object{models=[]object}
 //	@Failure     503  {object}  object{error=string,reachable=boolean}
 //	@Router      /admin/connections/ai/osaurus/models [get]
 func (h *AIHandler) ListOsaurusModels(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handlers/me_lookup.go
+++ b/internal/api/handlers/me_lookup.go
@@ -77,7 +77,8 @@ func (h *MeLookupHandler) SearchSeries(w http.ResponseWriter, r *http.Request) {
 
 	results := make([]MeSeriesResult, 0, 32)
 	for _, lib := range libs {
-		ss, err := h.seriesRepo.List(r.Context(), lib.ID, q, "")
+		// Caller-relative read counts not needed by the cross-library search.
+		ss, err := h.seriesRepo.List(r.Context(), lib.ID, uuid.Nil, q, "")
 		if err != nil {
 			respond.ServerError(w, r, err)
 			return

--- a/internal/api/handlers/series.go
+++ b/internal/api/handlers/series.go
@@ -51,7 +51,8 @@ func (h *SeriesHandler) ListSeries(w http.ResponseWriter, r *http.Request) {
 	}
 	search := r.URL.Query().Get("search")
 	tagFilter := r.URL.Query().Get("tag")
-	list, err := h.svc.ListSeries(r.Context(), libraryID, search, tagFilter)
+	claims := middleware.ClaimsFromContext(r.Context())
+	list, err := h.svc.ListSeries(r.Context(), libraryID, claims.UserID, search, tagFilter)
 	if err != nil {
 		respond.ServerError(w, r, err)
 		return
@@ -117,7 +118,8 @@ func (h *SeriesHandler) GetSeries(w http.ResponseWriter, r *http.Request) {
 		respond.Error(w, http.StatusBadRequest, "invalid series id")
 		return
 	}
-	s, err := h.svc.GetSeries(r.Context(), seriesID)
+	claims := middleware.ClaimsFromContext(r.Context())
+	s, err := h.svc.GetSeries(r.Context(), seriesID, claims.UserID)
 	if errors.Is(err, repository.ErrNotFound) {
 		respond.Error(w, http.StatusNotFound, "series not found")
 		return
@@ -216,7 +218,8 @@ func (h *SeriesHandler) ListSeriesBooks(w http.ResponseWriter, r *http.Request) 
 		respond.Error(w, http.StatusBadRequest, "invalid series id")
 		return
 	}
-	entries, err := h.svc.ListSeriesBooks(r.Context(), seriesID)
+	claims := middleware.ClaimsFromContext(r.Context())
+	entries, err := h.svc.ListSeriesBooks(r.Context(), seriesID, claims.UserID)
 	if err != nil {
 		respond.ServerError(w, r, err)
 		return
@@ -231,13 +234,13 @@ func (h *SeriesHandler) ListSeriesBooks(w http.ResponseWriter, r *http.Request) 
 // UpsertSeriesBook godoc
 //
 // @Summary     Add or update a book in a series
-// @Description Sets the position of a book within a series (insert or update).
+// @Description Sets the position of a book within a series (insert or update). When `arc_id` is present in the body the book is also assigned to that arc; pass an empty string to clear an existing arc assignment without changing it implicitly.
 // @Tags        series
 // @Accept      json
 // @Security    BearerAuth
 // @Param       library_id  path  string  true  "Library UUID"
 // @Param       series_id   path  string  true  "Series UUID"
-// @Param       body        body  object{book_id=string,position=number}  true  "Book position"
+// @Param       body        body  object{book_id=string,position=number,arc_id=string}  true  "Book position and optional arc"
 // @Success     204
 // @Failure     400  {object}  object{error=string}
 // @Failure     401  {object}  object{error=string}
@@ -248,9 +251,14 @@ func (h *SeriesHandler) UpsertSeriesBook(w http.ResponseWriter, r *http.Request)
 		respond.Error(w, http.StatusBadRequest, "invalid series id")
 		return
 	}
+	// arc_id semantics:
+	//   field absent       → leave existing arc assignment untouched
+	//   "" (empty string)  → clear the arc assignment
+	//   "<uuid>"           → assign to that arc
 	var body struct {
 		BookID   string  `json:"book_id"`
 		Position float64 `json:"position"`
+		ArcID    *string `json:"arc_id,omitempty"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		respond.Error(w, http.StatusBadRequest, "invalid request body")
@@ -261,7 +269,159 @@ func (h *SeriesHandler) UpsertSeriesBook(w http.ResponseWriter, r *http.Request)
 		respond.Error(w, http.StatusBadRequest, "invalid book_id")
 		return
 	}
-	if err := h.svc.UpsertSeriesBook(r.Context(), seriesID, bookID, body.Position); err != nil {
+	var arcID *uuid.UUID
+	if body.ArcID != nil {
+		if *body.ArcID == "" {
+			zero := uuid.Nil
+			arcID = &zero
+		} else {
+			parsed, err := uuid.Parse(*body.ArcID)
+			if err != nil {
+				respond.Error(w, http.StatusBadRequest, "invalid arc_id")
+				return
+			}
+			arcID = &parsed
+		}
+	}
+	if err := h.svc.UpsertSeriesBook(r.Context(), seriesID, bookID, body.Position, arcID); err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// ─── Arcs ──────────────────────────────────────────────────────────────────────
+
+// ListSeriesArcs godoc
+//
+// @Summary     List arcs for a series
+// @Description Returns the named arcs defined for a series, ordered by position.
+// @Tags        series
+// @Produce     json
+// @Security    BearerAuth
+// @Param       library_id  path      string  true  "Library UUID"
+// @Param       series_id   path      string  true  "Series UUID"
+// @Success     200  {array}   object{id=string,series_id=string,name=string,description=string,position=number,book_count=integer,created_at=string,updated_at=string}
+// @Failure     400  {object}  object{error=string}
+// @Failure     401  {object}  object{error=string}
+// @Router      /libraries/{library_id}/series/{series_id}/arcs [get]
+func (h *SeriesHandler) ListSeriesArcs(w http.ResponseWriter, r *http.Request) {
+	seriesID, err := uuid.Parse(r.PathValue("series_id"))
+	if err != nil {
+		respond.Error(w, http.StatusBadRequest, "invalid series id")
+		return
+	}
+	arcs, err := h.svc.ListSeriesArcs(r.Context(), seriesID)
+	if err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
+	out := make([]map[string]any, 0, len(arcs))
+	for _, a := range arcs {
+		out = append(out, seriesArcBody(a))
+	}
+	respond.JSON(w, http.StatusOK, out)
+}
+
+// CreateSeriesArc godoc
+//
+// @Summary     Create an arc within a series
+// @Description Adds a new named arc to the series.
+// @Tags        series
+// @Accept      json
+// @Produce     json
+// @Security    BearerAuth
+// @Param       library_id  path      string  true  "Library UUID"
+// @Param       series_id   path      string  true  "Series UUID"
+// @Param       body        body      object{name=string,description=string,position=number}  true  "Arc details"
+// @Success     201  {object}  object{id=string,series_id=string,name=string,description=string,position=number,book_count=integer,created_at=string,updated_at=string}
+// @Failure     400  {object}  object{error=string}
+// @Failure     401  {object}  object{error=string}
+// @Router      /libraries/{library_id}/series/{series_id}/arcs [post]
+func (h *SeriesHandler) CreateSeriesArc(w http.ResponseWriter, r *http.Request) {
+	seriesID, err := uuid.Parse(r.PathValue("series_id"))
+	if err != nil {
+		respond.Error(w, http.StatusBadRequest, "invalid series id")
+		return
+	}
+	req, err := decodeSeriesArcRequest(r)
+	if err != nil {
+		respond.Error(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	arc, err := h.svc.CreateSeriesArc(r.Context(), seriesID, *req)
+	if err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
+	respond.JSON(w, http.StatusCreated, seriesArcBody(arc))
+}
+
+// UpdateSeriesArc godoc
+//
+// @Summary     Update an arc
+// @Description Renames or repositions an arc.
+// @Tags        series
+// @Accept      json
+// @Produce     json
+// @Security    BearerAuth
+// @Param       library_id  path      string  true  "Library UUID"
+// @Param       series_id   path      string  true  "Series UUID"
+// @Param       arc_id      path      string  true  "Arc UUID"
+// @Param       body        body      object{name=string,description=string,position=number}  true  "Arc details"
+// @Success     200  {object}  object{id=string,series_id=string,name=string,description=string,position=number,book_count=integer,created_at=string,updated_at=string}
+// @Failure     400  {object}  object{error=string}
+// @Failure     401  {object}  object{error=string}
+// @Failure     404  {object}  object{error=string}
+// @Router      /libraries/{library_id}/series/{series_id}/arcs/{arc_id} [put]
+func (h *SeriesHandler) UpdateSeriesArc(w http.ResponseWriter, r *http.Request) {
+	arcID, err := uuid.Parse(r.PathValue("arc_id"))
+	if err != nil {
+		respond.Error(w, http.StatusBadRequest, "invalid arc id")
+		return
+	}
+	req, err := decodeSeriesArcRequest(r)
+	if err != nil {
+		respond.Error(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	arc, err := h.svc.UpdateSeriesArc(r.Context(), arcID, *req)
+	if errors.Is(err, repository.ErrNotFound) {
+		respond.Error(w, http.StatusNotFound, "arc not found")
+		return
+	}
+	if err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
+	respond.JSON(w, http.StatusOK, seriesArcBody(arc))
+}
+
+// DeleteSeriesArc godoc
+//
+// @Summary     Delete an arc
+// @Description Deletes an arc. Books that were in the arc remain in the series; their arc assignment is cleared.
+// @Tags        series
+// @Security    BearerAuth
+// @Param       library_id  path  string  true  "Library UUID"
+// @Param       series_id   path  string  true  "Series UUID"
+// @Param       arc_id      path  string  true  "Arc UUID"
+// @Success     204
+// @Failure     400  {object}  object{error=string}
+// @Failure     401  {object}  object{error=string}
+// @Failure     404  {object}  object{error=string}
+// @Router      /libraries/{library_id}/series/{series_id}/arcs/{arc_id} [delete]
+func (h *SeriesHandler) DeleteSeriesArc(w http.ResponseWriter, r *http.Request) {
+	arcID, err := uuid.Parse(r.PathValue("arc_id"))
+	if err != nil {
+		respond.Error(w, http.StatusBadRequest, "invalid arc id")
+		return
+	}
+	if err := h.svc.DeleteSeriesArc(r.Context(), arcID); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			respond.Error(w, http.StatusNotFound, "arc not found")
+			return
+		}
 		respond.ServerError(w, r, err)
 		return
 	}
@@ -727,10 +887,61 @@ func decodeSeriesRequest(r *http.Request) (*service.SeriesRequest, error) {
 	}, nil
 }
 
+func decodeSeriesArcRequest(r *http.Request) (*service.SeriesArcRequest, error) {
+	var body struct {
+		Name        string  `json:"name"`
+		Description string  `json:"description"`
+		Position    float64 `json:"position"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		return nil, errors.New("invalid request body")
+	}
+	if body.Name == "" {
+		return nil, errors.New("name is required")
+	}
+	return &service.SeriesArcRequest{
+		Name:        body.Name,
+		Description: body.Description,
+		Position:    body.Position,
+	}, nil
+}
+
+func seriesArcBody(a *models.SeriesArc) map[string]any {
+	return map[string]any{
+		"id":          a.ID,
+		"series_id":   a.SeriesID,
+		"name":        a.Name,
+		"description": a.Description,
+		"position":    a.Position,
+		"book_count":  a.BookCount,
+		"created_at":  a.CreatedAt,
+		"updated_at":  a.UpdatedAt,
+	}
+}
+
 func tagsToBody(tags []*models.Tag) []map[string]any {
 	out := make([]map[string]any, 0, len(tags))
 	for _, t := range tags {
 		out = append(out, map[string]any{"id": t.ID, "name": t.Name, "color": t.Color})
+	}
+	return out
+}
+
+// previewBooksToBody emits the trimmed shape used to render a series cover
+// mosaic: book_id, title, and a pre-built cover_url (null when the book has
+// no primary cover yet, so the client can render a gradient placeholder).
+func previewBooksToBody(preview []models.SeriesPreviewBook) []map[string]any {
+	out := make([]map[string]any, 0, len(preview))
+	for _, p := range preview {
+		var coverURL any
+		if p.HasCover {
+			coverURL = "/api/v1/books/" + p.BookID.String() + "/cover?v=" + itoa(p.UpdatedAt.Unix())
+		}
+		out = append(out, map[string]any{
+			"book_id":   p.BookID,
+			"title":     p.Title,
+			"cover_url": coverURL,
+		})
 	}
 	return out
 }
@@ -758,6 +969,10 @@ func seriesBody(s *models.Series) map[string]any {
 		"external_id":       s.ExternalID,
 		"external_source":   s.ExternalSource,
 		"book_count":        s.BookCount,
+		"arc_count":         s.ArcCount,
+		"read_count":        s.ReadCount,
+		"reading_count":     s.ReadingCount,
+		"preview_books":     previewBooksToBody(s.PreviewBooks),
 		"tags":              tagsToBody(tags),
 		"created_at":        s.CreatedAt,
 		"updated_at":        s.UpdatedAt,
@@ -790,12 +1005,24 @@ func seriesEntryBody(e *models.SeriesEntry) map[string]any {
 	if contribs == nil {
 		contribs = []models.BookContributor{}
 	}
-	return map[string]any{
-		"position":     e.Position,
-		"book_id":      e.BookID,
-		"title":        e.Title,
-		"subtitle":     e.Subtitle,
-		"media_type":   e.MediaType,
-		"contributors": contribs,
+	var coverURL any
+	if e.HasCover {
+		coverURL = "/api/v1/books/" + e.BookID.String() + "/cover?v=" + itoa(e.UpdatedAt.Unix())
 	}
+	body := map[string]any{
+		"position":         e.Position,
+		"book_id":          e.BookID,
+		"title":            e.Title,
+		"subtitle":         e.Subtitle,
+		"media_type":       e.MediaType,
+		"cover_url":        coverURL,
+		"user_read_status": e.UserReadStatus,
+		"contributors":     contribs,
+	}
+	if e.ArcID != nil {
+		body["arc_id"] = *e.ArcID
+	} else {
+		body["arc_id"] = nil
+	}
+	return body
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -57,6 +57,7 @@ func NewRouter(ctx context.Context, db *pgxpool.Pool, cfg *config.Config, riverC
 	shelfRepo := repository.NewShelfRepo(db)
 	loanRepo := repository.NewLoanRepo(db)
 	seriesRepo := repository.NewSeriesRepo(db)
+	seriesArcRepo := repository.NewSeriesArcRepo(db)
 	coverRepo := repository.NewCoverRepo(db)
 	storageLocationRepo := repository.NewStorageLocationRepo(db)
 	editionFileRepo := repository.NewEditionFileRepo(db)
@@ -83,7 +84,7 @@ func NewRouter(ctx context.Context, db *pgxpool.Pool, cfg *config.Config, riverC
 	contributorSvc := service.NewContributorService(contributorRepo, bookRepo, coverRepo, providerSvc.Registry(), cfg.CoverStoragePath)
 
 	loanSvc := service.NewLoanService(loanRepo, tagRepo)
-	seriesSvc := service.NewSeriesService(seriesRepo, seriesVolumesRepo, tagRepo)
+	seriesSvc := service.NewSeriesService(seriesRepo, seriesArcRepo, seriesVolumesRepo, tagRepo)
 	releaseSyncSvc := service.NewReleaseSyncService(seriesRepo, seriesVolumesRepo, providerSvc)
 
 	authSvc := service.NewAuthService(db, userRepo, identityRepo, tokenRepo, denylistRepo, jwtSvc, service.AuthConfig{
@@ -379,6 +380,12 @@ func NewRouter(ctx context.Context, db *pgxpool.Pool, cfg *config.Config, riverC
 	mux.Handle("POST /api/v1/libraries/{library_id}/series/{series_id}/volumes/sync", requireLibraryPerm("series:update", http.HandlerFunc(seriesHandler.SyncSeriesVolumes)))
 	mux.Handle("GET /api/v1/libraries/{library_id}/series/{series_id}/match-candidates", requireLibraryPerm("series:read", http.HandlerFunc(seriesHandler.MatchCandidates)))
 	mux.Handle("POST /api/v1/libraries/{library_id}/series/{series_id}/match-apply", requireLibraryPerm("series:update", http.HandlerFunc(seriesHandler.ApplyMatches)))
+
+	// Series arcs (optional named groupings within a series)
+	mux.Handle("GET /api/v1/libraries/{library_id}/series/{series_id}/arcs", requireLibraryPerm("series:read", http.HandlerFunc(seriesHandler.ListSeriesArcs)))
+	mux.Handle("POST /api/v1/libraries/{library_id}/series/{series_id}/arcs", requireLibraryPerm("series:update", http.HandlerFunc(seriesHandler.CreateSeriesArc)))
+	mux.Handle("PUT /api/v1/libraries/{library_id}/series/{series_id}/arcs/{arc_id}", requireLibraryPerm("series:update", http.HandlerFunc(seriesHandler.UpdateSeriesArc)))
+	mux.Handle("DELETE /api/v1/libraries/{library_id}/series/{series_id}/arcs/{arc_id}", requireLibraryPerm("series:update", http.HandlerFunc(seriesHandler.DeleteSeriesArc)))
 
 	// Shelves for a book
 	mux.Handle("GET /api/v1/libraries/{library_id}/books/{book_id}/shelves", requireLibraryPerm("shelves:read", http.HandlerFunc(shelfHandler.ListBookShelves)))

--- a/internal/db/migrations/000012_series_arcs.down.sql
+++ b/internal/db/migrations/000012_series_arcs.down.sql
@@ -1,0 +1,6 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Copyright (C) 2026 fireball1725
+
+DROP INDEX IF EXISTS idx_book_series_arc_id;
+ALTER TABLE book_series DROP COLUMN IF EXISTS arc_id;
+DROP TABLE IF EXISTS series_arcs;

--- a/internal/db/migrations/000012_series_arcs.up.sql
+++ b/internal/db/migrations/000012_series_arcs.up.sql
@@ -1,0 +1,30 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Copyright (C) 2026 fireball1725
+--
+-- Series can optionally be split into named arcs (manga story arcs,
+-- multi-trilogy fiction sub-series like Realm of the Elderlings, etc).
+-- Books opt in via book_series.arc_id; series with no arcs render flat.
+
+CREATE TABLE series_arcs (
+    id          UUID          PRIMARY KEY DEFAULT gen_random_uuid(),
+    series_id   UUID          NOT NULL REFERENCES series(id) ON DELETE CASCADE,
+    name        VARCHAR(256)  NOT NULL,
+    description TEXT,
+    position    NUMERIC(6,1)  NOT NULL DEFAULT 1,
+    created_at  TIMESTAMPTZ   NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ   NOT NULL DEFAULT NOW(),
+    UNIQUE (series_id, name)
+);
+
+CREATE TRIGGER series_arcs_updated_at
+    BEFORE UPDATE ON series_arcs
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+CREATE INDEX idx_series_arcs_series_id ON series_arcs(series_id);
+
+-- Books still belong to a series via book_series; arc_id is optional. When
+-- an arc is deleted the books in it stay in the series, just unassigned.
+ALTER TABLE book_series
+    ADD COLUMN arc_id UUID REFERENCES series_arcs(id) ON DELETE SET NULL;
+
+CREATE INDEX idx_book_series_arc_id ON book_series(arc_id);

--- a/internal/models/series.go
+++ b/internal/models/series.go
@@ -25,10 +25,42 @@ type Series struct {
 	ExternalSource   string     `json:"external_source"`
 	LastReleaseDate  *time.Time `json:"last_release_date"`
 	NextReleaseDate  *time.Time `json:"next_release_date"`
-	BookCount        int        `json:"book_count"`
-	Tags             []*Tag     `json:"tags"`
-	CreatedAt        time.Time  `json:"created_at"`
-	UpdatedAt        time.Time  `json:"updated_at"`
+	BookCount        int                  `json:"book_count"`
+	ArcCount         int                  `json:"arc_count"`
+	// Caller-relative reading state. Only populated when the caller is known
+	// (List / FindByID receive a non-zero callerID). Both default to 0 when
+	// not populated, which is fine because clients gate the indicator behind
+	// the user's `show_read_badges` preference anyway.
+	ReadCount        int                  `json:"read_count"`
+	ReadingCount     int                  `json:"reading_count"`
+	PreviewBooks     []SeriesPreviewBook  `json:"preview_books"`
+	Tags             []*Tag               `json:"tags"`
+	CreatedAt        time.Time            `json:"created_at"`
+	UpdatedAt        time.Time            `json:"updated_at"`
+}
+
+// SeriesPreviewBook is the trimmed shape used to assemble a series cover
+// mosaic on list views — first 4 books by position, with just enough data
+// to render a small thumbnail.
+type SeriesPreviewBook struct {
+	BookID    uuid.UUID `json:"book_id"`
+	Title     string    `json:"title"`
+	HasCover  bool      `json:"has_cover"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// SeriesArc is an optional named grouping of books inside a series. Manga
+// story arcs, multi-trilogy fiction sub-series, etc. A series can have zero
+// or more arcs; books opt in by setting their book_series.arc_id.
+type SeriesArc struct {
+	ID          uuid.UUID `json:"id"`
+	SeriesID    uuid.UUID `json:"series_id"`
+	Name        string    `json:"name"`
+	Description string    `json:"description"`
+	Position    float64   `json:"position"`
+	BookCount   int       `json:"book_count"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
 }
 
 type SeriesVolume struct {
@@ -45,12 +77,16 @@ type SeriesVolume struct {
 
 // SeriesEntry is a book entry within a series, including its reading position.
 type SeriesEntry struct {
-	Position     float64
-	BookID       uuid.UUID
-	Title        string
-	Subtitle     string
-	MediaType    string
-	Contributors []BookContributor
+	Position       float64
+	BookID         uuid.UUID
+	ArcID          *uuid.UUID
+	Title          string
+	Subtitle       string
+	MediaType      string
+	HasCover       bool
+	UpdatedAt      time.Time
+	UserReadStatus string // empty when caller is anonymous or no interactions
+	Contributors   []BookContributor
 }
 
 // BookSeriesRef is a lightweight reference used when looking up which series a book belongs to.

--- a/internal/repository/series.go
+++ b/internal/repository/series.go
@@ -31,9 +31,50 @@ const seriesTagsSubquery = `
         '[]'::json
     )`
 
+// readStateSubqueries returns the SELECT-list expressions for `read_count`
+// and `reading_count` against the caller's effective read status. The
+// effective status uses the same priority ordering as booksSelect — read >
+// reading > did_not_finish — so series indicators match book-cover badges.
+// When callerArg is 0, both counts are emitted as 0 so the column count
+// stays stable.
+func readStateSubqueries(callerArg int) string {
+	if callerArg == 0 {
+		return `0 AS read_count, 0 AS reading_count`
+	}
+	return fmt.Sprintf(`
+       (SELECT COUNT(*)::int FROM book_series bs2
+          JOIN books b ON b.id = bs2.book_id
+          WHERE bs2.series_id = s.id AND (
+              SELECT ubi.read_status FROM book_editions be
+              JOIN user_book_interactions ubi ON ubi.book_edition_id = be.id
+              WHERE be.book_id = b.id AND ubi.user_id = $%d
+              ORDER BY CASE ubi.read_status
+                  WHEN 'read' THEN 1
+                  WHEN 'reading' THEN 2
+                  WHEN 'did_not_finish' THEN 3
+                  ELSE 4
+              END
+              LIMIT 1
+          ) = 'read') AS read_count,
+       (SELECT COUNT(*)::int FROM book_series bs2
+          JOIN books b ON b.id = bs2.book_id
+          WHERE bs2.series_id = s.id AND (
+              SELECT ubi.read_status FROM book_editions be
+              JOIN user_book_interactions ubi ON ubi.book_edition_id = be.id
+              WHERE be.book_id = b.id AND ubi.user_id = $%d
+              ORDER BY CASE ubi.read_status
+                  WHEN 'read' THEN 1
+                  WHEN 'reading' THEN 2
+                  WHEN 'did_not_finish' THEN 3
+                  ELSE 4
+              END
+              LIMIT 1
+          ) = 'reading') AS reading_count`, callerArg, callerArg)
+}
+
 // ─── Series CRUD ──────────────────────────────────────────────────────────────
 
-func (r *SeriesRepo) List(ctx context.Context, libraryID uuid.UUID, search, tagFilter string) ([]*models.Series, error) {
+func (r *SeriesRepo) List(ctx context.Context, libraryID, callerID uuid.UUID, search, tagFilter string) ([]*models.Series, error) {
 	args := []any{libraryID}
 	where := `WHERE s.library_id = $1`
 	if search != "" {
@@ -44,6 +85,11 @@ func (r *SeriesRepo) List(ctx context.Context, libraryID uuid.UUID, search, tagF
 		args = append(args, tagFilter)
 		where += fmt.Sprintf(` AND EXISTS (SELECT 1 FROM series_tags st JOIN tags t ON t.id = st.tag_id WHERE st.series_id = s.id AND lower(t.name) = lower($%d))`, len(args))
 	}
+	callerArg := 0
+	if callerID != uuid.Nil {
+		args = append(args, callerID)
+		callerArg = len(args)
+	}
 
 	q := `
 		SELECT s.id, s.library_id, s.name, COALESCE(s.description,''),
@@ -53,6 +99,25 @@ func (r *SeriesRepo) List(ctx context.Context, libraryID uuid.UUID, search, tagF
 		       (SELECT MAX(sv.release_date) FROM series_volumes sv WHERE sv.series_id = s.id AND sv.release_date <= CURRENT_DATE) AS last_release_date,
 		       (SELECT MIN(sv.release_date) FROM series_volumes sv WHERE sv.series_id = s.id AND sv.release_date > CURRENT_DATE) AS next_release_date,
 		       COUNT(bs.book_id) AS book_count,
+		       (SELECT COUNT(*) FROM series_arcs sa WHERE sa.series_id = s.id) AS arc_count,
+		       ` + readStateSubqueries(callerArg) + `,
+		       (
+		           SELECT COALESCE(json_agg(jsonb_build_object(
+		               'book_id', t.id,
+		               'title', t.title,
+		               'updated_at', t.updated_at,
+		               'has_cover', t.has_cover
+		           ) ORDER BY t.position), '[]'::json)
+		           FROM (
+		               SELECT b.id, b.title, b.updated_at, bs2.position,
+		                      EXISTS(SELECT 1 FROM cover_images ci
+		                             WHERE ci.entity_type='book' AND ci.entity_id=b.id AND ci.is_primary=true) AS has_cover
+		               FROM book_series bs2 JOIN books b ON b.id = bs2.book_id
+		               WHERE bs2.series_id = s.id
+		               ORDER BY bs2.position
+		               LIMIT 4
+		           ) t
+		       ) AS preview_books,
 		       s.created_at, s.updated_at,
 		       ` + seriesTagsSubquery + ` AS tags
 		FROM series s
@@ -78,7 +143,13 @@ func (r *SeriesRepo) List(ctx context.Context, libraryID uuid.UUID, search, tagF
 	return out, rows.Err()
 }
 
-func (r *SeriesRepo) FindByID(ctx context.Context, id uuid.UUID) (*models.Series, error) {
+func (r *SeriesRepo) FindByID(ctx context.Context, id, callerID uuid.UUID) (*models.Series, error) {
+	args := []any{id}
+	callerArg := 0
+	if callerID != uuid.Nil {
+		args = append(args, callerID)
+		callerArg = len(args)
+	}
 	q := `
 		SELECT s.id, s.library_id, s.name, COALESCE(s.description,''),
 		       s.total_count, s.status, s.original_language, s.publication_year,
@@ -87,13 +158,32 @@ func (r *SeriesRepo) FindByID(ctx context.Context, id uuid.UUID) (*models.Series
 		       (SELECT MAX(sv.release_date) FROM series_volumes sv WHERE sv.series_id = s.id AND sv.release_date <= CURRENT_DATE) AS last_release_date,
 		       (SELECT MIN(sv.release_date) FROM series_volumes sv WHERE sv.series_id = s.id AND sv.release_date > CURRENT_DATE) AS next_release_date,
 		       COUNT(bs.book_id) AS book_count,
+		       (SELECT COUNT(*) FROM series_arcs sa WHERE sa.series_id = s.id) AS arc_count,
+		       ` + readStateSubqueries(callerArg) + `,
+		       (
+		           SELECT COALESCE(json_agg(jsonb_build_object(
+		               'book_id', t.id,
+		               'title', t.title,
+		               'updated_at', t.updated_at,
+		               'has_cover', t.has_cover
+		           ) ORDER BY t.position), '[]'::json)
+		           FROM (
+		               SELECT b.id, b.title, b.updated_at, bs2.position,
+		                      EXISTS(SELECT 1 FROM cover_images ci
+		                             WHERE ci.entity_type='book' AND ci.entity_id=b.id AND ci.is_primary=true) AS has_cover
+		               FROM book_series bs2 JOIN books b ON b.id = bs2.book_id
+		               WHERE bs2.series_id = s.id
+		               ORDER BY bs2.position
+		               LIMIT 4
+		           ) t
+		       ) AS preview_books,
 		       s.created_at, s.updated_at,
 		       ` + seriesTagsSubquery + ` AS tags
 		FROM series s
 		LEFT JOIN book_series bs ON bs.series_id = s.id
 		WHERE s.id = $1
 		GROUP BY s.id`
-	s, err := scanSeries(r.db.QueryRow(ctx, q, id))
+	s, err := scanSeries(r.db.QueryRow(ctx, q, args...))
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, ErrNotFound
 	}
@@ -116,7 +206,7 @@ func (r *SeriesRepo) Create(ctx context.Context, id, libraryID uuid.UUID, name, 
 	if _, err := r.db.Exec(ctx, q, id, libraryID, name, description, totalCount, status, originalLanguage, publicationYear, demographic, genres, url, externalID, externalSource, createdBy); err != nil {
 		return nil, fmt.Errorf("inserting series: %w", err)
 	}
-	return r.FindByID(ctx, id)
+	return r.FindByID(ctx, id, uuid.Nil)
 }
 
 func (r *SeriesRepo) Update(ctx context.Context, id uuid.UUID, name, description string, totalCount *int, status, originalLanguage string, publicationYear *int, demographic string, genres []string, url string, externalID, externalSource string) (*models.Series, error) {
@@ -148,7 +238,7 @@ func (r *SeriesRepo) Update(ctx context.Context, id uuid.UUID, name, description
 	if result.RowsAffected() == 0 {
 		return nil, ErrNotFound
 	}
-	return r.FindByID(ctx, id)
+	return r.FindByID(ctx, id, uuid.Nil)
 }
 
 func (r *SeriesRepo) Delete(ctx context.Context, id uuid.UUID) error {
@@ -164,11 +254,34 @@ func (r *SeriesRepo) Delete(ctx context.Context, id uuid.UUID) error {
 
 // ─── Series entries ───────────────────────────────────────────────────────────
 
-func (r *SeriesRepo) ListBooks(ctx context.Context, seriesID uuid.UUID) ([]*models.SeriesEntry, error) {
-	const q = `
+func (r *SeriesRepo) ListBooks(ctx context.Context, seriesID, callerID uuid.UUID) ([]*models.SeriesEntry, error) {
+	args := []any{seriesID}
+	userStatusExpr := `'' AS user_read_status`
+	if callerID != uuid.Nil {
+		args = append(args, callerID)
+		userStatusExpr = fmt.Sprintf(`COALESCE((
+			SELECT ubi.read_status
+			FROM book_editions be
+			JOIN user_book_interactions ubi ON ubi.book_edition_id = be.id
+			WHERE be.book_id = b.id AND ubi.user_id = $%d
+			ORDER BY CASE ubi.read_status
+				WHEN 'read' THEN 1
+				WHEN 'reading' THEN 2
+				WHEN 'did_not_finish' THEN 3
+				ELSE 4
+			END
+			LIMIT 1
+		), '') AS user_read_status`, len(args))
+	}
+	q := `
 		SELECT
 			bs.position,
 			b.id, b.title, COALESCE(b.subtitle,''), mt.display_name,
+			bs.arc_id,
+			b.updated_at,
+			EXISTS(SELECT 1 FROM cover_images ci
+			       WHERE ci.entity_type='book' AND ci.entity_id=b.id AND ci.is_primary=true) AS has_cover,
+			` + userStatusExpr + `,
 			(
 				SELECT COALESCE(
 					json_agg(
@@ -190,7 +303,7 @@ func (r *SeriesRepo) ListBooks(ctx context.Context, seriesID uuid.UUID) ([]*mode
 		JOIN media_types mt ON mt.id = b.media_type_id
 		WHERE bs.series_id = $1
 		ORDER BY bs.position`
-	rows, err := r.db.Query(ctx, q, seriesID)
+	rows, err := r.db.Query(ctx, q, args...)
 	if err != nil {
 		return nil, fmt.Errorf("listing series books: %w", err)
 	}
@@ -384,17 +497,18 @@ func (r *SeriesRepo) RemoveBook(ctx context.Context, seriesID, bookID uuid.UUID)
 
 func scanSeries(s scanner) (*models.Series, error) {
 	var (
-		pgID          pgtype.UUID
-		pgLibraryID   pgtype.UUID
-		pgTotal       pgtype.Int4
-		pgOrigLang    pgtype.Text
-		pgPubYear     pgtype.Int4
-		pgDemographic pgtype.Text
-		genres        []string
-		pgLastDate    pgtype.Date
-		pgNextDate    pgtype.Date
-		tagsJSON      []byte
-		ser           models.Series
+		pgID            pgtype.UUID
+		pgLibraryID     pgtype.UUID
+		pgTotal         pgtype.Int4
+		pgOrigLang      pgtype.Text
+		pgPubYear       pgtype.Int4
+		pgDemographic   pgtype.Text
+		genres          []string
+		pgLastDate      pgtype.Date
+		pgNextDate      pgtype.Date
+		previewJSON     []byte
+		tagsJSON        []byte
+		ser             models.Series
 	)
 	err := s.Scan(
 		&pgID, &pgLibraryID, &ser.Name, &ser.Description,
@@ -403,6 +517,9 @@ func scanSeries(s scanner) (*models.Series, error) {
 		&ser.ExternalID, &ser.ExternalSource,
 		&pgLastDate, &pgNextDate,
 		&ser.BookCount,
+		&ser.ArcCount,
+		&ser.ReadCount, &ser.ReadingCount,
+		&previewJSON,
 		&ser.CreatedAt, &ser.UpdatedAt,
 		&tagsJSON,
 	)
@@ -441,23 +558,35 @@ func scanSeries(s scanner) (*models.Series, error) {
 	if err := json.Unmarshal(tagsJSON, &ser.Tags); err != nil || ser.Tags == nil {
 		ser.Tags = []*models.Tag{}
 	}
+	if err := json.Unmarshal(previewJSON, &ser.PreviewBooks); err != nil || ser.PreviewBooks == nil {
+		ser.PreviewBooks = []models.SeriesPreviewBook{}
+	}
 	return &ser, nil
 }
 
 func scanSeriesEntry(s scanner) (*models.SeriesEntry, error) {
 	var (
 		pgBookID     pgtype.UUID
+		pgArcID      pgtype.UUID
 		contribsJSON []byte
 		entry        models.SeriesEntry
 	)
 	if err := s.Scan(
 		&entry.Position,
 		&pgBookID, &entry.Title, &entry.Subtitle, &entry.MediaType,
+		&pgArcID,
+		&entry.UpdatedAt,
+		&entry.HasCover,
+		&entry.UserReadStatus,
 		&contribsJSON,
 	); err != nil {
 		return nil, err
 	}
 	entry.BookID = uuid.UUID(pgBookID.Bytes)
+	if pgArcID.Valid {
+		id := uuid.UUID(pgArcID.Bytes)
+		entry.ArcID = &id
+	}
 	if err := json.Unmarshal(contribsJSON, &entry.Contributors); err != nil {
 		entry.Contributors = nil
 	}

--- a/internal/repository/series_arcs.go
+++ b/internal/repository/series_arcs.go
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725 (Adaléa)
+
+package repository
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/fireball1725/librarium-api/internal/models"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type SeriesArcRepo struct {
+	db *pgxpool.Pool
+}
+
+func NewSeriesArcRepo(db *pgxpool.Pool) *SeriesArcRepo {
+	return &SeriesArcRepo{db: db}
+}
+
+func (r *SeriesArcRepo) List(ctx context.Context, seriesID uuid.UUID) ([]*models.SeriesArc, error) {
+	const q = `
+		SELECT a.id, a.series_id, a.name, COALESCE(a.description, ''),
+		       a.position, a.created_at, a.updated_at,
+		       (SELECT COUNT(*) FROM book_series bs WHERE bs.arc_id = a.id) AS book_count
+		FROM series_arcs a
+		WHERE a.series_id = $1
+		ORDER BY a.position, a.name`
+	rows, err := r.db.Query(ctx, q, seriesID)
+	if err != nil {
+		return nil, fmt.Errorf("listing series arcs: %w", err)
+	}
+	defer rows.Close()
+
+	out := []*models.SeriesArc{}
+	for rows.Next() {
+		arc, err := scanSeriesArc(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, arc)
+	}
+	return out, rows.Err()
+}
+
+func (r *SeriesArcRepo) FindByID(ctx context.Context, id uuid.UUID) (*models.SeriesArc, error) {
+	const q = `
+		SELECT a.id, a.series_id, a.name, COALESCE(a.description, ''),
+		       a.position, a.created_at, a.updated_at,
+		       (SELECT COUNT(*) FROM book_series bs WHERE bs.arc_id = a.id) AS book_count
+		FROM series_arcs a
+		WHERE a.id = $1`
+	arc, err := scanSeriesArc(r.db.QueryRow(ctx, q, id))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("finding series arc: %w", err)
+	}
+	return arc, nil
+}
+
+func (r *SeriesArcRepo) Create(ctx context.Context, id, seriesID uuid.UUID, name, description string, position float64) (*models.SeriesArc, error) {
+	const q = `
+		INSERT INTO series_arcs (id, series_id, name, description, position)
+		VALUES ($1, $2, $3, NULLIF($4,''), $5)`
+	if _, err := r.db.Exec(ctx, q, id, seriesID, name, description, position); err != nil {
+		return nil, fmt.Errorf("inserting series arc: %w", err)
+	}
+	return r.FindByID(ctx, id)
+}
+
+func (r *SeriesArcRepo) Update(ctx context.Context, id uuid.UUID, name, description string, position float64) (*models.SeriesArc, error) {
+	const q = `
+		UPDATE series_arcs
+		SET name        = $2,
+		    description = NULLIF($3, ''),
+		    position    = $4,
+		    updated_at  = NOW()
+		WHERE id = $1`
+	result, err := r.db.Exec(ctx, q, id, name, description, position)
+	if err != nil {
+		return nil, fmt.Errorf("updating series arc: %w", err)
+	}
+	if result.RowsAffected() == 0 {
+		return nil, ErrNotFound
+	}
+	return r.FindByID(ctx, id)
+}
+
+func (r *SeriesArcRepo) Delete(ctx context.Context, id uuid.UUID) error {
+	result, err := r.db.Exec(ctx, `DELETE FROM series_arcs WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("deleting series arc: %w", err)
+	}
+	if result.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// SetBookArc assigns or unassigns a book within a series to/from an arc. Pass
+// arcID = nil to clear the assignment. Returns ErrNotFound when the (series,
+// book) pair is not in book_series.
+func (r *SeriesArcRepo) SetBookArc(ctx context.Context, seriesID, bookID uuid.UUID, arcID *uuid.UUID) error {
+	result, err := r.db.Exec(ctx,
+		`UPDATE book_series SET arc_id = $3 WHERE series_id = $1 AND book_id = $2`,
+		seriesID, bookID, arcID,
+	)
+	if err != nil {
+		return fmt.Errorf("setting book arc: %w", err)
+	}
+	if result.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func scanSeriesArc(s scanner) (*models.SeriesArc, error) {
+	var (
+		pgID       pgtype.UUID
+		pgSeriesID pgtype.UUID
+		arc        models.SeriesArc
+	)
+	err := s.Scan(
+		&pgID, &pgSeriesID, &arc.Name, &arc.Description,
+		&arc.Position, &arc.CreatedAt, &arc.UpdatedAt,
+		&arc.BookCount,
+	)
+	if err != nil {
+		return nil, err
+	}
+	arc.ID = uuid.UUID(pgID.Bytes)
+	arc.SeriesID = uuid.UUID(pgSeriesID.Bytes)
+	return &arc, nil
+}

--- a/internal/service/releases.go
+++ b/internal/service/releases.go
@@ -25,7 +25,7 @@ func NewReleaseSyncService(seriesRepo *repository.SeriesRepo, volumesRepo *repos
 
 // SyncSeries fetches volume data for a single series from its linked provider.
 func (s *ReleaseSyncService) SyncSeries(ctx context.Context, seriesID uuid.UUID) error {
-	series, err := s.seriesRepo.FindByID(ctx, seriesID)
+	series, err := s.seriesRepo.FindByID(ctx, seriesID, uuid.Nil)
 	if err != nil {
 		return fmt.Errorf("finding series: %w", err)
 	}

--- a/internal/service/series.go
+++ b/internal/service/series.go
@@ -16,12 +16,13 @@ import (
 
 type SeriesService struct {
 	series  *repository.SeriesRepo
+	arcs    *repository.SeriesArcRepo
 	volumes *repository.SeriesVolumesRepo
 	tags    *repository.TagRepo
 }
 
-func NewSeriesService(series *repository.SeriesRepo, volumes *repository.SeriesVolumesRepo, tags *repository.TagRepo) *SeriesService {
-	return &SeriesService{series: series, volumes: volumes, tags: tags}
+func NewSeriesService(series *repository.SeriesRepo, arcs *repository.SeriesArcRepo, volumes *repository.SeriesVolumesRepo, tags *repository.TagRepo) *SeriesService {
+	return &SeriesService{series: series, arcs: arcs, volumes: volumes, tags: tags}
 }
 
 type SeriesRequest struct {
@@ -39,12 +40,12 @@ type SeriesRequest struct {
 	TagIDs           []uuid.UUID
 }
 
-func (s *SeriesService) ListSeries(ctx context.Context, libraryID uuid.UUID, search, tagFilter string) ([]*models.Series, error) {
-	return s.series.List(ctx, libraryID, search, tagFilter)
+func (s *SeriesService) ListSeries(ctx context.Context, libraryID, callerID uuid.UUID, search, tagFilter string) ([]*models.Series, error) {
+	return s.series.List(ctx, libraryID, callerID, search, tagFilter)
 }
 
-func (s *SeriesService) GetSeries(ctx context.Context, id uuid.UUID) (*models.Series, error) {
-	return s.series.FindByID(ctx, id)
+func (s *SeriesService) GetSeries(ctx context.Context, id, callerID uuid.UUID) (*models.Series, error) {
+	return s.series.FindByID(ctx, id, callerID)
 }
 
 func (s *SeriesService) CreateSeries(ctx context.Context, libraryID, callerID uuid.UUID, req SeriesRequest) (*models.Series, error) {
@@ -60,7 +61,7 @@ func (s *SeriesService) CreateSeries(ctx context.Context, libraryID, callerID uu
 			return nil, fmt.Errorf("setting series tags: %w", err)
 		}
 		// Reload to get tags populated
-		ser, err = s.series.FindByID(ctx, ser.ID)
+		ser, err = s.series.FindByID(ctx, ser.ID, uuid.Nil)
 		if err != nil {
 			return nil, err
 		}
@@ -81,7 +82,7 @@ func (s *SeriesService) UpdateSeries(ctx context.Context, id uuid.UUID, req Seri
 			return nil, fmt.Errorf("setting series tags: %w", err)
 		}
 		// Reload to get tags populated
-		ser, err = s.series.FindByID(ctx, ser.ID)
+		ser, err = s.series.FindByID(ctx, ser.ID, uuid.Nil)
 		if err != nil {
 			return nil, err
 		}
@@ -93,16 +94,63 @@ func (s *SeriesService) DeleteSeries(ctx context.Context, id uuid.UUID) error {
 	return s.series.Delete(ctx, id)
 }
 
-func (s *SeriesService) ListSeriesBooks(ctx context.Context, seriesID uuid.UUID) ([]*models.SeriesEntry, error) {
-	return s.series.ListBooks(ctx, seriesID)
+func (s *SeriesService) ListSeriesBooks(ctx context.Context, seriesID, callerID uuid.UUID) ([]*models.SeriesEntry, error) {
+	return s.series.ListBooks(ctx, seriesID, callerID)
 }
 
-func (s *SeriesService) UpsertSeriesBook(ctx context.Context, seriesID, bookID uuid.UUID, position float64) error {
-	return s.series.UpsertBook(ctx, seriesID, bookID, position)
+// UpsertSeriesBook places a book at a given position within the series. If
+// arcID is non-nil it also assigns the book to that arc (or unassigns when
+// arcID points at a zero UUID — see handler decoding).
+func (s *SeriesService) UpsertSeriesBook(ctx context.Context, seriesID, bookID uuid.UUID, position float64, arcID *uuid.UUID) error {
+	if err := s.series.UpsertBook(ctx, seriesID, bookID, position); err != nil {
+		return err
+	}
+	if arcID != nil {
+		// Caller wants to set or clear the arc explicitly. A zero UUID means
+		// "clear"; otherwise it's the target arc.
+		var target *uuid.UUID
+		if *arcID != uuid.Nil {
+			target = arcID
+		}
+		if err := s.arcs.SetBookArc(ctx, seriesID, bookID, target); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (s *SeriesService) RemoveSeriesBook(ctx context.Context, seriesID, bookID uuid.UUID) error {
 	return s.series.RemoveBook(ctx, seriesID, bookID)
+}
+
+// ─── Arcs ──────────────────────────────────────────────────────────────────────
+
+type SeriesArcRequest struct {
+	Name        string
+	Description string
+	Position    float64
+}
+
+func (s *SeriesService) ListSeriesArcs(ctx context.Context, seriesID uuid.UUID) ([]*models.SeriesArc, error) {
+	return s.arcs.List(ctx, seriesID)
+}
+
+func (s *SeriesService) CreateSeriesArc(ctx context.Context, seriesID uuid.UUID, req SeriesArcRequest) (*models.SeriesArc, error) {
+	if req.Name == "" {
+		return nil, fmt.Errorf("name is required")
+	}
+	return s.arcs.Create(ctx, uuid.New(), seriesID, req.Name, req.Description, req.Position)
+}
+
+func (s *SeriesService) UpdateSeriesArc(ctx context.Context, arcID uuid.UUID, req SeriesArcRequest) (*models.SeriesArc, error) {
+	if req.Name == "" {
+		return nil, fmt.Errorf("name is required")
+	}
+	return s.arcs.Update(ctx, arcID, req.Name, req.Description, req.Position)
+}
+
+func (s *SeriesService) DeleteSeriesArc(ctx context.Context, arcID uuid.UUID) error {
+	return s.arcs.Delete(ctx, arcID)
 }
 
 func (s *SeriesService) GetSeriesForBook(ctx context.Context, libraryID, bookID uuid.UUID) ([]*models.BookSeriesRef, error) {
@@ -129,7 +177,7 @@ type MatchCandidate struct {
 // returns the books with a proposed volume position. Results are sorted by
 // position ascending.
 func (s *SeriesService) MatchCandidates(ctx context.Context, seriesID uuid.UUID) ([]*MatchCandidate, error) {
-	ser, err := s.series.FindByID(ctx, seriesID)
+	ser, err := s.series.FindByID(ctx, seriesID, uuid.Nil)
 	if err != nil {
 		return nil, err
 	}
@@ -287,7 +335,7 @@ func (s *SeriesService) BulkCreateSeries(ctx context.Context, libraryID, callerI
 				return out, fmt.Errorf("adding book %s to series %q: %w", b.BookID, item.Name, err)
 			}
 		}
-		reloaded, err := s.series.FindByID(ctx, ser.ID)
+		reloaded, err := s.series.FindByID(ctx, ser.ID, uuid.Nil)
 		if err == nil && reloaded != nil {
 			ser = reloaded
 		}


### PR DESCRIPTION
- Optional named arcs on series (`series_arcs` + nullable `book_series.arc_id`), full CRUD endpoints; list/get responses gain `arc_count`, caller-relative `read_count` + `reading_count`, and a `preview_books` shape used for the web mosaic.
- Surfaces `user_read_status` per book on `ListSeriesBooks` so detail-page covers carry the same read-state glow as the rest of the app. Web side in librarium-web `feat/series-rework`.