### PR TITLE
feat(sync): add schema migrations for sync protocol

### DIFF
--- a/internal/db/migrations/000018_sync_per_field_timestamps.down.sql
+++ b/internal/db/migrations/000018_sync_per_field_timestamps.down.sql
@@ -1,0 +1,8 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Copyright (C) 2026 fireball1725
+
+ALTER TABLE user_book_interactions
+    DROP COLUMN IF EXISTS rating_updated_at,
+    DROP COLUMN IF EXISTS read_status_updated_at,
+    DROP COLUMN IF EXISTS progress_updated_at,
+    DROP COLUMN IF EXISTS is_favorite_updated_at;

--- a/internal/db/migrations/000018_sync_per_field_timestamps.up.sql
+++ b/internal/db/migrations/000018_sync_per_field_timestamps.up.sql
@@ -1,0 +1,26 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Copyright (C) 2026 fireball1725
+--
+-- Per-field timestamps for the most-contested soft fields on
+-- user_book_interactions. Lets the new sync protocol resolve concurrent
+-- offline edits with field-level last-write-wins instead of clobbering
+-- the whole row.
+--
+-- Notes and reviews intentionally don't get per-field timestamps here.
+-- They're handled via the append-only history tables in 000020.
+-- Less-contested per-user fields (date_started, date_finished,
+-- reread_count) fall back to row-level LWW via the existing updated_at.
+
+ALTER TABLE user_book_interactions
+    ADD COLUMN rating_updated_at      TIMESTAMPTZ,
+    ADD COLUMN read_status_updated_at TIMESTAMPTZ,
+    ADD COLUMN progress_updated_at    TIMESTAMPTZ,
+    ADD COLUMN is_favorite_updated_at TIMESTAMPTZ;
+
+-- Backfill from the row-level updated_at so existing data has a baseline
+-- to compare against. Future writes set these explicitly per field.
+UPDATE user_book_interactions
+   SET rating_updated_at      = updated_at,
+       read_status_updated_at = updated_at,
+       progress_updated_at    = updated_at,
+       is_favorite_updated_at = updated_at;

--- a/internal/db/migrations/000019_sync_tombstones.down.sql
+++ b/internal/db/migrations/000019_sync_tombstones.down.sql
@@ -1,0 +1,24 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Copyright (C) 2026 fireball1725
+
+DROP INDEX IF EXISTS idx_user_book_interactions_deleted_at;
+DROP INDEX IF EXISTS idx_loans_deleted_at;
+DROP INDEX IF EXISTS idx_shelves_deleted_at;
+DROP INDEX IF EXISTS idx_series_deleted_at;
+DROP INDEX IF EXISTS idx_library_books_deleted_at;
+DROP INDEX IF EXISTS idx_library_book_editions_deleted_at;
+DROP INDEX IF EXISTS idx_book_shelves_deleted_at;
+DROP INDEX IF EXISTS idx_book_tags_deleted_at;
+DROP INDEX IF EXISTS idx_library_memberships_deleted_at;
+DROP INDEX IF EXISTS idx_tags_deleted_at;
+
+ALTER TABLE user_book_interactions DROP COLUMN IF EXISTS deleted_at;
+ALTER TABLE loans                  DROP COLUMN IF EXISTS deleted_at;
+ALTER TABLE shelves                DROP COLUMN IF EXISTS deleted_at;
+ALTER TABLE series                 DROP COLUMN IF EXISTS deleted_at;
+ALTER TABLE library_books          DROP COLUMN IF EXISTS deleted_at;
+ALTER TABLE library_book_editions  DROP COLUMN IF EXISTS deleted_at;
+ALTER TABLE book_shelves           DROP COLUMN IF EXISTS deleted_at;
+ALTER TABLE book_tags              DROP COLUMN IF EXISTS deleted_at;
+ALTER TABLE library_memberships    DROP COLUMN IF EXISTS deleted_at;
+ALTER TABLE tags                   DROP COLUMN IF EXISTS deleted_at;

--- a/internal/db/migrations/000019_sync_tombstones.up.sql
+++ b/internal/db/migrations/000019_sync_tombstones.up.sql
@@ -1,0 +1,38 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Copyright (C) 2026 fireball1725
+--
+-- Tombstones for the sync protocol. Adds a deleted_at column to every
+-- table whose row deletions need to propagate to offline clients via the
+-- sync delta endpoint. Rows with deleted_at set are soft-deleted; reads
+-- should filter WHERE deleted_at IS NULL.
+--
+-- A nightly GC will hard-delete tombstones once every active client has
+-- synced past their deleted_at (see plans/sync-protocol.md).
+--
+-- Existing queries continue to work unchanged at this point. Adopting
+-- the filter happens alongside the sync endpoints in a follow-up.
+
+ALTER TABLE user_book_interactions ADD COLUMN deleted_at TIMESTAMPTZ;
+ALTER TABLE loans                  ADD COLUMN deleted_at TIMESTAMPTZ;
+ALTER TABLE shelves                ADD COLUMN deleted_at TIMESTAMPTZ;
+ALTER TABLE series                 ADD COLUMN deleted_at TIMESTAMPTZ;
+ALTER TABLE library_books          ADD COLUMN deleted_at TIMESTAMPTZ;
+ALTER TABLE library_book_editions  ADD COLUMN deleted_at TIMESTAMPTZ;
+ALTER TABLE book_shelves           ADD COLUMN deleted_at TIMESTAMPTZ;
+ALTER TABLE book_tags              ADD COLUMN deleted_at TIMESTAMPTZ;
+ALTER TABLE library_memberships    ADD COLUMN deleted_at TIMESTAMPTZ;
+ALTER TABLE tags                   ADD COLUMN deleted_at TIMESTAMPTZ;
+
+-- Partial indexes on deleted_at IS NOT NULL keep the sync delta query
+-- ("give me everything deleted since T") fast without bloating the
+-- index. Most rows are never deleted, so the partial index stays small.
+CREATE INDEX idx_user_book_interactions_deleted_at ON user_book_interactions(deleted_at) WHERE deleted_at IS NOT NULL;
+CREATE INDEX idx_loans_deleted_at                  ON loans(deleted_at)                  WHERE deleted_at IS NOT NULL;
+CREATE INDEX idx_shelves_deleted_at                ON shelves(deleted_at)                WHERE deleted_at IS NOT NULL;
+CREATE INDEX idx_series_deleted_at                 ON series(deleted_at)                 WHERE deleted_at IS NOT NULL;
+CREATE INDEX idx_library_books_deleted_at          ON library_books(deleted_at)          WHERE deleted_at IS NOT NULL;
+CREATE INDEX idx_library_book_editions_deleted_at  ON library_book_editions(deleted_at)  WHERE deleted_at IS NOT NULL;
+CREATE INDEX idx_book_shelves_deleted_at           ON book_shelves(deleted_at)           WHERE deleted_at IS NOT NULL;
+CREATE INDEX idx_book_tags_deleted_at              ON book_tags(deleted_at)              WHERE deleted_at IS NOT NULL;
+CREATE INDEX idx_library_memberships_deleted_at    ON library_memberships(deleted_at)    WHERE deleted_at IS NOT NULL;
+CREATE INDEX idx_tags_deleted_at                   ON tags(deleted_at)                   WHERE deleted_at IS NOT NULL;

--- a/internal/db/migrations/000020_sync_free_text_history.down.sql
+++ b/internal/db/migrations/000020_sync_free_text_history.down.sql
@@ -1,0 +1,8 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Copyright (C) 2026 fireball1725
+
+DROP INDEX IF EXISTS idx_ubi_notes_history_interaction;
+DROP INDEX IF EXISTS idx_ubi_review_history_interaction;
+
+DROP TABLE IF EXISTS user_book_interaction_notes_history;
+DROP TABLE IF EXISTS user_book_interaction_review_history;

--- a/internal/db/migrations/000020_sync_free_text_history.up.sql
+++ b/internal/db/migrations/000020_sync_free_text_history.up.sql
@@ -1,0 +1,51 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Copyright (C) 2026 fireball1725
+--
+-- Append-only history for the free-text fields on user_book_interactions
+-- (notes and review). Two offline devices that edit the same note never
+-- silently lose either version: both end up in the history, and the
+-- client surfaces a "conflicting versions" affordance the user can
+-- resolve at their leisure.
+--
+-- The parent row's `notes` / `review` columns continue to hold the
+-- current canonical content for fast reads. The history table is the
+-- audit log + the source the conflict-review UI reads from.
+--
+-- Backfill: for every interaction with a non-empty notes or review
+-- field, insert an initial history row stamped with the row's
+-- updated_at. That way the sync delta from time T returns the existing
+-- text as a normal history op without needing special-case logic.
+
+CREATE TABLE user_book_interaction_notes_history (
+    id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    interaction_id  UUID        NOT NULL REFERENCES user_book_interactions(id) ON DELETE CASCADE,
+    content         TEXT        NOT NULL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    client_id       UUID
+);
+
+CREATE INDEX idx_ubi_notes_history_interaction
+    ON user_book_interaction_notes_history(interaction_id, created_at DESC);
+
+CREATE TABLE user_book_interaction_review_history (
+    id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    interaction_id  UUID        NOT NULL REFERENCES user_book_interactions(id) ON DELETE CASCADE,
+    content         TEXT        NOT NULL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    client_id       UUID
+);
+
+CREATE INDEX idx_ubi_review_history_interaction
+    ON user_book_interaction_review_history(interaction_id, created_at DESC);
+
+-- Backfill existing notes content as the initial history entry.
+INSERT INTO user_book_interaction_notes_history (interaction_id, content, created_at)
+    SELECT id, notes, updated_at
+      FROM user_book_interactions
+     WHERE notes IS NOT NULL AND notes <> '';
+
+-- Backfill existing review content as the initial history entry.
+INSERT INTO user_book_interaction_review_history (interaction_id, content, created_at)
+    SELECT id, review, updated_at
+      FROM user_book_interactions
+     WHERE review IS NOT NULL AND review <> '';

--- a/internal/db/migrations/000021_sync_clients.down.sql
+++ b/internal/db/migrations/000021_sync_clients.down.sql
@@ -1,0 +1,7 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Copyright (C) 2026 fireball1725
+
+DROP INDEX IF EXISTS idx_sync_clients_user_id;
+DROP INDEX IF EXISTS idx_sync_clients_last_seen_at;
+
+DROP TABLE IF EXISTS sync_clients;

--- a/internal/db/migrations/000021_sync_clients.up.sql
+++ b/internal/db/migrations/000021_sync_clients.up.sql
@@ -1,0 +1,29 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Copyright (C) 2026 fireball1725
+--
+-- Tracks the devices a user has synced from. Used for two things:
+--
+-- 1. Tombstone GC. The safe cutoff for hard-deleting a tombstone is
+--    min(last_synced_through) across all of the user's active clients.
+--    Inactive clients (no last_seen_at within the retention window)
+--    drop out of the calculation so a forgotten device doesn't pin
+--    tombstones forever.
+--
+-- 2. Sync delta filtering. The server omits ops authored by the
+--    requesting client_id from its /sync/changes response since the
+--    client already has them in its outbox.
+--
+-- Lite users have a single client; their cutoff is just that one
+-- device's last_synced_through.
+
+CREATE TABLE sync_clients (
+    id                   UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id              UUID        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    device_name          VARCHAR(128),
+    last_seen_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_synced_through  TIMESTAMPTZ,
+    created_at           TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_sync_clients_user_id      ON sync_clients(user_id);
+CREATE INDEX idx_sync_clients_last_seen_at ON sync_clients(last_seen_at);


### PR DESCRIPTION
- Lands the four schema migrations from plans/sync-protocol.md (per-field timestamps on user_book_interactions, deleted_at tombstones on ten tables, append-only notes/review history, sync_clients).
- No application code consumes these yet; existing endpoints unchanged. Local stack migrates cleanly (version 21, dirty=false).