### PR TITLE
feat(loans): surface loan state on book responses + book_id filter

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -6994,6 +6994,12 @@ const docTemplate = `{
                         "description": "Filter by tag",
                         "name": "tag",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter to loans of a specific book",
+                        "name": "book_id",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -13176,6 +13182,17 @@ const docTemplate = `{
         "responses.BookResponse": {
             "type": "object",
             "properties": {
+                "active_loan_count": {
+                    "description": "ActiveLoanCount is the number of active (not yet returned) loans for\nthis book — scoped to the library when the read is library-scoped,\nglobal otherwise. Always populated.",
+                    "type": "integer"
+                },
+                "active_loans": {
+                    "description": "ActiveLoans is the full list of active loans for this book. Only\npopulated by single-book reads (GetBook); list endpoints omit it to\nkeep payloads lean — use active_loan_count there for the badge.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/responses.LoanResponse"
+                    }
+                },
                 "added_by": {
                     "type": "string"
                 },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -6988,6 +6988,12 @@
                         "description": "Filter by tag",
                         "name": "tag",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter to loans of a specific book",
+                        "name": "book_id",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -13170,6 +13176,17 @@
         "responses.BookResponse": {
             "type": "object",
             "properties": {
+                "active_loan_count": {
+                    "description": "ActiveLoanCount is the number of active (not yet returned) loans for\nthis book — scoped to the library when the read is library-scoped,\nglobal otherwise. Always populated.",
+                    "type": "integer"
+                },
+                "active_loans": {
+                    "description": "ActiveLoans is the full list of active loans for this book. Only\npopulated by single-book reads (GetBook); list endpoints omit it to\nkeep payloads lean — use active_loan_count there for the badge.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/responses.LoanResponse"
+                    }
+                },
                 "added_by": {
                     "type": "string"
                 },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -838,6 +838,20 @@ definitions:
     type: object
   responses.BookResponse:
     properties:
+      active_loan_count:
+        description: |-
+          ActiveLoanCount is the number of active (not yet returned) loans for
+          this book — scoped to the library when the read is library-scoped,
+          global otherwise. Always populated.
+        type: integer
+      active_loans:
+        description: |-
+          ActiveLoans is the full list of active loans for this book. Only
+          populated by single-book reads (GetBook); list endpoints omit it to
+          keep payloads lean — use active_loan_count there for the badge.
+        items:
+          $ref: '#/definitions/responses.LoanResponse'
+        type: array
       added_by:
         type: string
       contributors:
@@ -5759,6 +5773,10 @@ paths:
       - description: Filter by tag
         in: query
         name: tag
+        type: string
+      - description: Filter to loans of a specific book
+        in: query
+        name: book_id
         type: string
       produces:
       - application/json

--- a/internal/api/handlers/books.go
+++ b/internal/api/handlers/books.go
@@ -28,13 +28,14 @@ import (
 type BookHandler struct {
 	svc               *service.BookService
 	books             *repository.BookRepo             // used for TitlesByIDs at batch creation
+	loans             *repository.LoanRepo             // active loans on GetBook responses
 	riverClient       *river.Client[pgx.Tx]            // may be nil; used for enrichment batch jobs
 	enrichmentBatches *repository.EnrichmentBatchRepo  // may be nil; required for bulk enrich/cover
 	editionFiles      *service.EditionFileService
 }
 
-func NewBookHandler(svc *service.BookService, books *repository.BookRepo, riverClient *river.Client[pgx.Tx], enrichmentBatches *repository.EnrichmentBatchRepo, editionFiles *service.EditionFileService) *BookHandler {
-	return &BookHandler{svc: svc, books: books, riverClient: riverClient, enrichmentBatches: enrichmentBatches, editionFiles: editionFiles}
+func NewBookHandler(svc *service.BookService, books *repository.BookRepo, loans *repository.LoanRepo, riverClient *river.Client[pgx.Tx], enrichmentBatches *repository.EnrichmentBatchRepo, editionFiles *service.EditionFileService) *BookHandler {
+	return &BookHandler{svc: svc, books: books, loans: loans, riverClient: riverClient, enrichmentBatches: enrichmentBatches, editionFiles: editionFiles}
 }
 
 // ─── Media types ──────────────────────────────────────────────────────────────
@@ -368,7 +369,13 @@ func (h *BookHandler) GetBook(w http.ResponseWriter, r *http.Request) {
 		respond.ServerError(w, r, err)
 		return
 	}
-	respond.JSON(w, http.StatusOK, bookBody(book))
+	// Active loans surface only on the single-book read so the badge on
+	// list views stays cheap (just the count). Errors here aren't fatal —
+	// the book row is still useful without the loan list.
+	loans, _ := h.loans.ListActiveByBook(r.Context(), bookID)
+	body := bookBody(book)
+	body["active_loans"] = loanBodies(loans)
+	respond.JSON(w, http.StatusOK, body)
 }
 
 // UpdateBook godoc
@@ -667,7 +674,8 @@ func bookBody(b *models.Book) map[string]any {
 		"publisher":        b.Publisher,
 		"publish_year":     b.PublishYear,
 		"language":         b.Language,
-		"user_read_status": b.UserReadStatus,
+		"user_read_status":  b.UserReadStatus,
+		"active_loan_count": b.ActiveLoanCount,
 	}
 }
 

--- a/internal/api/handlers/loans.go
+++ b/internal/api/handlers/loans.go
@@ -36,6 +36,7 @@ func NewLoanHandler(svc *service.LoanService) *LoanHandler {
 // @Param       include_returned  query     boolean  false  "Include returned loans"
 // @Param       search            query     string   false  "Filter by borrower name"
 // @Param       tag               query     string   false  "Filter by tag"
+// @Param       book_id           query     string   false  "Filter to loans of a specific book"
 // @Success     200  {array}   responses.LoanResponse
 // @Failure     400  {object}  object{error=string}
 // @Failure     401  {object}  object{error=string}
@@ -49,7 +50,15 @@ func (h *LoanHandler) ListLoans(w http.ResponseWriter, r *http.Request) {
 	includeReturned := r.URL.Query().Get("include_returned") == "true"
 	search := r.URL.Query().Get("search")
 	tagFilter := r.URL.Query().Get("tag")
-	loans, err := h.svc.ListLoans(r.Context(), libraryID, includeReturned, search, tagFilter)
+	var bookID uuid.UUID
+	if raw := r.URL.Query().Get("book_id"); raw != "" {
+		bookID, err = uuid.Parse(raw)
+		if err != nil {
+			respond.Error(w, http.StatusBadRequest, "invalid book_id")
+			return
+		}
+	}
+	loans, err := h.svc.ListLoans(r.Context(), libraryID, includeReturned, search, tagFilter, bookID)
 	if err != nil {
 		respond.ServerError(w, r, err)
 		return
@@ -272,6 +281,16 @@ func tagsToBodyLoans(tags []*models.Tag) []map[string]any {
 	out := make([]map[string]any, 0, len(tags))
 	for _, t := range tags {
 		out = append(out, map[string]any{"id": t.ID, "name": t.Name, "color": t.Color})
+	}
+	return out
+}
+
+// loanBodies projects a slice of loans through loanBody. Always returns a
+// non-nil slice so JSON marshalling yields [] not null.
+func loanBodies(loans []*models.Loan) []map[string]any {
+	out := make([]map[string]any, 0, len(loans))
+	for _, l := range loans {
+		out = append(out, loanBody(l))
 	}
 	return out
 }

--- a/internal/api/responses/responses.go
+++ b/internal/api/responses/responses.go
@@ -149,8 +149,16 @@ type BookResponse struct {
 	Series       []SeriesRef      `json:"series"`
 	Shelves      []ShelfRef       `json:"shelves"`
 	AddedBy      *uuid.UUID       `json:"added_by,omitempty"`
-	CreatedAt    time.Time        `json:"created_at"`
-	UpdatedAt    time.Time        `json:"updated_at"`
+	// ActiveLoanCount is the number of active (not yet returned) loans for
+	// this book — scoped to the library when the read is library-scoped,
+	// global otherwise. Always populated.
+	ActiveLoanCount int `json:"active_loan_count"`
+	// ActiveLoans is the full list of active loans for this book. Only
+	// populated by single-book reads (GetBook); list endpoints omit it to
+	// keep payloads lean — use active_loan_count there for the badge.
+	ActiveLoans []LoanResponse `json:"active_loans,omitempty"`
+	CreatedAt   time.Time      `json:"created_at"`
+	UpdatedAt   time.Time      `json:"updated_at"`
 }
 
 // PagedBooksResponse is the paginated response from book list endpoints.

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -111,7 +111,7 @@ func NewRouter(ctx context.Context, db *pgxpool.Pool, cfg *config.Config, riverC
 	setupHandler := handlers.NewSetupHandler(authSvc, userRepo)
 	adminHandler := handlers.NewAdminHandler(authSvc)
 	libraryHandler := handlers.NewLibraryHandler(libSvc)
-	bookHandler := handlers.NewBookHandler(bookSvc, bookRepo, riverClient, enrichmentBatchRepo, editionFileSvc)
+	bookHandler := handlers.NewBookHandler(bookSvc, bookRepo, loanRepo, riverClient, enrichmentBatchRepo, editionFileSvc)
 	shelfHandler := handlers.NewShelfHandler(shelfSvc)
 	loanHandler := handlers.NewLoanHandler(loanSvc)
 	seriesHandler := handlers.NewSeriesHandler(seriesSvc, releaseSyncSvc)

--- a/internal/models/book.go
+++ b/internal/models/book.go
@@ -54,6 +54,12 @@ type Book struct {
 	PublishYear    *int
 	Language       string
 	UserReadStatus string
+	// ActiveLoanCount is the number of active (not yet returned) loans for
+	// this book. Scoped to a single library when the read is library-scoped
+	// (ListBooks via library), or counted across every library otherwise.
+	// Drives the "loaned out" badge on book rows without forcing the client
+	// to fetch loans separately.
+	ActiveLoanCount int
 	// Libraries is the set of libraries holding this book (populated by the
 	// service layer on reads that need it; empty when the book is floating).
 	Libraries []BookLibraryRef

--- a/internal/repository/books.go
+++ b/internal/repository/books.go
@@ -60,10 +60,15 @@ func (r *BookRepo) ListMediaTypes(ctx context.Context) ([]*models.MediaType, err
 // booksSelect returns the reusable base SELECT for books. It uses correlated
 // subqueries for contributors and tags to avoid cross-product row inflation
 // when joining both at once. Append WHERE/ORDER BY/LIMIT as needed.
+//
 // When userStatusArg > 0, the query includes a user_read_status column using
 // that positional argument index ($N) for the user ID. When 0, a constant
-// empty string is selected so the column count is always 20.
-func booksSelect(userStatusArg int) string {
+// empty string is selected. Column count is always the same regardless.
+//
+// When loanLibraryArg > 0, active_loan_count is scoped to that library_id
+// arg (used by ListBooks). When 0, it counts active loans across every
+// library the book belongs to (used by FindByID).
+func booksSelect(userStatusArg, loanLibraryArg int) string {
 	var userReadStatusExpr string
 	if userStatusArg > 0 {
 		userReadStatusExpr = fmt.Sprintf(`COALESCE((
@@ -81,6 +86,19 @@ func booksSelect(userStatusArg int) string {
 	), '') AS user_read_status`, userStatusArg)
 	} else {
 		userReadStatusExpr = `'' AS user_read_status`
+	}
+
+	var activeLoanExpr string
+	if loanLibraryArg > 0 {
+		activeLoanExpr = fmt.Sprintf(`(
+		SELECT COUNT(*) FROM loans
+		WHERE book_id = b.id AND library_id = $%d AND returned_at IS NULL
+	) AS active_loan_count`, loanLibraryArg)
+	} else {
+		activeLoanExpr = `(
+		SELECT COUNT(*) FROM loans
+		WHERE book_id = b.id AND returned_at IS NULL
+	) AS active_loan_count`
 	}
 
 	return `
@@ -174,7 +192,8 @@ func booksSelect(userStatusArg int) string {
 			WHERE be.book_id = b.id AND be.is_primary = true
 			LIMIT 1
 		), '') AS language,
-		` + userReadStatusExpr + `
+		` + userReadStatusExpr + `,
+		` + activeLoanExpr + `
 	FROM books b
 	JOIN media_types mt ON mt.id = b.media_type_id`
 }
@@ -249,7 +268,7 @@ func (r *BookRepo) EnsureBookContributor(ctx context.Context, tx pgx.Tx, bookID,
 }
 
 func (r *BookRepo) FindByID(ctx context.Context, id uuid.UUID) (*models.Book, error) {
-	q := booksSelect(0) + ` WHERE b.id = $1`
+	q := booksSelect(0, 0) + ` WHERE b.id = $1`
 
 	book, err := scanBook(r.db.QueryRow(ctx, q, id))
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -276,10 +295,10 @@ func (r *BookRepo) ListByContributor(ctx context.Context, libraryID, contributor
 		  )
 		ORDER BY natural_sort_key(b.title)`
 	if callerID != uuid.Nil {
-		q = booksSelect(3) + scope
+		q = booksSelect(3, 1) + scope
 		args = []any{libraryID, contributorID, callerID}
 	} else {
-		q = booksSelect(0) + scope
+		q = booksSelect(0, 1) + scope
 		args = []any{libraryID, contributorID}
 	}
 
@@ -669,9 +688,9 @@ func (r *BookRepo) List(ctx context.Context, libraryID uuid.UUID, opts ListBooks
 		args = append(args, opts.CallerID)
 		userArgIdx := argIdx
 		argIdx++
-		selectQuery = booksSelect(userArgIdx)
+		selectQuery = booksSelect(userArgIdx, 1)
 	} else {
-		selectQuery = booksSelect(0)
+		selectQuery = booksSelect(0, 1)
 	}
 
 	// List
@@ -781,6 +800,7 @@ func scanBook(s scanner) (*models.Book, error) {
 		publishYear    pgtype.Int4
 		language       pgtype.Text
 		userReadStatus string
+		activeLoans    int
 		b              models.Book
 	)
 
@@ -790,7 +810,7 @@ func scanBook(s scanner) (*models.Book, error) {
 		&pgDesc, &b.CreatedAt, &b.UpdatedAt,
 		&contribJSON, &tagsJSON, &genresJSON, &b.HasCover,
 		&seriesJSON, &shelvesJSON, &publisher, &publishYear, &language,
-		&userReadStatus,
+		&userReadStatus, &activeLoans,
 	)
 	if err != nil {
 		return nil, err
@@ -804,6 +824,7 @@ func scanBook(s scanner) (*models.Book, error) {
 	b.Publisher = publisher.String
 	b.Language = language.String
 	b.UserReadStatus = userReadStatus
+	b.ActiveLoanCount = activeLoans
 	if publishYear.Valid {
 		y := int(publishYear.Int32)
 		b.PublishYear = &y

--- a/internal/repository/loans.go
+++ b/internal/repository/loans.go
@@ -42,7 +42,7 @@ const loanTagsSubquery = `
         '[]'::json
     )`
 
-func (r *LoanRepo) List(ctx context.Context, libraryID uuid.UUID, includeReturned bool, search, tagFilter string) ([]*models.Loan, error) {
+func (r *LoanRepo) List(ctx context.Context, libraryID uuid.UUID, includeReturned bool, search, tagFilter string, bookID uuid.UUID) ([]*models.Loan, error) {
 	args := []any{libraryID, includeReturned}
 	where := `WHERE l.library_id = $1 AND ($2 OR l.returned_at IS NULL)`
 	if search != "" {
@@ -52,6 +52,10 @@ func (r *LoanRepo) List(ctx context.Context, libraryID uuid.UUID, includeReturne
 	if tagFilter != "" {
 		args = append(args, tagFilter)
 		where += fmt.Sprintf(` AND EXISTS (SELECT 1 FROM loan_tags lt JOIN tags t ON t.id = lt.tag_id WHERE lt.loan_id = l.id AND lower(t.name) = lower($%d))`, len(args))
+	}
+	if bookID != uuid.Nil {
+		args = append(args, bookID)
+		where += fmt.Sprintf(` AND l.book_id = $%d`, len(args))
 	}
 
 	q := `
@@ -71,6 +75,36 @@ func (r *LoanRepo) List(ctx context.Context, libraryID uuid.UUID, includeReturne
 	}
 	defer rows.Close()
 
+	var out []*models.Loan
+	for rows.Next() {
+		l, err := scanLoan(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, l)
+	}
+	return out, rows.Err()
+}
+
+// ListActiveByBook returns every active (not yet returned) loan for the
+// given book across every library. Powers the active-loan panel on the
+// library-agnostic GetBook response.
+func (r *LoanRepo) ListActiveByBook(ctx context.Context, bookID uuid.UUID) ([]*models.Loan, error) {
+	q := `
+		SELECT l.id, l.library_id, l.book_id, b.title,
+		       l.loaned_to, l.loaned_at, l.due_date, l.returned_at,
+		       COALESCE(l.notes, ''),
+		       l.created_at, l.updated_at,
+		       ` + loanTagsSubquery + ` AS tags
+		FROM loans l
+		JOIN books b ON b.id = l.book_id
+		WHERE l.book_id = $1 AND l.returned_at IS NULL
+		ORDER BY l.loaned_at DESC, l.created_at DESC`
+	rows, err := r.db.Query(ctx, q, bookID)
+	if err != nil {
+		return nil, fmt.Errorf("listing active loans by book: %w", err)
+	}
+	defer rows.Close()
 	var out []*models.Loan
 	for rows.Next() {
 		l, err := scanLoan(rows)

--- a/internal/repository/shelves.go
+++ b/internal/repository/shelves.go
@@ -167,7 +167,7 @@ func (r *ShelfRepo) FindByBook(ctx context.Context, libraryID, bookID uuid.UUID)
 // ─── Shelf books ──────────────────────────────────────────────────────────────
 
 func (r *ShelfRepo) ListBooks(ctx context.Context, shelfID uuid.UUID) ([]*models.Book, error) {
-	q := booksSelect(0) + `
+	q := booksSelect(0, 0) + `
 		JOIN book_shelves bs ON bs.book_id = b.id
 		WHERE bs.shelf_id = $1
 		ORDER BY bs.added_at DESC`

--- a/internal/service/loan.go
+++ b/internal/service/loan.go
@@ -39,8 +39,8 @@ type LoanUpdateRequest struct {
 	TagIDs     []uuid.UUID
 }
 
-func (s *LoanService) ListLoans(ctx context.Context, libraryID uuid.UUID, includeReturned bool, search, tagFilter string) ([]*models.Loan, error) {
-	return s.loans.List(ctx, libraryID, includeReturned, search, tagFilter)
+func (s *LoanService) ListLoans(ctx context.Context, libraryID uuid.UUID, includeReturned bool, search, tagFilter string, bookID uuid.UUID) ([]*models.Loan, error) {
+	return s.loans.List(ctx, libraryID, includeReturned, search, tagFilter, bookID)
 }
 
 func (s *LoanService) CreateLoan(ctx context.Context, libraryID, callerID uuid.UUID, req LoanRequest) (*models.Loan, error) {


### PR DESCRIPTION
- \`ListLoans\` gains optional \`book_id\` query param so per-book loan history queries skip client-side filtering.
- Book responses gain \`active_loan_count\` on every row (drives "loaned out" badge on list views) and \`active_loans\` (full list) on single-book \`GetBook\` reads.