### PR TITLE
feat(loans): drop loan_tags — tags are not a property of a loan

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -6991,12 +6991,6 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Filter by tag",
-                        "name": "tag",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
                         "description": "Filter to loans of a specific book",
                         "name": "book_id",
                         "in": "query"
@@ -7083,12 +7077,6 @@ const docTemplate = `{
                                 },
                                 "notes": {
                                     "type": "string"
-                                },
-                                "tag_ids": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
                                 }
                             }
                         }
@@ -7244,12 +7232,6 @@ const docTemplate = `{
                                 },
                                 "returned_at": {
                                     "type": "string"
-                                },
-                                "tag_ids": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
                                 }
                             }
                         }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -6985,12 +6985,6 @@
                     },
                     {
                         "type": "string",
-                        "description": "Filter by tag",
-                        "name": "tag",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
                         "description": "Filter to loans of a specific book",
                         "name": "book_id",
                         "in": "query"
@@ -7077,12 +7071,6 @@
                                 },
                                 "notes": {
                                     "type": "string"
-                                },
-                                "tag_ids": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
                                 }
                             }
                         }
@@ -7238,12 +7226,6 @@
                                 },
                                 "returned_at": {
                                     "type": "string"
-                                },
-                                "tag_ids": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
                                 }
                             }
                         }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -5770,10 +5770,6 @@ paths:
         in: query
         name: search
         type: string
-      - description: Filter by tag
-        in: query
-        name: tag
-        type: string
       - description: Filter to loans of a specific book
         in: query
         name: book_id
@@ -5832,10 +5828,6 @@ paths:
               type: string
             notes:
               type: string
-            tag_ids:
-              items:
-                type: string
-              type: array
           type: object
       produces:
       - application/json
@@ -5935,10 +5927,6 @@ paths:
               type: string
             returned_at:
               type: string
-            tag_ids:
-              items:
-                type: string
-              type: array
           type: object
       produces:
       - application/json

--- a/internal/api/handlers/loans.go
+++ b/internal/api/handlers/loans.go
@@ -35,7 +35,6 @@ func NewLoanHandler(svc *service.LoanService) *LoanHandler {
 // @Param       library_id        path      string   true   "Library UUID"
 // @Param       include_returned  query     boolean  false  "Include returned loans"
 // @Param       search            query     string   false  "Filter by borrower name"
-// @Param       tag               query     string   false  "Filter by tag"
 // @Param       book_id           query     string   false  "Filter to loans of a specific book"
 // @Success     200  {array}   responses.LoanResponse
 // @Failure     400  {object}  object{error=string}
@@ -49,7 +48,6 @@ func (h *LoanHandler) ListLoans(w http.ResponseWriter, r *http.Request) {
 	}
 	includeReturned := r.URL.Query().Get("include_returned") == "true"
 	search := r.URL.Query().Get("search")
-	tagFilter := r.URL.Query().Get("tag")
 	var bookID uuid.UUID
 	if raw := r.URL.Query().Get("book_id"); raw != "" {
 		bookID, err = uuid.Parse(raw)
@@ -58,7 +56,7 @@ func (h *LoanHandler) ListLoans(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	loans, err := h.svc.ListLoans(r.Context(), libraryID, includeReturned, search, tagFilter, bookID)
+	loans, err := h.svc.ListLoans(r.Context(), libraryID, includeReturned, search, bookID)
 	if err != nil {
 		respond.ServerError(w, r, err)
 		return
@@ -79,7 +77,7 @@ func (h *LoanHandler) ListLoans(w http.ResponseWriter, r *http.Request) {
 // @Produce     json
 // @Security    BearerAuth
 // @Param       library_id  path      string  true  "Library UUID"
-// @Param       body        body      object{book_id=string,loaned_to=string,loaned_at=string,due_date=string,notes=string,tag_ids=[]string}  true  "Loan details"
+// @Param       body        body      object{book_id=string,loaned_to=string,loaned_at=string,due_date=string,notes=string}  true  "Loan details"
 // @Success     201  {object}  responses.LoanResponse
 // @Failure     400  {object}  object{error=string}
 // @Failure     401  {object}  object{error=string}
@@ -114,7 +112,7 @@ func (h *LoanHandler) CreateLoan(w http.ResponseWriter, r *http.Request) {
 // @Security    BearerAuth
 // @Param       library_id  path      string  true  "Library UUID"
 // @Param       loan_id     path      string  true  "Loan UUID"
-// @Param       body        body      object{loaned_to=string,due_date=string,returned_at=string,notes=string,tag_ids=[]string}  true  "Updated loan"
+// @Param       body        body      object{loaned_to=string,due_date=string,returned_at=string,notes=string}  true  "Updated loan"
 // @Success     200  {object}  responses.LoanResponse
 // @Failure     400  {object}  object{error=string}
 // @Failure     401  {object}  object{error=string}
@@ -176,12 +174,11 @@ func (h *LoanHandler) DeleteLoan(w http.ResponseWriter, r *http.Request) {
 
 func decodeLoanCreateRequest(r *http.Request) (*service.LoanRequest, error) {
 	var body struct {
-		BookID   string   `json:"book_id"`
-		LoanedTo string   `json:"loaned_to"`
-		LoanedAt string   `json:"loaned_at"` // YYYY-MM-DD; defaults to today
-		DueDate  string   `json:"due_date"`  // YYYY-MM-DD or ""
-		Notes    string   `json:"notes"`
-		TagIDs   []string `json:"tag_ids"`
+		BookID   string `json:"book_id"`
+		LoanedTo string `json:"loaned_to"`
+		LoanedAt string `json:"loaned_at"` // YYYY-MM-DD; defaults to today
+		DueDate  string `json:"due_date"`  // YYYY-MM-DD or ""
+		Notes    string `json:"notes"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		return nil, errors.New("invalid request body")
@@ -208,35 +205,21 @@ func decodeLoanCreateRequest(r *http.Request) (*service.LoanRequest, error) {
 		}
 	}
 
-	var tagIDs []uuid.UUID
-	if body.TagIDs != nil {
-		tagIDs = make([]uuid.UUID, 0, len(body.TagIDs))
-		for _, s := range body.TagIDs {
-			id, err := uuid.Parse(s)
-			if err != nil {
-				return nil, errors.New("invalid tag_id: " + s)
-			}
-			tagIDs = append(tagIDs, id)
-		}
-	}
-
 	return &service.LoanRequest{
 		BookID:   bookID,
 		LoanedTo: body.LoanedTo,
 		LoanedAt: loanedAt,
 		DueDate:  dueDate,
 		Notes:    body.Notes,
-		TagIDs:   tagIDs,
 	}, nil
 }
 
 func decodeLoanUpdateRequest(r *http.Request) (*service.LoanUpdateRequest, error) {
 	var body struct {
-		LoanedTo   string   `json:"loaned_to"`
-		DueDate    *string  `json:"due_date"`    // null = clear, "YYYY-MM-DD" = set
-		ReturnedAt *string  `json:"returned_at"` // null = clear, "YYYY-MM-DD" = set
-		Notes      string   `json:"notes"`
-		TagIDs     []string `json:"tag_ids"`
+		LoanedTo   string  `json:"loaned_to"`
+		DueDate    *string `json:"due_date"`    // null = clear, "YYYY-MM-DD" = set
+		ReturnedAt *string `json:"returned_at"` // null = clear, "YYYY-MM-DD" = set
+		Notes      string  `json:"notes"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		return nil, errors.New("invalid request body")
@@ -256,33 +239,12 @@ func decodeLoanUpdateRequest(r *http.Request) (*service.LoanUpdateRequest, error
 		return &t
 	}
 
-	var tagIDs []uuid.UUID
-	if body.TagIDs != nil {
-		tagIDs = make([]uuid.UUID, 0, len(body.TagIDs))
-		for _, s := range body.TagIDs {
-			id, err := uuid.Parse(s)
-			if err != nil {
-				return nil, errors.New("invalid tag_id: " + s)
-			}
-			tagIDs = append(tagIDs, id)
-		}
-	}
-
 	return &service.LoanUpdateRequest{
 		LoanedTo:   body.LoanedTo,
 		DueDate:    parseDate(body.DueDate),
 		ReturnedAt: parseDate(body.ReturnedAt),
 		Notes:      body.Notes,
-		TagIDs:     tagIDs,
 	}, nil
-}
-
-func tagsToBodyLoans(tags []*models.Tag) []map[string]any {
-	out := make([]map[string]any, 0, len(tags))
-	for _, t := range tags {
-		out = append(out, map[string]any{"id": t.ID, "name": t.Name, "color": t.Color})
-	}
-	return out
 }
 
 // loanBodies projects a slice of loans through loanBody. Always returns a
@@ -296,10 +258,6 @@ func loanBodies(loans []*models.Loan) []map[string]any {
 }
 
 func loanBody(l *models.Loan) map[string]any {
-	tags := l.Tags
-	if tags == nil {
-		tags = []*models.Tag{}
-	}
 	body := map[string]any{
 		"id":         l.ID,
 		"library_id": l.LibraryID,
@@ -308,7 +266,6 @@ func loanBody(l *models.Loan) map[string]any {
 		"loaned_to":  l.LoanedTo,
 		"loaned_at":  l.LoanedAt.Format("2006-01-02"),
 		"notes":      l.Notes,
-		"tags":       tagsToBodyLoans(tags),
 		"created_at": l.CreatedAt,
 		"updated_at": l.UpdatedAt,
 	}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -83,7 +83,7 @@ func NewRouter(ctx context.Context, db *pgxpool.Pool, cfg *config.Config, riverC
 
 	contributorSvc := service.NewContributorService(contributorRepo, bookRepo, coverRepo, providerSvc.Registry(), cfg.CoverStoragePath)
 
-	loanSvc := service.NewLoanService(loanRepo, tagRepo)
+	loanSvc := service.NewLoanService(loanRepo)
 	seriesSvc := service.NewSeriesService(seriesRepo, seriesArcRepo, seriesVolumesRepo, tagRepo)
 	releaseSyncSvc := service.NewReleaseSyncService(seriesRepo, seriesVolumesRepo, providerSvc)
 

--- a/internal/db/migrations/000016_drop_loan_tags.down.sql
+++ b/internal/db/migrations/000016_drop_loan_tags.down.sql
@@ -1,0 +1,8 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Copyright (C) 2026 fireball1725
+
+CREATE TABLE loan_tags (
+    loan_id UUID NOT NULL REFERENCES loans(id) ON DELETE CASCADE,
+    tag_id  UUID NOT NULL REFERENCES tags(id)  ON DELETE CASCADE,
+    PRIMARY KEY (loan_id, tag_id)
+);

--- a/internal/db/migrations/000016_drop_loan_tags.up.sql
+++ b/internal/db/migrations/000016_drop_loan_tags.up.sql
@@ -1,0 +1,11 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Copyright (C) 2026 fireball1725
+--
+-- Loans no longer carry tags. Tags are a property of the book / shelf,
+-- not the loan record — borrow rows shouldn't pull from the same shared
+-- pool that holds genre-style classifications. Drop the junction.
+--
+-- Any existing rows are silently dropped; no migration of data is
+-- attempted because tagged loans were a misuse of the field.
+
+DROP TABLE IF EXISTS loan_tags;

--- a/internal/models/loan.go
+++ b/internal/models/loan.go
@@ -19,7 +19,6 @@ type Loan struct {
 	DueDate    *time.Time `json:"due_date"`
 	ReturnedAt *time.Time `json:"returned_at"`
 	Notes      string     `json:"notes"`
-	Tags       []*Tag     `json:"tags"`
 	CreatedAt  time.Time  `json:"created_at"`
 	UpdatedAt  time.Time  `json:"updated_at"`
 }

--- a/internal/repository/loans.go
+++ b/internal/repository/loans.go
@@ -5,7 +5,6 @@ package repository
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -25,7 +24,8 @@ func NewLoanRepo(db *pgxpool.Pool) *LoanRepo {
 	return &LoanRepo{db: db}
 }
 
-// loanSelect is used by FindByID (no tag aggregation needed for single-row fetches).
+// loanSelect is the shared SELECT body used by every loan read. Loans
+// no longer carry tags — the join was dropped along with `loan_tags`.
 const loanSelect = `
 	SELECT l.id, l.library_id, l.book_id, b.title,
 	       l.loaned_to, l.loaned_at, l.due_date, l.returned_at,
@@ -35,38 +35,19 @@ const loanSelect = `
 	JOIN books b ON b.id = l.book_id
 `
 
-const loanTagsSubquery = `
-    COALESCE(
-        (SELECT json_agg(json_build_object('id', t.id, 'name', t.name, 'color', t.color) ORDER BY t.name)
-         FROM loan_tags lt JOIN tags t ON t.id = lt.tag_id WHERE lt.loan_id = l.id),
-        '[]'::json
-    )`
-
-func (r *LoanRepo) List(ctx context.Context, libraryID uuid.UUID, includeReturned bool, search, tagFilter string, bookID uuid.UUID) ([]*models.Loan, error) {
+func (r *LoanRepo) List(ctx context.Context, libraryID uuid.UUID, includeReturned bool, search string, bookID uuid.UUID) ([]*models.Loan, error) {
 	args := []any{libraryID, includeReturned}
 	where := `WHERE l.library_id = $1 AND ($2 OR l.returned_at IS NULL)`
 	if search != "" {
 		args = append(args, "%"+search+"%")
 		where += fmt.Sprintf(` AND lower(l.loaned_to || ' ' || b.title) LIKE lower($%d)`, len(args))
 	}
-	if tagFilter != "" {
-		args = append(args, tagFilter)
-		where += fmt.Sprintf(` AND EXISTS (SELECT 1 FROM loan_tags lt JOIN tags t ON t.id = lt.tag_id WHERE lt.loan_id = l.id AND lower(t.name) = lower($%d))`, len(args))
-	}
 	if bookID != uuid.Nil {
 		args = append(args, bookID)
 		where += fmt.Sprintf(` AND l.book_id = $%d`, len(args))
 	}
 
-	q := `
-		SELECT l.id, l.library_id, l.book_id, b.title,
-		       l.loaned_to, l.loaned_at, l.due_date, l.returned_at,
-		       COALESCE(l.notes, ''),
-		       l.created_at, l.updated_at,
-		       ` + loanTagsSubquery + ` AS tags
-		FROM loans l
-		JOIN books b ON b.id = l.book_id
-		` + where + `
+	q := loanSelect + where + `
 		ORDER BY l.loaned_at DESC, l.created_at DESC`
 
 	rows, err := r.db.Query(ctx, q, args...)
@@ -90,15 +71,7 @@ func (r *LoanRepo) List(ctx context.Context, libraryID uuid.UUID, includeReturne
 // given book across every library. Powers the active-loan panel on the
 // library-agnostic GetBook response.
 func (r *LoanRepo) ListActiveByBook(ctx context.Context, bookID uuid.UUID) ([]*models.Loan, error) {
-	q := `
-		SELECT l.id, l.library_id, l.book_id, b.title,
-		       l.loaned_to, l.loaned_at, l.due_date, l.returned_at,
-		       COALESCE(l.notes, ''),
-		       l.created_at, l.updated_at,
-		       ` + loanTagsSubquery + ` AS tags
-		FROM loans l
-		JOIN books b ON b.id = l.book_id
-		WHERE l.book_id = $1 AND l.returned_at IS NULL
+	q := loanSelect + `WHERE l.book_id = $1 AND l.returned_at IS NULL
 		ORDER BY l.loaned_at DESC, l.created_at DESC`
 	rows, err := r.db.Query(ctx, q, bookID)
 	if err != nil {
@@ -118,7 +91,7 @@ func (r *LoanRepo) ListActiveByBook(ctx context.Context, bookID uuid.UUID) ([]*m
 
 func (r *LoanRepo) FindByID(ctx context.Context, id uuid.UUID) (*models.Loan, error) {
 	q := loanSelect + `WHERE l.id = $1`
-	l, err := scanLoanNoTags(r.db.QueryRow(ctx, q, id))
+	l, err := scanLoan(r.db.QueryRow(ctx, q, id))
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, ErrNotFound
 	}
@@ -168,7 +141,9 @@ func (r *LoanRepo) Delete(ctx context.Context, id uuid.UUID) error {
 	return nil
 }
 
-// scanLoan scans a loan row that includes a tags JSON column (used by List).
+// scanLoan scans a single loan row from any of the loan reads. Loans
+// no longer carry tags; the loanSelect SELECT shape is the same for
+// every read path.
 func scanLoan(s scanner) (*models.Loan, error) {
 	var (
 		pgID        pgtype.UUID
@@ -176,43 +151,6 @@ func scanLoan(s scanner) (*models.Loan, error) {
 		pgBookID    pgtype.UUID
 		pgDueDate   pgtype.Date
 		pgReturned  pgtype.Date
-		tagsJSON    []byte
-		l           models.Loan
-	)
-	err := s.Scan(
-		&pgID, &pgLibraryID, &pgBookID, &l.BookTitle,
-		&l.LoanedTo, &l.LoanedAt, &pgDueDate, &pgReturned,
-		&l.Notes, &l.CreatedAt, &l.UpdatedAt,
-		&tagsJSON,
-	)
-	if err != nil {
-		return nil, err
-	}
-	l.ID = uuid.UUID(pgID.Bytes)
-	l.LibraryID = uuid.UUID(pgLibraryID.Bytes)
-	l.BookID = uuid.UUID(pgBookID.Bytes)
-	if pgDueDate.Valid {
-		t := pgDueDate.Time
-		l.DueDate = &t
-	}
-	if pgReturned.Valid {
-		t := pgReturned.Time
-		l.ReturnedAt = &t
-	}
-	if err := json.Unmarshal(tagsJSON, &l.Tags); err != nil || l.Tags == nil {
-		l.Tags = []*models.Tag{}
-	}
-	return &l, nil
-}
-
-// scanLoanNoTags scans a loan row without a tags column (used by FindByID).
-func scanLoanNoTags(s scanner) (*models.Loan, error) {
-	var (
-		pgID        pgtype.UUID
-		pgLibraryID pgtype.UUID
-		pgBookID    pgtype.UUID
-		pgDueDate   pgtype.Date
-		pgReturned  pgtype.Date
 		l           models.Loan
 	)
 	err := s.Scan(
@@ -234,6 +172,5 @@ func scanLoanNoTags(s scanner) (*models.Loan, error) {
 		t := pgReturned.Time
 		l.ReturnedAt = &t
 	}
-	l.Tags = []*models.Tag{}
 	return &l, nil
 }

--- a/internal/repository/tags.go
+++ b/internal/repository/tags.go
@@ -135,18 +135,6 @@ func (r *TagRepo) SetShelfTags(ctx context.Context, shelfID uuid.UUID, tagIDs []
 	return nil
 }
 
-func (r *TagRepo) SetLoanTags(ctx context.Context, loanID uuid.UUID, tagIDs []uuid.UUID) error {
-	if _, err := r.db.Exec(ctx, `DELETE FROM loan_tags WHERE loan_id = $1`, loanID); err != nil {
-		return fmt.Errorf("clearing loan tags: %w", err)
-	}
-	for _, tid := range tagIDs {
-		if _, err := r.db.Exec(ctx, `INSERT INTO loan_tags (loan_id, tag_id) VALUES ($1, $2) ON CONFLICT DO NOTHING`, loanID, tid); err != nil {
-			return fmt.Errorf("inserting loan tag: %w", err)
-		}
-	}
-	return nil
-}
-
 func (r *TagRepo) SetMemberTags(ctx context.Context, libraryID, userID uuid.UUID, tagIDs []uuid.UUID) error {
 	if _, err := r.db.Exec(ctx, `DELETE FROM member_tags WHERE library_id = $1 AND user_id = $2`, libraryID, userID); err != nil {
 		return fmt.Errorf("clearing member tags: %w", err)

--- a/internal/service/loan.go
+++ b/internal/service/loan.go
@@ -15,11 +15,10 @@ import (
 
 type LoanService struct {
 	loans *repository.LoanRepo
-	tags  *repository.TagRepo
 }
 
-func NewLoanService(loans *repository.LoanRepo, tags *repository.TagRepo) *LoanService {
-	return &LoanService{loans: loans, tags: tags}
+func NewLoanService(loans *repository.LoanRepo) *LoanService {
+	return &LoanService{loans: loans}
 }
 
 type LoanRequest struct {
@@ -28,7 +27,6 @@ type LoanRequest struct {
 	LoanedAt time.Time
 	DueDate  *time.Time
 	Notes    string
-	TagIDs   []uuid.UUID
 }
 
 type LoanUpdateRequest struct {
@@ -36,52 +34,25 @@ type LoanUpdateRequest struct {
 	DueDate    *time.Time
 	ReturnedAt *time.Time
 	Notes      string
-	TagIDs     []uuid.UUID
 }
 
-func (s *LoanService) ListLoans(ctx context.Context, libraryID uuid.UUID, includeReturned bool, search, tagFilter string, bookID uuid.UUID) ([]*models.Loan, error) {
-	return s.loans.List(ctx, libraryID, includeReturned, search, tagFilter, bookID)
+func (s *LoanService) ListLoans(ctx context.Context, libraryID uuid.UUID, includeReturned bool, search string, bookID uuid.UUID) ([]*models.Loan, error) {
+	return s.loans.List(ctx, libraryID, includeReturned, search, bookID)
 }
 
 func (s *LoanService) CreateLoan(ctx context.Context, libraryID, callerID uuid.UUID, req LoanRequest) (*models.Loan, error) {
 	if req.LoanedTo == "" {
 		return nil, fmt.Errorf("loaned_to is required")
 	}
-	loan, err := s.loans.Create(ctx, uuid.New(), libraryID, req.BookID, callerID,
+	return s.loans.Create(ctx, uuid.New(), libraryID, req.BookID, callerID,
 		req.LoanedTo, req.Notes, req.LoanedAt, req.DueDate)
-	if err != nil {
-		return nil, err
-	}
-	if req.TagIDs != nil {
-		if err := s.tags.SetLoanTags(ctx, loan.ID, req.TagIDs); err != nil {
-			return nil, fmt.Errorf("setting loan tags: %w", err)
-		}
-		loan, err = s.loans.FindByID(ctx, loan.ID)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return loan, nil
 }
 
 func (s *LoanService) UpdateLoan(ctx context.Context, id uuid.UUID, req LoanUpdateRequest) (*models.Loan, error) {
 	if req.LoanedTo == "" {
 		return nil, fmt.Errorf("loaned_to is required")
 	}
-	loan, err := s.loans.Update(ctx, id, req.LoanedTo, req.Notes, req.DueDate, req.ReturnedAt)
-	if err != nil {
-		return nil, err
-	}
-	if req.TagIDs != nil {
-		if err := s.tags.SetLoanTags(ctx, loan.ID, req.TagIDs); err != nil {
-			return nil, fmt.Errorf("setting loan tags: %w", err)
-		}
-		loan, err = s.loans.FindByID(ctx, loan.ID)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return loan, nil
+	return s.loans.Update(ctx, id, req.LoanedTo, req.Notes, req.DueDate, req.ReturnedAt)
 }
 
 func (s *LoanService) DeleteLoan(ctx context.Context, id uuid.UUID) error {


### PR DESCRIPTION
- Migration 000016 drops the \`loan_tags\` junction table; loan endpoints lose \`tag_ids\` on create/update bodies and the \`tag\` query filter on list.
- \`LoanService\` no longer takes a \`TagRepo\`; \`Loan.Tags\` field gone; the two scanners collapse into one since every read path now returns the same shape.