### PR TITLE
feat: ios v1 redesign prep — caller-scoped fields, per-library counts, fuzzy search, author sort

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -13246,6 +13246,14 @@ const docTemplate = `{
                 },
                 "updated_at": {
                     "type": "string"
+                },
+                "user_progress_pct": {
+                    "description": "UserProgressPct is the caller's reading progress 0-100 (0 = none).",
+                    "type": "number"
+                },
+                "user_rating": {
+                    "description": "UserRating is the caller's rating (1-10 half-star integer; 0 = none).",
+                    "type": "integer"
                 }
             }
         },
@@ -13412,6 +13420,10 @@ const docTemplate = `{
         "responses.LibraryResponse": {
             "type": "object",
             "properties": {
+                "book_count": {
+                    "description": "BookCount is the total number of books in the library. ReadingCount\nand ReadCount are caller-scoped — the calling user's reading + read\nbooks in this library. Always populated on list endpoints; on single-\nlibrary endpoints they fall back to 0 unless the path was scoped.",
+                    "type": "integer"
+                },
                 "created_at": {
                     "type": "string"
                 },
@@ -13429,6 +13441,12 @@ const docTemplate = `{
                 },
                 "owner_id": {
                     "type": "string"
+                },
+                "read_count": {
+                    "type": "integer"
+                },
+                "reading_count": {
+                    "type": "integer"
                 },
                 "slug": {
                     "type": "string"
@@ -13554,6 +13572,12 @@ const docTemplate = `{
                 },
                 "per_page": {
                     "type": "integer"
+                },
+                "suggestions": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "total": {
                     "type": "integer"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -13240,6 +13240,14 @@
                 },
                 "updated_at": {
                     "type": "string"
+                },
+                "user_progress_pct": {
+                    "description": "UserProgressPct is the caller's reading progress 0-100 (0 = none).",
+                    "type": "number"
+                },
+                "user_rating": {
+                    "description": "UserRating is the caller's rating (1-10 half-star integer; 0 = none).",
+                    "type": "integer"
                 }
             }
         },
@@ -13406,6 +13414,10 @@
         "responses.LibraryResponse": {
             "type": "object",
             "properties": {
+                "book_count": {
+                    "description": "BookCount is the total number of books in the library. ReadingCount\nand ReadCount are caller-scoped — the calling user's reading + read\nbooks in this library. Always populated on list endpoints; on single-\nlibrary endpoints they fall back to 0 unless the path was scoped.",
+                    "type": "integer"
+                },
                 "created_at": {
                     "type": "string"
                 },
@@ -13423,6 +13435,12 @@
                 },
                 "owner_id": {
                     "type": "string"
+                },
+                "read_count": {
+                    "type": "integer"
+                },
+                "reading_count": {
+                    "type": "integer"
                 },
                 "slug": {
                     "type": "string"
@@ -13548,6 +13566,12 @@
                 },
                 "per_page": {
                     "type": "integer"
+                },
+                "suggestions": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "total": {
                     "type": "integer"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -900,6 +900,13 @@ definitions:
         type: string
       updated_at:
         type: string
+      user_progress_pct:
+        description: UserProgressPct is the caller's reading progress 0-100 (0 = none).
+        type: number
+      user_rating:
+        description: UserRating is the caller's rating (1-10 half-star integer; 0
+          = none).
+        type: integer
     type: object
   responses.ContributorItem:
     properties:
@@ -1009,6 +1016,13 @@ definitions:
     type: object
   responses.LibraryResponse:
     properties:
+      book_count:
+        description: |-
+          BookCount is the total number of books in the library. ReadingCount
+          and ReadCount are caller-scoped — the calling user's reading + read
+          books in this library. Always populated on list endpoints; on single-
+          library endpoints they fall back to 0 unless the path was scoped.
+        type: integer
       created_at:
         type: string
       description:
@@ -1021,6 +1035,10 @@ definitions:
         type: string
       owner_id:
         type: string
+      read_count:
+        type: integer
+      reading_count:
+        type: integer
       slug:
         type: string
       updated_at:
@@ -1104,6 +1122,10 @@ definitions:
         type: integer
       per_page:
         type: integer
+      suggestions:
+        items:
+          type: string
+        type: array
       total:
         type: integer
     type: object

--- a/internal/api/handlers/books.go
+++ b/internal/api/handlers/books.go
@@ -369,7 +369,21 @@ func (h *BookHandler) GetBook(w http.ResponseWriter, r *http.Request) {
 		respond.Error(w, http.StatusBadRequest, "invalid book id")
 		return
 	}
-	book, err := h.svc.GetBook(r.Context(), bookID)
+	libraryID, err := uuid.Parse(r.PathValue("library_id"))
+	if err != nil {
+		respond.Error(w, http.StatusBadRequest, "invalid library id")
+		return
+	}
+	// Caller-scope the user_read_status / user_rating / user_progress_pct
+	// + per-library active_loan_count columns so the per-book GET emits
+	// the same shape as the list endpoint. Series detail (and any other
+	// per-book lookup that needs reading state) depends on this.
+	claims := middleware.ClaimsFromContext(r.Context())
+	var callerID uuid.UUID
+	if claims != nil {
+		callerID = claims.UserID
+	}
+	book, err := h.svc.GetBook(r.Context(), bookID, callerID, libraryID)
 	if errors.Is(err, repository.ErrNotFound) {
 		respond.Error(w, http.StatusNotFound, "book not found")
 		return

--- a/internal/api/handlers/books.go
+++ b/internal/api/handlers/books.go
@@ -296,12 +296,21 @@ func (h *BookHandler) ListBooks(w http.ResponseWriter, r *http.Request) {
 	for _, b := range books {
 		items = append(items, bookBody(b))
 	}
-	respond.JSON(w, http.StatusOK, map[string]any{
+	resp := map[string]any{
 		"items":    items,
 		"total":    total,
 		"page":     max(page, 1),
 		"per_page": perPage,
-	})
+	}
+	// "Did you mean…" — when the literal query found nothing, run a
+	// pg_trgm similarity match and include up to 5 suggestions. Skipped
+	// when q is empty (pure browse) or when results came back.
+	if total == 0 && q != "" {
+		if suggestions, err := h.books.SearchSuggestions(r.Context(), libraryID, q); err == nil && len(suggestions) > 0 {
+			resp["suggestions"] = suggestions
+		}
+	}
+	respond.JSON(w, http.StatusOK, resp)
 }
 
 // CreateBook godoc

--- a/internal/api/handlers/books.go
+++ b/internal/api/handlers/books.go
@@ -674,8 +674,10 @@ func bookBody(b *models.Book) map[string]any {
 		"publisher":        b.Publisher,
 		"publish_year":     b.PublishYear,
 		"language":         b.Language,
-		"user_read_status":  b.UserReadStatus,
-		"active_loan_count": b.ActiveLoanCount,
+		"user_read_status":   b.UserReadStatus,
+		"user_rating":        b.UserRating,
+		"user_progress_pct":  b.UserProgressPct,
+		"active_loan_count":  b.ActiveLoanCount,
 	}
 }
 

--- a/internal/api/handlers/editions.go
+++ b/internal/api/handlers/editions.go
@@ -360,13 +360,14 @@ func parseEditionRequestBody(body *editionRequestBody) (*service.EditionRequest,
 }
 
 type interactionRequestBody struct {
-	ReadStatus   string `json:"read_status"`
-	Rating       *int   `json:"rating"`
-	Notes        string `json:"notes"`
-	Review       string `json:"review"`
-	DateStarted  string `json:"date_started"`  // YYYY-MM-DD or ""
-	DateFinished string `json:"date_finished"` // YYYY-MM-DD or ""
-	IsFavorite   bool   `json:"is_favorite"`
+	ReadStatus   string          `json:"read_status"`
+	Rating       *int            `json:"rating"`
+	Notes        string          `json:"notes"`
+	Review       string          `json:"review"`
+	DateStarted  string          `json:"date_started"`  // YYYY-MM-DD or ""
+	DateFinished string          `json:"date_finished"` // YYYY-MM-DD or ""
+	IsFavorite   bool            `json:"is_favorite"`
+	Progress     json.RawMessage `json:"progress"` // {pages_read?, percent?, position?}
 }
 
 func decodeInteractionRequest(r *http.Request) (*service.InteractionRequest, error) {
@@ -402,6 +403,7 @@ func decodeInteractionRequest(r *http.Request) (*service.InteractionRequest, err
 		DateStarted:  dateStarted,
 		DateFinished: dateFinished,
 		IsFavorite:   body.IsFavorite,
+		Progress:     body.Progress,
 	}, nil
 }
 
@@ -467,6 +469,11 @@ func interactionBody(i *models.UserBookInteraction) map[string]any {
 		"reread_count":    i.RereadCount,
 		"created_at":      i.CreatedAt,
 		"updated_at":      i.UpdatedAt,
+	}
+	if len(i.Progress) > 0 {
+		body["progress"] = json.RawMessage(i.Progress)
+	} else {
+		body["progress"] = nil
 	}
 	if i.Rating != nil {
 		body["rating"] = *i.Rating

--- a/internal/api/handlers/libraries.go
+++ b/internal/api/handlers/libraries.go
@@ -402,14 +402,17 @@ func (h *LibraryHandler) RemoveMember(w http.ResponseWriter, r *http.Request) {
 
 func libraryBody(l *models.Library) map[string]any {
 	return map[string]any{
-		"id":          l.ID,
-		"name":        l.Name,
-		"description": l.Description,
-		"slug":        l.Slug,
-		"owner_id":    l.OwnerID,
-		"is_public":   l.IsPublic,
-		"created_at":  l.CreatedAt,
-		"updated_at":  l.UpdatedAt,
+		"id":            l.ID,
+		"name":          l.Name,
+		"description":   l.Description,
+		"slug":          l.Slug,
+		"owner_id":      l.OwnerID,
+		"is_public":     l.IsPublic,
+		"created_at":    l.CreatedAt,
+		"updated_at":    l.UpdatedAt,
+		"book_count":    l.BookCount,
+		"reading_count": l.ReadingCount,
+		"read_count":    l.ReadCount,
 	}
 }
 

--- a/internal/api/responses/responses.go
+++ b/internal/api/responses/responses.go
@@ -156,6 +156,10 @@ type BookResponse struct {
 	Series       []SeriesRef      `json:"series"`
 	Shelves      []ShelfRef       `json:"shelves"`
 	AddedBy      *uuid.UUID       `json:"added_by,omitempty"`
+	// UserRating is the caller's rating (1-10 half-star integer; 0 = none).
+	UserRating int `json:"user_rating"`
+	// UserProgressPct is the caller's reading progress 0-100 (0 = none).
+	UserProgressPct float64 `json:"user_progress_pct"`
 	// ActiveLoanCount is the number of active (not yet returned) loans for
 	// this book — scoped to the library when the read is library-scoped,
 	// global otherwise. Always populated.

--- a/internal/api/responses/responses.go
+++ b/internal/api/responses/responses.go
@@ -113,6 +113,13 @@ type LibraryResponse struct {
 	IsPublic    bool      `json:"is_public"`
 	CreatedAt   time.Time `json:"created_at"`
 	UpdatedAt   time.Time `json:"updated_at"`
+	// BookCount is the total number of books in the library. ReadingCount
+	// and ReadCount are caller-scoped — the calling user's reading + read
+	// books in this library. Always populated on list endpoints; on single-
+	// library endpoints they fall back to 0 unless the path was scoped.
+	BookCount    int `json:"book_count"`
+	ReadingCount int `json:"reading_count"`
+	ReadCount    int `json:"read_count"`
 }
 
 // MemberResponse is returned by library member endpoints.

--- a/internal/api/responses/responses.go
+++ b/internal/api/responses/responses.go
@@ -173,11 +173,15 @@ type BookResponse struct {
 }
 
 // PagedBooksResponse is the paginated response from book list endpoints.
+// When the literal query returns zero results, Suggestions carries up to
+// five trigram-similar titles so the client can surface a "did you mean"
+// hint.
 type PagedBooksResponse struct {
-	Items   []BookResponse `json:"items"`
-	Total   int            `json:"total"`
-	Page    int            `json:"page"`
-	PerPage int            `json:"per_page"`
+	Items       []BookResponse `json:"items"`
+	Total       int            `json:"total"`
+	Page        int            `json:"page"`
+	PerPage     int            `json:"per_page"`
+	Suggestions []string       `json:"suggestions,omitempty"`
 }
 
 // LettersResponse is returned by GET .../books/letters.

--- a/internal/db/migrations/000017_book_search_trgm.down.sql
+++ b/internal/db/migrations/000017_book_search_trgm.down.sql
@@ -1,0 +1,5 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Copyright (C) 2026 fireball1725
+
+DROP INDEX IF EXISTS idx_books_title_trgm;
+-- Leave the extension in place — other queries may have started using it.

--- a/internal/db/migrations/000017_book_search_trgm.up.sql
+++ b/internal/db/migrations/000017_book_search_trgm.up.sql
@@ -1,0 +1,14 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Copyright (C) 2026 fireball1725
+--
+-- Fuzzy "did you mean" support for book search. Enables the pg_trgm
+-- extension and adds a GIN index on lower(title || ' ' || subtitle) so
+-- a similarity match is fast even on large libraries.
+--
+-- The search handler falls through to a similarity match when the
+-- literal `q` returns 0 hits and surfaces the top suggestion.
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE INDEX IF NOT EXISTS idx_books_title_trgm
+    ON books USING gin (lower(title || ' ' || COALESCE(subtitle, '')) gin_trgm_ops);

--- a/internal/models/book.go
+++ b/internal/models/book.go
@@ -54,6 +54,14 @@ type Book struct {
 	PublishYear    *int
 	Language       string
 	UserReadStatus string
+	// UserRating is the calling user's rating (1-10 half-star integer; 0
+	// means no rating). Picked from the same interaction row as
+	// UserReadStatus so multi-edition books stay consistent.
+	UserRating int
+	// UserProgressPct is the calling user's reading progress as a percent
+	// (0-100). Pulled from progress.percent on the chosen interaction;
+	// zero when there's no progress row or no percent set.
+	UserProgressPct float64
 	// ActiveLoanCount is the number of active (not yet returned) loans for
 	// this book. Scoped to a single library when the read is library-scoped
 	// (ListBooks via library), or counted across every library otherwise.

--- a/internal/models/edition.go
+++ b/internal/models/edition.go
@@ -83,6 +83,11 @@ type UserBookInteraction struct {
 	DateFinished  *time.Time
 	IsFavorite    bool
 	RereadCount   int
+	// Progress is the user's reading progress on this edition. Schema is
+	// {pages_read?: int, percent?: float, position?: string} — pages for
+	// print, percent for ebook readers, position free text for audio.
+	// Empty []byte (or nil) when never set; raw JSON bytes otherwise.
+	Progress      []byte
 	CreatedAt     time.Time
 	UpdatedAt     time.Time
 }

--- a/internal/models/library.go
+++ b/internal/models/library.go
@@ -18,6 +18,13 @@ type Library struct {
 	IsPublic    bool
 	CreatedAt   time.Time
 	UpdatedAt   time.Time
+	// BookCount is the total number of books in the library. ReadingCount
+	// and ReadCount are caller-scoped — books the calling user has marked
+	// 'reading' or 'read' respectively. List endpoints populate these so
+	// clients can render per-library hero stats without a follow-up call.
+	BookCount    int
+	ReadingCount int
+	ReadCount    int
 }
 
 type LibraryMember struct {

--- a/internal/repository/books.go
+++ b/internal/repository/books.go
@@ -293,10 +293,27 @@ func (r *BookRepo) EnsureBookContributor(ctx context.Context, tx pgx.Tx, bookID,
 	return nil
 }
 
-func (r *BookRepo) FindByID(ctx context.Context, id uuid.UUID) (*models.Book, error) {
-	q := booksSelect(0, 0) + ` WHERE b.id = $1`
+// FindByID returns a single book by id. callerID + libraryID are
+// optional; when non-Nil they hydrate the caller-scoped subqueries
+// (user_read_status / user_rating / user_progress_pct + per-library
+// active_loan_count) that mirror the list endpoint. Pass uuid.Nil for
+// internal lookups that don't need them.
+func (r *BookRepo) FindByID(ctx context.Context, id uuid.UUID, callerID uuid.UUID, libraryID uuid.UUID) (*models.Book, error) {
+	args := []any{id}
+	callerArg := 0
+	loanLibraryArg := 0
+	if callerID != uuid.Nil {
+		args = append(args, callerID)
+		callerArg = len(args)
+	}
+	if libraryID != uuid.Nil {
+		args = append(args, libraryID)
+		loanLibraryArg = len(args)
+	}
 
-	book, err := scanBook(r.db.QueryRow(ctx, q, id))
+	q := booksSelect(callerArg, loanLibraryArg) + ` WHERE b.id = $1`
+
+	book, err := scanBook(r.db.QueryRow(ctx, q, args...))
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, ErrNotFound
 	}

--- a/internal/repository/books.go
+++ b/internal/repository/books.go
@@ -748,6 +748,36 @@ func (r *BookRepo) List(ctx context.Context, libraryID uuid.UUID, opts ListBooks
 	return books, total, nil
 }
 
+// SearchSuggestions returns up to 5 book titles in the library whose
+// (title || subtitle) is similar to the supplied query, ranked by trgm
+// distance. Used by the books-search "did you mean" fallback when a
+// literal match returns nothing. Empty result if pg_trgm has no candidates
+// above the default similarity threshold (0.3).
+func (r *BookRepo) SearchSuggestions(ctx context.Context, libraryID uuid.UUID, query string) ([]string, error) {
+	const q = `
+		SELECT DISTINCT ON (lower(b.title)) b.title
+		FROM books b
+		JOIN library_books lb ON lb.book_id = b.id
+		WHERE lb.library_id = $1
+		  AND lower(b.title || ' ' || COALESCE(b.subtitle, '')) % lower($2)
+		ORDER BY lower(b.title), lower(b.title || ' ' || COALESCE(b.subtitle, '')) <-> lower($2)
+		LIMIT 5`
+	rows, err := r.db.Query(ctx, q, libraryID, query)
+	if err != nil {
+		return nil, fmt.Errorf("fuzzy search: %w", err)
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var t string
+		if err := rows.Scan(&t); err != nil {
+			return nil, err
+		}
+		out = append(out, t)
+	}
+	return out, rows.Err()
+}
+
 func (r *BookRepo) Update(ctx context.Context, tx pgx.Tx, id uuid.UUID, title, subtitle string, mediaTypeID uuid.UUID, description string) error {
 	const q = `
 		UPDATE books

--- a/internal/repository/books.go
+++ b/internal/repository/books.go
@@ -69,23 +69,47 @@ func (r *BookRepo) ListMediaTypes(ctx context.Context) ([]*models.MediaType, err
 // arg (used by ListBooks). When 0, it counts active loans across every
 // library the book belongs to (used by FindByID).
 func booksSelect(userStatusArg, loanLibraryArg int) string {
-	var userReadStatusExpr string
+	// All three caller-scoped subqueries (status / rating / progress) use
+	// the same ORDER BY so they pick the same interaction row, keeping the
+	// returned values internally consistent for users who own multiple
+	// editions of the same book.
+	const interactionPickOrder = `ORDER BY CASE ubi.read_status
+		WHEN 'read' THEN 1
+		WHEN 'reading' THEN 2
+		WHEN 'did_not_finish' THEN 3
+		ELSE 4
+	END`
+
+	var userReadStatusExpr, userRatingExpr, userProgressExpr string
 	if userStatusArg > 0 {
 		userReadStatusExpr = fmt.Sprintf(`COALESCE((
 		SELECT ubi.read_status
 		FROM book_editions be_rs
 		JOIN user_book_interactions ubi ON ubi.book_edition_id = be_rs.id
 		WHERE be_rs.book_id = b.id AND ubi.user_id = $%d
-		ORDER BY CASE ubi.read_status
-			WHEN 'read' THEN 1
-			WHEN 'reading' THEN 2
-			WHEN 'did_not_finish' THEN 3
-			ELSE 4
-		END
+		%s
 		LIMIT 1
-	), '') AS user_read_status`, userStatusArg)
+	), '') AS user_read_status`, userStatusArg, interactionPickOrder)
+		userRatingExpr = fmt.Sprintf(`COALESCE((
+		SELECT ubi.rating
+		FROM book_editions be_rt
+		JOIN user_book_interactions ubi ON ubi.book_edition_id = be_rt.id
+		WHERE be_rt.book_id = b.id AND ubi.user_id = $%d
+		%s
+		LIMIT 1
+	), 0) AS user_rating`, userStatusArg, interactionPickOrder)
+		userProgressExpr = fmt.Sprintf(`COALESCE((
+		SELECT (ubi.progress->>'percent')::numeric
+		FROM book_editions be_pg
+		JOIN user_book_interactions ubi ON ubi.book_edition_id = be_pg.id
+		WHERE be_pg.book_id = b.id AND ubi.user_id = $%d
+		%s
+		LIMIT 1
+	), 0) AS user_progress_pct`, userStatusArg, interactionPickOrder)
 	} else {
 		userReadStatusExpr = `'' AS user_read_status`
+		userRatingExpr = `0 AS user_rating`
+		userProgressExpr = `0 AS user_progress_pct`
 	}
 
 	var activeLoanExpr string
@@ -193,6 +217,8 @@ func booksSelect(userStatusArg, loanLibraryArg int) string {
 			LIMIT 1
 		), '') AS language,
 		` + userReadStatusExpr + `,
+		` + userRatingExpr + `,
+		` + userProgressExpr + `,
 		` + activeLoanExpr + `
 	FROM books b
 	JOIN media_types mt ON mt.id = b.media_type_id`
@@ -800,6 +826,8 @@ func scanBook(s scanner) (*models.Book, error) {
 		publishYear    pgtype.Int4
 		language       pgtype.Text
 		userReadStatus string
+		userRating     int
+		userProgress   pgtype.Numeric
 		activeLoans    int
 		b              models.Book
 	)
@@ -810,7 +838,7 @@ func scanBook(s scanner) (*models.Book, error) {
 		&pgDesc, &b.CreatedAt, &b.UpdatedAt,
 		&contribJSON, &tagsJSON, &genresJSON, &b.HasCover,
 		&seriesJSON, &shelvesJSON, &publisher, &publishYear, &language,
-		&userReadStatus, &activeLoans,
+		&userReadStatus, &userRating, &userProgress, &activeLoans,
 	)
 	if err != nil {
 		return nil, err
@@ -824,6 +852,11 @@ func scanBook(s scanner) (*models.Book, error) {
 	b.Publisher = publisher.String
 	b.Language = language.String
 	b.UserReadStatus = userReadStatus
+	b.UserRating = userRating
+	if userProgress.Valid {
+		f, _ := userProgress.Float64Value()
+		b.UserProgressPct = f.Float64
+	}
 	b.ActiveLoanCount = activeLoans
 	if publishYear.Valid {
 		y := int(publishYear.Int32)

--- a/internal/repository/books.go
+++ b/internal/repository/books.go
@@ -462,6 +462,18 @@ func (r *BookRepo) List(ctx context.Context, libraryID uuid.UUID, opts ListBooks
 		sortCol = "lower(mt.display_name)"
 	case "publish_date":
 		sortCol = "(SELECT be.publish_date FROM book_editions be WHERE be.book_id = b.id AND be.is_primary = true AND be.publish_date IS NOT NULL LIMIT 1)"
+	case "author":
+		// Sort by the first contributor's lowercased name (display
+		// order ascending so the "primary" credit wins). Books with
+		// no contributors fall to the end via NULLS LAST below.
+		sortCol = `(
+			SELECT lower(c.name)
+			FROM book_contributors bc
+			JOIN contributors c ON c.id = bc.contributor_id
+			WHERE bc.book_id = b.id
+			ORDER BY bc.display_order, c.name
+			LIMIT 1
+		)`
 	}
 	sortDir := "ASC"
 	if opts.SortDir == "desc" {
@@ -739,7 +751,7 @@ func (r *BookRepo) List(ctx context.Context, libraryID uuid.UUID, opts ListBooks
 	// List
 	args = append(args, opts.PerPage, offset)
 	nullsClause := ""
-	if opts.Sort == "publish_date" {
+	if opts.Sort == "publish_date" || opts.Sort == "author" {
 		nullsClause = " NULLS LAST"
 	}
 	listQ := selectQuery + scopeJoin + where +

--- a/internal/repository/editions.go
+++ b/internal/repository/editions.go
@@ -256,7 +256,7 @@ func (r *EditionRepo) IncrementCopyCount(ctx context.Context, libraryID, edition
 
 const interactionColumns = `
 	id, user_id, book_edition_id, read_status, rating, COALESCE(notes,''), COALESCE(review,''),
-	date_started, date_finished, is_favorite, reread_count, created_at, updated_at
+	date_started, date_finished, is_favorite, reread_count, progress, created_at, updated_at
 `
 
 func (r *EditionRepo) GetInteraction(ctx context.Context, userID, editionID uuid.UUID) (*models.UserBookInteraction, error) {
@@ -271,12 +271,16 @@ func (r *EditionRepo) GetInteraction(ctx context.Context, userID, editionID uuid
 	return i, nil
 }
 
-func (r *EditionRepo) UpsertInteraction(ctx context.Context, userID, editionID uuid.UUID, readStatus string, rating any, notes, review string, dateStarted, dateFinished any, isFavorite bool) (*models.UserBookInteraction, error) {
+// UpsertInteraction creates or fully overwrites a user's interaction
+// with an edition. progress is the JSONB body for reading-progress
+// ({pages_read?, percent?, position?}) — pass nil or empty []byte to
+// clear the column.
+func (r *EditionRepo) UpsertInteraction(ctx context.Context, userID, editionID uuid.UUID, readStatus string, rating any, notes, review string, dateStarted, dateFinished any, isFavorite bool, progress []byte) (*models.UserBookInteraction, error) {
 	const q = `
 		INSERT INTO user_book_interactions
-			(id, user_id, book_edition_id, read_status, rating, notes, review, date_started, date_finished, is_favorite)
+			(id, user_id, book_edition_id, read_status, rating, notes, review, date_started, date_finished, is_favorite, progress)
 		VALUES
-			($1, $2, $3, $4, $5, NULLIF($6,''), NULLIF($7,''), $8, $9, $10)
+			($1, $2, $3, $4, $5, NULLIF($6,''), NULLIF($7,''), $8, $9, $10, $11)
 		ON CONFLICT (user_id, book_edition_id) DO UPDATE
 		SET read_status   = EXCLUDED.read_status,
 		    rating        = EXCLUDED.rating,
@@ -285,10 +289,15 @@ func (r *EditionRepo) UpsertInteraction(ctx context.Context, userID, editionID u
 		    date_started  = EXCLUDED.date_started,
 		    date_finished = EXCLUDED.date_finished,
 		    is_favorite   = EXCLUDED.is_favorite,
+		    progress      = EXCLUDED.progress,
 		    updated_at    = NOW()
 		RETURNING ` + interactionColumns
 
-	i, err := scanInteraction(r.db.QueryRow(ctx, q, uuid.New(), userID, editionID, readStatus, rating, notes, review, dateStarted, dateFinished, isFavorite))
+	var progressArg any
+	if len(progress) > 0 {
+		progressArg = progress
+	}
+	i, err := scanInteraction(r.db.QueryRow(ctx, q, uuid.New(), userID, editionID, readStatus, rating, notes, review, dateStarted, dateFinished, isFavorite, progressArg))
 	if err != nil {
 		return nil, fmt.Errorf("upserting interaction: %w", err)
 	}
@@ -305,6 +314,8 @@ func (r *EditionRepo) UpsertInteraction(ctx context.Context, userID, editionID u
 // String columns treat empty as no-input via NULLIF; nullable columns
 // treat nil the same way. is_favorite has to be tri-state, so it
 // takes a *bool — pass nil to leave the existing flag alone.
+// MergeInteraction is the import-safe variant — pass nil progress to
+// preserve whatever the existing row holds.
 func (r *EditionRepo) MergeInteraction(
 	ctx context.Context,
 	userID, editionID uuid.UUID,
@@ -313,12 +324,13 @@ func (r *EditionRepo) MergeInteraction(
 	notes, review *string,
 	dateStarted, dateFinished any,
 	isFavorite *bool,
+	progress []byte,
 ) (*models.UserBookInteraction, error) {
 	const q = `
 		INSERT INTO user_book_interactions
-			(id, user_id, book_edition_id, read_status, rating, notes, review, date_started, date_finished, is_favorite)
+			(id, user_id, book_edition_id, read_status, rating, notes, review, date_started, date_finished, is_favorite, progress)
 		VALUES
-			($1, $2, $3, COALESCE(NULLIF($4,''),''), $5, NULLIF($6,''), NULLIF($7,''), $8, $9, COALESCE($10, false))
+			($1, $2, $3, COALESCE(NULLIF($4,''),''), $5, NULLIF($6,''), NULLIF($7,''), $8, $9, COALESCE($10, false), $11)
 		ON CONFLICT (user_id, book_edition_id) DO UPDATE
 		SET read_status   = COALESCE(NULLIF(EXCLUDED.read_status,''), user_book_interactions.read_status),
 		    rating        = COALESCE(EXCLUDED.rating, user_book_interactions.rating),
@@ -327,6 +339,7 @@ func (r *EditionRepo) MergeInteraction(
 		    date_started  = COALESCE(EXCLUDED.date_started, user_book_interactions.date_started),
 		    date_finished = COALESCE(EXCLUDED.date_finished, user_book_interactions.date_finished),
 		    is_favorite   = COALESCE($10, user_book_interactions.is_favorite),
+		    progress      = COALESCE(EXCLUDED.progress, user_book_interactions.progress),
 		    updated_at    = NOW()
 		RETURNING ` + interactionColumns
 
@@ -342,7 +355,11 @@ func (r *EditionRepo) MergeInteraction(
 	if review != nil {
 		rv = *review
 	}
-	i, err := scanInteraction(r.db.QueryRow(ctx, q, uuid.New(), userID, editionID, rs, rating, nt, rv, dateStarted, dateFinished, isFavorite))
+	var progressArg any
+	if len(progress) > 0 {
+		progressArg = progress
+	}
+	i, err := scanInteraction(r.db.QueryRow(ctx, q, uuid.New(), userID, editionID, rs, rating, nt, rv, dateStarted, dateFinished, isFavorite, progressArg))
 	if err != nil {
 		return nil, fmt.Errorf("merging interaction: %w", err)
 	}
@@ -365,19 +382,21 @@ func (r *EditionRepo) DeleteInteraction(ctx context.Context, userID, editionID u
 
 func scanInteraction(s scanner) (*models.UserBookInteraction, error) {
 	var (
-		pgID          pgtype.UUID
-		pgUserID      pgtype.UUID
-		pgEditionID   pgtype.UUID
-		pgRating      pgtype.Int4
-		pgDateStarted pgtype.Date
+		pgID           pgtype.UUID
+		pgUserID       pgtype.UUID
+		pgEditionID    pgtype.UUID
+		pgRating       pgtype.Int4
+		pgDateStarted  pgtype.Date
 		pgDateFinished pgtype.Date
-		i             models.UserBookInteraction
+		progress       []byte
+		i              models.UserBookInteraction
 	)
 	err := s.Scan(
 		&pgID, &pgUserID, &pgEditionID,
 		&i.ReadStatus, &pgRating, &i.Notes, &i.Review,
 		&pgDateStarted, &pgDateFinished,
-		&i.IsFavorite, &i.RereadCount, &i.CreatedAt, &i.UpdatedAt,
+		&i.IsFavorite, &i.RereadCount, &progress,
+		&i.CreatedAt, &i.UpdatedAt,
 	)
 	if err != nil {
 		return nil, err
@@ -397,5 +416,6 @@ func scanInteraction(s scanner) (*models.UserBookInteraction, error) {
 		t := pgDateFinished.Time
 		i.DateFinished = &t
 	}
+	i.Progress = progress
 	return &i, nil
 }

--- a/internal/repository/libraries.go
+++ b/internal/repository/libraries.go
@@ -26,6 +26,35 @@ func NewLibraryRepo(db *pgxpool.Pool) *LibraryRepo {
 
 const libraryColumns = `id, name, description, slug, owner_id, is_public, created_at, updated_at`
 
+// libraryListColumns extends libraryColumns with caller-scoped count
+// columns for the list endpoints. callerArg is the positional arg index
+// holding the calling user id; pass 0 to skip the per-user counts (they
+// will return 0).
+func libraryListColumns(callerArg int) string {
+	if callerArg <= 0 {
+		return libraryColumns + `,
+		COALESCE((SELECT COUNT(*) FROM library_books lb WHERE lb.library_id = l.id), 0) AS book_count,
+		0 AS reading_count,
+		0 AS read_count`
+	}
+	return libraryColumns + `,
+		COALESCE((SELECT COUNT(*) FROM library_books lb WHERE lb.library_id = l.id), 0) AS book_count,
+		COALESCE((
+			SELECT COUNT(DISTINCT lb.book_id)
+			FROM library_books lb
+			JOIN book_editions be ON be.book_id = lb.book_id
+			JOIN user_book_interactions ubi ON ubi.book_edition_id = be.id
+			WHERE lb.library_id = l.id AND ubi.user_id = $` + fmt.Sprint(callerArg) + ` AND ubi.read_status = 'reading'
+		), 0) AS reading_count,
+		COALESCE((
+			SELECT COUNT(DISTINCT lb.book_id)
+			FROM library_books lb
+			JOIN book_editions be ON be.book_id = lb.book_id
+			JOIN user_book_interactions ubi ON ubi.book_edition_id = be.id
+			WHERE lb.library_id = l.id AND ubi.user_id = $` + fmt.Sprint(callerArg) + ` AND ubi.read_status = 'read'
+		), 0) AS read_count`
+}
+
 func scanLibrary(s scanner) (*models.Library, error) {
 	var (
 		pgID      pgtype.UUID
@@ -40,6 +69,28 @@ func scanLibrary(s scanner) (*models.Library, error) {
 	lib.ID = uuid.UUID(pgID.Bytes)
 	lib.OwnerID = uuid.UUID(pgOwnerID.Bytes)
 	lib.Description = pgDesc.String // empty string when NULL
+	return &lib, nil
+}
+
+// scanLibraryWithCounts is the list-path scanner — same as scanLibrary
+// plus the three count columns added by libraryListColumns.
+func scanLibraryWithCounts(s scanner) (*models.Library, error) {
+	var (
+		pgID      pgtype.UUID
+		pgOwnerID pgtype.UUID
+		pgDesc    pgtype.Text
+		lib       models.Library
+	)
+	err := s.Scan(
+		&pgID, &lib.Name, &pgDesc, &lib.Slug, &pgOwnerID, &lib.IsPublic, &lib.CreatedAt, &lib.UpdatedAt,
+		&lib.BookCount, &lib.ReadingCount, &lib.ReadCount,
+	)
+	if err != nil {
+		return nil, err
+	}
+	lib.ID = uuid.UUID(pgID.Bytes)
+	lib.OwnerID = uuid.UUID(pgOwnerID.Bytes)
+	lib.Description = pgDesc.String
 	return &lib, nil
 }
 
@@ -81,10 +132,12 @@ func (r *LibraryRepo) ExistsBySlug(ctx context.Context, slug string) (bool, erro
 	return exists, nil
 }
 
-// ListForUser returns all libraries in which the user holds a membership.
+// ListForUser returns all libraries in which the user holds a membership,
+// each populated with caller-scoped counts (book_count global, reading +
+// read counts for the same userID).
 func (r *LibraryRepo) ListForUser(ctx context.Context, userID uuid.UUID) ([]*models.Library, error) {
 	q := `
-		SELECT l.` + libraryColumns + `
+		SELECT l.` + libraryListColumns(1) + `
 		FROM libraries l
 		JOIN library_memberships lm ON lm.library_id = l.id
 		WHERE lm.user_id = $1
@@ -95,18 +148,29 @@ func (r *LibraryRepo) ListForUser(ctx context.Context, userID uuid.UUID) ([]*mod
 		return nil, fmt.Errorf("listing libraries for user: %w", err)
 	}
 	defer rows.Close()
-	return collectLibraries(rows)
+	return collectLibrariesWithCounts(rows)
 }
 
-// ListAll returns every library. Used by instance admins.
-func (r *LibraryRepo) ListAll(ctx context.Context) ([]*models.Library, error) {
-	q := `SELECT ` + libraryColumns + ` FROM libraries ORDER BY name`
-	rows, err := r.db.Query(ctx, q)
+// ListAll returns every library. Used by instance admins. callerID is
+// optional — when non-zero, reading + read counts are scoped to that
+// user; otherwise they're zero (book_count is always populated).
+func (r *LibraryRepo) ListAll(ctx context.Context, callerID uuid.UUID) ([]*models.Library, error) {
+	if callerID == uuid.Nil {
+		q := `SELECT ` + libraryListColumns(0) + ` FROM libraries l ORDER BY l.name`
+		rows, err := r.db.Query(ctx, q)
+		if err != nil {
+			return nil, fmt.Errorf("listing all libraries: %w", err)
+		}
+		defer rows.Close()
+		return collectLibrariesWithCounts(rows)
+	}
+	q := `SELECT ` + libraryListColumns(1) + ` FROM libraries l ORDER BY l.name`
+	rows, err := r.db.Query(ctx, q, callerID)
 	if err != nil {
 		return nil, fmt.Errorf("listing all libraries: %w", err)
 	}
 	defer rows.Close()
-	return collectLibraries(rows)
+	return collectLibrariesWithCounts(rows)
 }
 
 func (r *LibraryRepo) Update(ctx context.Context, id uuid.UUID, name, description string, isPublic bool) (*models.Library, error) {
@@ -141,6 +205,18 @@ func collectLibraries(rows pgx.Rows) ([]*models.Library, error) {
 	var out []*models.Library
 	for rows.Next() {
 		lib, err := scanLibrary(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scanning library: %w", err)
+		}
+		out = append(out, lib)
+	}
+	return out, rows.Err()
+}
+
+func collectLibrariesWithCounts(rows pgx.Rows) ([]*models.Library, error) {
+	var out []*models.Library
+	for rows.Next() {
+		lib, err := scanLibraryWithCounts(rows)
 		if err != nil {
 			return nil, fmt.Errorf("scanning library: %w", err)
 		}

--- a/internal/repository/libraries.go
+++ b/internal/repository/libraries.go
@@ -201,18 +201,6 @@ func (r *LibraryRepo) Delete(ctx context.Context, id uuid.UUID) error {
 	return nil
 }
 
-func collectLibraries(rows pgx.Rows) ([]*models.Library, error) {
-	var out []*models.Library
-	for rows.Next() {
-		lib, err := scanLibrary(rows)
-		if err != nil {
-			return nil, fmt.Errorf("scanning library: %w", err)
-		}
-		out = append(out, lib)
-	}
-	return out, rows.Err()
-}
-
 func collectLibrariesWithCounts(rows pgx.Rows) ([]*models.Library, error) {
 	var out []*models.Library
 	for rows.Next() {

--- a/internal/service/book.go
+++ b/internal/service/book.go
@@ -105,7 +105,7 @@ func (s *BookService) CreateBook(ctx context.Context, libraryID, callerID uuid.U
 				if incrErr := s.editions.IncrementCopyCount(ctx, libraryID, existing.ID); incrErr != nil {
 					return nil, fmt.Errorf("incrementing copy count: %w", incrErr)
 				}
-				return s.books.FindByID(ctx, existing.BookID)
+				return s.books.FindByID(ctx, existing.BookID, callerID, libraryID)
 			}
 		}
 	}
@@ -169,11 +169,16 @@ func (s *BookService) CreateBook(ctx context.Context, libraryID, callerID uuid.U
 		return nil, fmt.Errorf("committing transaction: %w", err)
 	}
 
-	return s.books.FindByID(ctx, bookID)
+	return s.books.FindByID(ctx, bookID, callerID, libraryID)
 }
 
-func (s *BookService) GetBook(ctx context.Context, id uuid.UUID) (*models.Book, error) {
-	b, err := s.books.FindByID(ctx, id)
+// GetBook returns one book with caller-scoped fields hydrated. callerID
+// and libraryID are passed through to the repo so user_read_status /
+// user_rating / user_progress_pct + per-library active_loan_count match
+// what the list endpoint emits. Pass uuid.Nil for either param when the
+// caller is purely internal.
+func (s *BookService) GetBook(ctx context.Context, id uuid.UUID, callerID uuid.UUID, libraryID uuid.UUID) (*models.Book, error) {
+	b, err := s.books.FindByID(ctx, id, callerID, libraryID)
 	if err != nil {
 		return nil, err
 	}
@@ -203,7 +208,7 @@ func (s *BookService) FindBookByISBN(ctx context.Context, libraryID uuid.UUID, i
 	if err != nil {
 		return nil, err
 	}
-	return s.books.FindByID(ctx, edition.BookID)
+	return s.books.FindByID(ctx, edition.BookID, uuid.Nil, libraryID)
 }
 
 func (s *BookService) ListBooks(ctx context.Context, libraryID uuid.UUID, opts repository.ListBooksOpts) ([]*models.Book, int, error) {
@@ -255,7 +260,7 @@ func (s *BookService) UpdateBook(ctx context.Context, id uuid.UUID, req BookRequ
 		return nil, fmt.Errorf("committing transaction: %w", err)
 	}
 
-	return s.books.FindByID(ctx, id)
+	return s.books.FindByID(ctx, id, uuid.Nil, uuid.Nil)
 }
 
 // DeleteBook permanently deletes a book. Cascades through library_books,

--- a/internal/service/book.go
+++ b/internal/service/book.go
@@ -401,6 +401,9 @@ type InteractionRequest struct {
 	DateStarted  *time.Time
 	DateFinished *time.Time
 	IsFavorite   bool
+	// Progress is the {pages_read?, percent?, position?} JSON body for
+	// reading progress. Empty / nil clears the column.
+	Progress []byte
 }
 
 func (s *BookService) GetInteraction(ctx context.Context, userID, editionID uuid.UUID) (*models.UserBookInteraction, error) {
@@ -410,7 +413,7 @@ func (s *BookService) GetInteraction(ctx context.Context, userID, editionID uuid
 func (s *BookService) UpsertInteraction(ctx context.Context, userID, editionID uuid.UUID, req InteractionRequest) (*models.UserBookInteraction, error) {
 	interaction, err := s.editions.UpsertInteraction(ctx, userID, editionID,
 		req.ReadStatus, req.Rating, req.Notes, req.Review,
-		req.DateStarted, req.DateFinished, req.IsFavorite,
+		req.DateStarted, req.DateFinished, req.IsFavorite, req.Progress,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/service/edition_files.go
+++ b/internal/service/edition_files.go
@@ -178,7 +178,7 @@ func (s *EditionFileService) UploadEditionFile(ctx context.Context, edition *mod
 		return nil, validationErr("unsupported file type %q", ext)
 	}
 
-	book, err := s.bookRepo.FindByID(ctx, edition.BookID)
+	book, err := s.bookRepo.FindByID(ctx, edition.BookID, uuid.Nil, uuid.Nil)
 	if err != nil {
 		return nil, fmt.Errorf("looking up book: %w", err)
 	}

--- a/internal/service/library.go
+++ b/internal/service/library.go
@@ -129,7 +129,7 @@ func (s *LibraryService) GetLibrary(ctx context.Context, id uuid.UUID) (*models.
 
 func (s *LibraryService) ListLibraries(ctx context.Context, callerID uuid.UUID, isAdmin bool) ([]*models.Library, error) {
 	if isAdmin {
-		return s.libraries.ListAll(ctx)
+		return s.libraries.ListAll(ctx, callerID)
 	}
 	return s.libraries.ListForUser(ctx, callerID)
 }

--- a/internal/workers/import_worker.go
+++ b/internal/workers/import_worker.go
@@ -597,7 +597,7 @@ func (w *ImportWorker) applyInteraction(ctx context.Context, editionID, userID u
 		readStatusArg, ratingArg,
 		notesArg, reviewArg,
 		startedArg, finishedArg,
-		favoriteArg,
+		favoriteArg, nil, // progress not imported from CSV
 	); err != nil {
 		slog.Warn("import: merging user interaction failed",
 			"user_id", userID, "edition_id", editionID, "error", err)

--- a/internal/workers/metadata_worker.go
+++ b/internal/workers/metadata_worker.go
@@ -164,7 +164,7 @@ func (w *MetadataWorker) applyMerged(
 	force bool,
 ) error {
 	_ = callerID // reserved for audit trail; applyMerged itself doesn't use it
-	book, err := w.bookSvc.GetBook(ctx, bookID)
+	book, err := w.bookSvc.GetBook(ctx, bookID, uuid.Nil, uuid.Nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Per-library counts + caller-scoped user fields on book rows + author sort + pg_trgm "did you mean" + reading progress on PUT my-interaction.
- Drives the iOS redesign's books grid, series detail, scan flow, home stats, and search.