### PR TITLE
docs: align README and OpenAPI opener with editions positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # librarium-api
 
-The backend service for **[Librarium](https://librarium.press)** — a self-hosted, privacy-focused tracker for your physical book, manga, and comic collection. A self-hosted alternative to Libib and similar cloud catalog services.
+The backend service for **[Librarium](https://librarium.press)**, a self-hosted, privacy-focused tracker for your physical book, manga, and comic collection. A self-hosted alternative to Libib and similar cloud catalog services. iOS Lite and Librarium Plus (hosted) are on the roadmap.
 
 Go 1.25 · PostgreSQL 16 · [River](https://riverqueue.com) for background jobs · Swagger-generated OpenAPI docs.
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -3,7 +3,7 @@
 
 // @title           Librarium API
 // @version         26.4.0
-// @description     Backend API for Librarium — a self-hosted, privacy-focused tracker for your physical book, manga, and comic collection. All protected endpoints require a Bearer JWT (or `lbrm_pat_*` personal access token) in the Authorization header.
+// @description     Backend API for Librarium, a privacy-focused tracker for your physical book, manga, and comic collection. Powers the self-hosted edition today; iOS Lite and Librarium Plus (hosted) are on the roadmap. All protected endpoints require a Bearer JWT (or `lbrm_pat_*` personal access token) in the Authorization header.
 // @termsOfService  https://librarium.press
 
 // @contact.name   Librarium

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -13860,7 +13860,7 @@ var SwaggerInfo = &swag.Spec{
 	BasePath:         "/api/v1",
 	Schemes:          []string{},
 	Title:            "Librarium API",
-	Description:      "Backend API for Librarium — a self-hosted, privacy-focused tracker for your physical book, manga, and comic collection. All protected endpoints require a Bearer JWT (or `lbrm_pat_*` personal access token) in the Authorization header.",
+	Description:      "Backend API for Librarium, a privacy-focused tracker for your physical book, manga, and comic collection. Powers the self-hosted edition today; iOS Lite and Librarium Plus (hosted) are on the roadmap. All protected endpoints require a Bearer JWT (or `lbrm_pat_*` personal access token) in the Authorization header.",
 	InfoInstanceName: "swagger",
 	SwaggerTemplate:  docTemplate,
 	LeftDelim:        "{{",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1,7 +1,7 @@
 {
     "swagger": "2.0",
     "info": {
-        "description": "Backend API for Librarium — a self-hosted, privacy-focused tracker for your physical book, manga, and comic collection. All protected endpoints require a Bearer JWT (or `lbrm_pat_*` personal access token) in the Authorization header.",
+        "description": "Backend API for Librarium, a privacy-focused tracker for your physical book, manga, and comic collection. Powers the self-hosted edition today; iOS Lite and Librarium Plus (hosted) are on the roadmap. All protected endpoints require a Bearer JWT (or `lbrm_pat_*` personal access token) in the Authorization header.",
         "title": "Librarium API",
         "termsOfService": "https://librarium.press",
         "contact": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1304,8 +1304,9 @@ info:
   contact:
     name: Librarium
     url: https://librarium.press
-  description: Backend API for Librarium — a self-hosted, privacy-focused tracker
-    for your physical book, manga, and comic collection. All protected endpoints require
+  description: Backend API for Librarium, a privacy-focused tracker for your physical
+    book, manga, and comic collection. Powers the self-hosted edition today; iOS Lite
+    and Librarium Plus (hosted) are on the roadmap. All protected endpoints require
     a Bearer JWT (or `lbrm_pat_*` personal access token) in the Authorization header.
   license:
     name: AGPL-3.0


### PR DESCRIPTION
- Opener now uses a comma instead of an em-dash; OpenAPI @description mentions iOS Lite and Librarium Plus (hosted) as roadmap items.
- Swagger files regenerated via make docs.