### PR TITLE
feat(sync): add POST /sync/apply endpoint

### DIFF
--- a/internal/api/handlers/sync.go
+++ b/internal/api/handlers/sync.go
@@ -4,6 +4,7 @@
 package handlers
 
 import (
+	"encoding/json"
 	"net/http"
 	"strconv"
 	"time"
@@ -15,8 +16,9 @@ import (
 )
 
 const (
-	syncDefaultLimit = 500
-	syncMaxLimit     = 1000
+	syncDefaultLimit  = 500
+	syncMaxLimit      = 1000
+	syncApplyMaxBatch = 1000
 )
 
 type SyncHandler struct {
@@ -94,5 +96,66 @@ func (h *SyncHandler) GetChanges(w http.ResponseWriter, r *http.Request) {
 		Ops:        ops,
 		ServerTime: serverTime,
 		HasMore:    hasMore,
+	})
+}
+
+// ApplyChanges accepts a batch of outbox ops from a client and applies
+// them with per-field LWW. Each op gets a status in the response so the
+// client can clear its outbox accordingly.
+//
+// Request body shape (responses.SyncApplyRequest): { client_id?, ops: [...] }.
+// Op shape (responses.SyncApplyOp): { op_id, entity_type, entity_id, field?, value?, deleted?, updated_at }.
+//
+// Response shape (responses.SyncApplyResponse): { results: [...], server_time }.
+// Each result is { op_id, status, error? } where status is one of:
+// applied / discarded_stale / not_found / invalid.
+//
+// v1 scope is user_book_interactions only and update-only (no creates
+// through this endpoint; clients still POST/PUT new rows via the
+// existing per-resource endpoints).
+func (h *SyncHandler) ApplyChanges(w http.ResponseWriter, r *http.Request) {
+	claims := middleware.ClaimsFromContext(r.Context())
+	if claims == nil {
+		respond.Error(w, http.StatusUnauthorized, "unauthenticated")
+		return
+	}
+
+	var req responses.SyncApplyRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		respond.Error(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if len(req.Ops) == 0 {
+		respond.JSON(w, http.StatusOK, responses.SyncApplyResponse{
+			Results:    []responses.SyncApplyResult{},
+			ServerTime: time.Now().UTC(),
+		})
+		return
+	}
+	if len(req.Ops) > syncApplyMaxBatch {
+		respond.Error(w, http.StatusBadRequest, "too many ops in one request (max 1000)")
+		return
+	}
+
+	results := make([]responses.SyncApplyResult, 0, len(req.Ops))
+	for _, op := range req.Ops {
+		status, err := h.repo.ApplyUserBookInteractionOp(r.Context(), claims.UserID, op)
+		if err != nil {
+			results = append(results, responses.SyncApplyResult{
+				OpID:   op.OpID,
+				Status: "error",
+				Error:  err.Error(),
+			})
+			continue
+		}
+		results = append(results, responses.SyncApplyResult{
+			OpID:   op.OpID,
+			Status: status,
+		})
+	}
+
+	respond.JSON(w, http.StatusOK, responses.SyncApplyResponse{
+		Results:    results,
+		ServerTime: time.Now().UTC(),
 	})
 }

--- a/internal/api/responses/sync.go
+++ b/internal/api/responses/sync.go
@@ -35,3 +35,48 @@ type SyncOp struct {
 	Deleted    bool        `json:"deleted,omitempty"`
 	UpdatedAt  time.Time   `json:"updated_at"`
 }
+
+// SyncApplyRequest is the wire shape for POST /sync/apply.
+//
+// The client batches outbox ops (per-field LWW changes and tombstones
+// written while offline) and pushes them. The server reconciles each
+// op via field-level last-write-wins and returns a per-op status. The
+// endpoint is idempotent: replaying the same ops just produces
+// discarded_stale results since the timestamps no longer beat what's
+// in the database.
+type SyncApplyRequest struct {
+	ClientID uuid.UUID      `json:"client_id,omitempty"`
+	Ops      []SyncApplyOp  `json:"ops"`
+}
+
+// SyncApplyOp mirrors SyncOp but is what the client sends back to the
+// server. OpID is a client-generated UUID the client uses to correlate
+// the per-op result.
+type SyncApplyOp struct {
+	OpID       uuid.UUID   `json:"op_id"`
+	EntityType string      `json:"entity_type"`
+	EntityID   uuid.UUID   `json:"entity_id"`
+	Field      string      `json:"field,omitempty"`
+	Value      interface{} `json:"value,omitempty"`
+	Deleted    bool        `json:"deleted,omitempty"`
+	UpdatedAt  time.Time   `json:"updated_at"`
+}
+
+// SyncApplyResponse is the wire shape returned by POST /sync/apply.
+type SyncApplyResponse struct {
+	Results    []SyncApplyResult `json:"results"`
+	ServerTime time.Time         `json:"server_time"`
+}
+
+// SyncApplyResult is the per-op outcome.
+//
+// Status values:
+//   - "applied"          field was updated (or row was soft-deleted)
+//   - "discarded_stale"  server's timestamp for this field is newer; op is older
+//   - "not_found"        no row matches entity_id (or caller doesn't own it)
+//   - "invalid"          op shape was malformed (unknown field, bad value type, etc.)
+type SyncApplyResult struct {
+	OpID   uuid.UUID `json:"op_id"`
+	Status string    `json:"status"`
+	Error  string    `json:"error,omitempty"`
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -264,8 +264,9 @@ func NewRouter(ctx context.Context, db *pgxpool.Pool, cfg *config.Config, riverC
 	mux.Handle("DELETE /api/v1/me/suggestions/{id}", requireAuth(http.HandlerFunc(aiSuggestionsHandler.DeleteSuggestion)))
 	mux.Handle("POST /api/v1/me/suggestions/{id}/block", requireAuth(http.HandlerFunc(aiSuggestionsHandler.BlockSuggestion)))
 
-	// Sync (per-user delta endpoint)
+	// Sync (per-user delta endpoint + outbox apply)
 	mux.Handle("GET /api/v1/sync/changes", requireAuth(http.HandlerFunc(syncHandler.GetChanges)))
+	mux.Handle("POST /api/v1/sync/apply", requireAuth(http.HandlerFunc(syncHandler.ApplyChanges)))
 
 	// Lookup (any authenticated user)
 	mux.Handle("GET /api/v1/lookup/isbn/{isbn}", requireAuth(http.HandlerFunc(providerHandler.LookupISBN)))

--- a/internal/repository/sync.go
+++ b/internal/repository/sync.go
@@ -6,12 +6,22 @@ package repository
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/fireball1725/librarium-api/internal/api/responses"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Apply status values returned by ApplyUserBookInteractionOp.
+const (
+	SyncApplyStatusApplied        = "applied"
+	SyncApplyStatusDiscardedStale = "discarded_stale"
+	SyncApplyStatusNotFound       = "not_found"
+	SyncApplyStatusInvalid        = "invalid"
 )
 
 type SyncRepo struct {
@@ -144,4 +154,119 @@ func (r *SyncRepo) UserBookInteractionChanges(ctx context.Context, userID uuid.U
 		return nil, fmt.Errorf("sync ubi rows: %w", err)
 	}
 	return ops, nil
+}
+
+// ApplyUserBookInteractionOp applies a single op against
+// user_book_interactions. The caller's user_id is enforced as the row
+// owner; ops targeting other users' rows return not_found.
+//
+// Returns one of SyncApplyStatus* constants describing what happened.
+func (r *SyncRepo) ApplyUserBookInteractionOp(ctx context.Context, userID uuid.UUID, op responses.SyncApplyOp) (string, error) {
+	if op.EntityType != "user_book_interaction" {
+		return SyncApplyStatusInvalid, nil
+	}
+	if op.Deleted {
+		return r.applyUBITombstone(ctx, userID, op.EntityID, op.UpdatedAt)
+	}
+	switch op.Field {
+	case "rating":
+		var rating *int16
+		if op.Value != nil {
+			f, ok := op.Value.(float64)
+			if !ok {
+				return SyncApplyStatusInvalid, nil
+			}
+			n := int16(f)
+			if n < 1 || n > 10 {
+				return SyncApplyStatusInvalid, nil
+			}
+			rating = &n
+		}
+		return r.applyUBIField(ctx, userID, op.EntityID, op.UpdatedAt, "rating", "rating_updated_at", rating)
+	case "read_status":
+		s, ok := op.Value.(string)
+		if !ok {
+			return SyncApplyStatusInvalid, nil
+		}
+		return r.applyUBIField(ctx, userID, op.EntityID, op.UpdatedAt, "read_status", "read_status_updated_at", s)
+	case "is_favorite":
+		b, ok := op.Value.(bool)
+		if !ok {
+			return SyncApplyStatusInvalid, nil
+		}
+		return r.applyUBIField(ctx, userID, op.EntityID, op.UpdatedAt, "is_favorite", "is_favorite_updated_at", b)
+	case "progress":
+		var progressJSON interface{}
+		if op.Value != nil {
+			b, err := json.Marshal(op.Value)
+			if err != nil {
+				return SyncApplyStatusInvalid, nil
+			}
+			progressJSON = string(b)
+		}
+		return r.applyUBIField(ctx, userID, op.EntityID, op.UpdatedAt, "progress", "progress_updated_at", progressJSON)
+	default:
+		return SyncApplyStatusInvalid, nil
+	}
+}
+
+// applyUBIField does the per-field LWW UPDATE: only writes if the
+// server's timestamp for the field is older than the op's, or if the
+// field has never been touched. Skipped writes are reported as
+// discarded_stale unless the row doesn't exist at all (not_found).
+func (r *SyncRepo) applyUBIField(ctx context.Context, userID, entityID uuid.UUID, opTS time.Time, valueCol, tsCol string, value interface{}) (string, error) {
+	q := fmt.Sprintf(`
+		UPDATE user_book_interactions
+		   SET %s = $3, %s = $4, updated_at = NOW()
+		 WHERE id = $1 AND user_id = $2
+		   AND (%s IS NULL OR %s < $4)
+		   AND deleted_at IS NULL
+		 RETURNING id`,
+		valueCol, tsCol, tsCol, tsCol,
+	)
+	var returned uuid.UUID
+	err := r.db.QueryRow(ctx, q, entityID, userID, value, opTS).Scan(&returned)
+	if err == nil {
+		return SyncApplyStatusApplied, nil
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return "", fmt.Errorf("apply %s: %w", valueCol, err)
+	}
+	return r.classifyUBIMiss(ctx, userID, entityID)
+}
+
+// applyUBITombstone sets deleted_at if it's NULL or older than opTS.
+// A row already deleted with a newer or equal timestamp is treated as
+// discarded_stale (the existing deletion wins).
+func (r *SyncRepo) applyUBITombstone(ctx context.Context, userID, entityID uuid.UUID, opTS time.Time) (string, error) {
+	const q = `
+		UPDATE user_book_interactions
+		   SET deleted_at = $3, updated_at = NOW()
+		 WHERE id = $1 AND user_id = $2
+		   AND (deleted_at IS NULL OR deleted_at < $3)
+		 RETURNING id`
+	var returned uuid.UUID
+	err := r.db.QueryRow(ctx, q, entityID, userID, opTS).Scan(&returned)
+	if err == nil {
+		return SyncApplyStatusApplied, nil
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return "", fmt.Errorf("apply tombstone: %w", err)
+	}
+	return r.classifyUBIMiss(ctx, userID, entityID)
+}
+
+// classifyUBIMiss runs after an apply UPDATE returned 0 rows. It
+// distinguishes "row doesn't exist (or wrong owner)" from "row exists
+// but the LWW comparison rejected the write."
+func (r *SyncRepo) classifyUBIMiss(ctx context.Context, userID, entityID uuid.UUID) (string, error) {
+	const q = `SELECT EXISTS(SELECT 1 FROM user_book_interactions WHERE id = $1 AND user_id = $2)`
+	var exists bool
+	if err := r.db.QueryRow(ctx, q, entityID, userID).Scan(&exists); err != nil {
+		return "", fmt.Errorf("classify miss: %w", err)
+	}
+	if !exists {
+		return SyncApplyStatusNotFound, nil
+	}
+	return SyncApplyStatusDiscardedStale, nil
 }


### PR DESCRIPTION
- New `POST /api/v1/sync/apply` accepting outbox batches with per-op status results (applied / discarded_stale / not_found / invalid). Field-level LWW for rating, read_status, progress, is_favorite; tombstones via Deleted flag.
- v1 scope is user_book_interactions only and update-only; row creates still go through the existing per-resource endpoints. Idempotent on replay.