### PR TITLE
feat(sync): add GET /sync/changes endpoint (v1: user_book_interactions)

### DIFF
--- a/internal/api/handlers/sync.go
+++ b/internal/api/handlers/sync.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725 (Adaléa)
+
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/fireball1725/librarium-api/internal/api/middleware"
+	"github.com/fireball1725/librarium-api/internal/api/respond"
+	"github.com/fireball1725/librarium-api/internal/api/responses"
+	"github.com/fireball1725/librarium-api/internal/repository"
+)
+
+const (
+	syncDefaultLimit = 500
+	syncMaxLimit     = 1000
+)
+
+type SyncHandler struct {
+	repo *repository.SyncRepo
+}
+
+func NewSyncHandler(repo *repository.SyncRepo) *SyncHandler {
+	return &SyncHandler{repo: repo}
+}
+
+// GetChanges returns the caller's data that has changed since the given timestamp.
+//
+// Query params: since (RFC3339, required), limit (1..1000, default 500).
+//
+// Response shape (responses.SyncChangesResponse): { ops, server_time, has_more }.
+// Clients advance `since` to max(updated_at) of returned ops; when has_more is
+// true, call again immediately to keep draining the queue.
+//
+// v1 scope is user_book_interactions only. Other synced tables (loans, shelves,
+// memberships, etc.) follow one at a time.
+//
+// TODO: add swag annotations. The current swag 1.16.4 hits a parser bug when
+// this handler references responses.SyncChangesResponse, which corrupts type
+// resolution for unrelated handlers (auth.go's UserResponse fails to resolve).
+// Tracked separately; the endpoint is documented inline above for now.
+func (h *SyncHandler) GetChanges(w http.ResponseWriter, r *http.Request) {
+	claims := middleware.ClaimsFromContext(r.Context())
+	if claims == nil {
+		respond.Error(w, http.StatusUnauthorized, "unauthenticated")
+		return
+	}
+
+	sinceRaw := r.URL.Query().Get("since")
+	if sinceRaw == "" {
+		respond.Error(w, http.StatusBadRequest, "since is required (RFC3339 timestamp)")
+		return
+	}
+	since, err := time.Parse(time.RFC3339Nano, sinceRaw)
+	if err != nil {
+		respond.Error(w, http.StatusBadRequest, "since must be an RFC3339 timestamp")
+		return
+	}
+
+	limit := syncDefaultLimit
+	if raw := r.URL.Query().Get("limit"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil || n <= 0 {
+			respond.Error(w, http.StatusBadRequest, "limit must be a positive integer")
+			return
+		}
+		if n > syncMaxLimit {
+			n = syncMaxLimit
+		}
+		limit = n
+	}
+
+	// Capture server_time before the query so the client can use it as a
+	// lower bound for the next sync if no ops are returned.
+	serverTime := time.Now().UTC()
+
+	ops, err := h.repo.UserBookInteractionChanges(r.Context(), claims.UserID, since, limit)
+	if err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
+
+	// has_more is best-effort: if the query returned exactly `limit` rows, the
+	// next page may exist. The client advances `since` to the max updated_at
+	// and calls again. With per-field LWW emitting multiple ops per row, the
+	// row count is bounded but ops aren't, so this can occasionally over-report.
+	// Safe: an extra round-trip never hurts correctness.
+	hasMore := len(ops) >= limit
+
+	respond.JSON(w, http.StatusOK, responses.SyncChangesResponse{
+		Ops:        ops,
+		ServerTime: serverTime,
+		HasMore:    hasMore,
+	})
+}

--- a/internal/api/responses/sync.go
+++ b/internal/api/responses/sync.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725 (Adaléa)
+
+package responses
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// SyncChangesResponse is the wire shape for GET /sync/changes.
+//
+// Clients call /sync/changes?since=<ts> and apply each op locally.
+// On the next call, they pass since=<max(updated_at) of previously
+// applied ops>. When HasMore is true, the response was capped by the
+// limit and the client should call again immediately to keep draining.
+type SyncChangesResponse struct {
+	Ops        []SyncOp  `json:"ops"`
+	ServerTime time.Time `json:"server_time"`
+	HasMore    bool      `json:"has_more"`
+}
+
+// SyncOp is a single change emitted by the sync delta endpoint.
+//
+// Per-field LWW fields emit one op per changed field (Field set, Value
+// holds the new field value). Tombstones emit one op with Deleted=true
+// and Value=null. Field is left empty for row-level / set-membership ops
+// in tables that don't use per-field LWW.
+type SyncOp struct {
+	EntityType string      `json:"entity_type"`
+	EntityID   uuid.UUID   `json:"entity_id"`
+	Field      string      `json:"field,omitempty"`
+	Value      interface{} `json:"value,omitempty"`
+	Deleted    bool        `json:"deleted,omitempty"`
+	UpdatedAt  time.Time   `json:"updated_at"`
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -67,6 +67,7 @@ func NewRouter(ctx context.Context, db *pgxpool.Pool, cfg *config.Config, riverC
 	genreRepo := repository.NewGenreRepo(db)
 	mediaTypeRepo := repository.NewMediaTypeRepo(db)
 	importJobRepo := repository.NewImportJobRepo(db)
+	syncRepo := repository.NewSyncRepo(db)
 
 	// Book and AI provider services are built in main.go and passed in so the
 	// HTTP handlers and the worker share the same registry instances — that's
@@ -121,6 +122,7 @@ func NewRouter(ctx context.Context, db *pgxpool.Pool, cfg *config.Config, riverC
 	importHandler := handlers.NewImportHandler(importSvc, membershipRepo)
 	genreHandler := handlers.NewGenreHandler(genreRepo)
 	mediaTypeHandler := handlers.NewMediaTypeHandler(mediaTypeRepo)
+	syncHandler := handlers.NewSyncHandler(syncRepo)
 	enrichmentHandler := handlers.NewEnrichmentBatchHandler(enrichmentBatchRepo)
 	editionFileHandler := handlers.NewEditionFileHandler(editionFileSvc, bookSvc)
 	storageLocationHandler := handlers.NewStorageLocationHandler(editionFileSvc)
@@ -261,6 +263,9 @@ func NewRouter(ctx context.Context, db *pgxpool.Pool, cfg *config.Config, riverC
 	mux.Handle("PUT /api/v1/me/suggestions/{id}/status", requireAuth(http.HandlerFunc(aiSuggestionsHandler.UpdateSuggestionStatus)))
 	mux.Handle("DELETE /api/v1/me/suggestions/{id}", requireAuth(http.HandlerFunc(aiSuggestionsHandler.DeleteSuggestion)))
 	mux.Handle("POST /api/v1/me/suggestions/{id}/block", requireAuth(http.HandlerFunc(aiSuggestionsHandler.BlockSuggestion)))
+
+	// Sync (per-user delta endpoint)
+	mux.Handle("GET /api/v1/sync/changes", requireAuth(http.HandlerFunc(syncHandler.GetChanges)))
 
 	// Lookup (any authenticated user)
 	mux.Handle("GET /api/v1/lookup/isbn/{isbn}", requireAuth(http.HandlerFunc(providerHandler.LookupISBN)))

--- a/internal/repository/sync.go
+++ b/internal/repository/sync.go
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725 (Adaléa)
+
+package repository
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/fireball1725/librarium-api/internal/api/responses"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type SyncRepo struct {
+	db *pgxpool.Pool
+}
+
+func NewSyncRepo(db *pgxpool.Pool) *SyncRepo {
+	return &SyncRepo{db: db}
+}
+
+// UserBookInteractionChanges returns up to `limit` ops for the given
+// user's interactions that have a per-field updated_at, row updated_at,
+// or deleted_at strictly greater than `since`. Ordered by row updated_at
+// ascending so the client can advance its sync cursor by taking the max
+// updated_at of the returned ops.
+//
+// Per-field LWW emits one op per changed field. A tombstone (deleted_at)
+// emits a single Deleted=true op and suppresses the per-field ops for
+// that row (the row is gone; per-field state is moot).
+func (r *SyncRepo) UserBookInteractionChanges(ctx context.Context, userID uuid.UUID, since time.Time, limit int) ([]responses.SyncOp, error) {
+	const q = `
+		SELECT id,
+		       rating, rating_updated_at,
+		       read_status, read_status_updated_at,
+		       progress, progress_updated_at,
+		       is_favorite, is_favorite_updated_at,
+		       updated_at, deleted_at
+		  FROM user_book_interactions
+		 WHERE user_id = $1
+		   AND (
+		           updated_at             > $2
+		        OR rating_updated_at      > $2
+		        OR read_status_updated_at > $2
+		        OR progress_updated_at    > $2
+		        OR is_favorite_updated_at > $2
+		        OR deleted_at             > $2
+		       )
+		 ORDER BY updated_at ASC
+		 LIMIT $3`
+	rows, err := r.db.Query(ctx, q, userID, since, limit)
+	if err != nil {
+		return nil, fmt.Errorf("sync ubi changes: %w", err)
+	}
+	defer rows.Close()
+
+	var ops []responses.SyncOp
+	for rows.Next() {
+		var (
+			id             uuid.UUID
+			rating         *int16
+			ratingTS       *time.Time
+			readStatus     string
+			readStatusTS   *time.Time
+			progressRaw    []byte
+			progressTS     *time.Time
+			isFavorite     bool
+			isFavoriteTS   *time.Time
+			updatedAt      time.Time
+			deletedAt      *time.Time
+		)
+		if err := rows.Scan(
+			&id,
+			&rating, &ratingTS,
+			&readStatus, &readStatusTS,
+			&progressRaw, &progressTS,
+			&isFavorite, &isFavoriteTS,
+			&updatedAt, &deletedAt,
+		); err != nil {
+			return nil, fmt.Errorf("sync ubi scan: %w", err)
+		}
+
+		// Tombstone short-circuit: per-field state is irrelevant once
+		// the row is gone. Emit one op and move on.
+		if deletedAt != nil && deletedAt.After(since) {
+			ops = append(ops, responses.SyncOp{
+				EntityType: "user_book_interaction",
+				EntityID:   id,
+				Deleted:    true,
+				UpdatedAt:  *deletedAt,
+			})
+			continue
+		}
+
+		if ratingTS != nil && ratingTS.After(since) {
+			var v any
+			if rating != nil {
+				v = *rating
+			}
+			ops = append(ops, responses.SyncOp{
+				EntityType: "user_book_interaction",
+				EntityID:   id,
+				Field:      "rating",
+				Value:      v,
+				UpdatedAt:  *ratingTS,
+			})
+		}
+		if readStatusTS != nil && readStatusTS.After(since) {
+			ops = append(ops, responses.SyncOp{
+				EntityType: "user_book_interaction",
+				EntityID:   id,
+				Field:      "read_status",
+				Value:      readStatus,
+				UpdatedAt:  *readStatusTS,
+			})
+		}
+		if progressTS != nil && progressTS.After(since) {
+			var v any
+			if len(progressRaw) > 0 {
+				v = json.RawMessage(progressRaw)
+			}
+			ops = append(ops, responses.SyncOp{
+				EntityType: "user_book_interaction",
+				EntityID:   id,
+				Field:      "progress",
+				Value:      v,
+				UpdatedAt:  *progressTS,
+			})
+		}
+		if isFavoriteTS != nil && isFavoriteTS.After(since) {
+			ops = append(ops, responses.SyncOp{
+				EntityType: "user_book_interaction",
+				EntityID:   id,
+				Field:      "is_favorite",
+				Value:      isFavorite,
+				UpdatedAt:  *isFavoriteTS,
+			})
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("sync ubi rows: %w", err)
+	}
+	return ops, nil
+}


### PR DESCRIPTION
- New `GET /api/v1/sync/changes` returning per-field LWW + tombstone ops for the caller's user_book_interactions (rating, read_status, progress, is_favorite). v1 scope: this table only; other synced tables follow one at a time.
- Swag annotations deferred (swag 1.16.4 hits a parser bug when referencing the new responses type; tracked for follow-up). Endpoint behavior verified via curl end-to-end.