### PR TITLE
fix(search): prevent non-ASCII queries from matching all books

### DIFF
--- a/internal/api/handlers/books.go
+++ b/internal/api/handlers/books.go
@@ -27,10 +27,10 @@ import (
 
 type BookHandler struct {
 	svc               *service.BookService
-	books             *repository.BookRepo             // used for TitlesByIDs at batch creation
-	loans             *repository.LoanRepo             // active loans on GetBook responses
-	riverClient       *river.Client[pgx.Tx]            // may be nil; used for enrichment batch jobs
-	enrichmentBatches *repository.EnrichmentBatchRepo  // may be nil; required for bulk enrich/cover
+	books             *repository.BookRepo            // used for TitlesByIDs at batch creation
+	loans             *repository.LoanRepo            // active loans on GetBook responses
+	riverClient       *river.Client[pgx.Tx]           // may be nil; used for enrichment batch jobs
+	enrichmentBatches *repository.EnrichmentBatchRepo // may be nil; required for bulk enrich/cover
 	editionFiles      *service.EditionFileService
 }
 
@@ -208,6 +208,7 @@ func (h *BookHandler) ListBooks(w http.ResponseWriter, r *http.Request) {
 	}
 
 	q := r.URL.Query().Get("q")
+	rawSearchQuery := q
 	if len(q) > 500 {
 		respond.Error(w, http.StatusBadRequest, "query too long")
 		return
@@ -305,8 +306,8 @@ func (h *BookHandler) ListBooks(w http.ResponseWriter, r *http.Request) {
 	// "Did you mean…" — when the literal query found nothing, run a
 	// pg_trgm similarity match and include up to 5 suggestions. Skipped
 	// when q is empty (pure browse) or when results came back.
-	if total == 0 && q != "" {
-		if suggestions, err := h.books.SearchSuggestions(r.Context(), libraryID, q); err == nil && len(suggestions) > 0 {
+	if total == 0 && rawSearchQuery != "" {
+		if suggestions, err := h.books.SearchSuggestions(r.Context(), libraryID, rawSearchQuery); err == nil && len(suggestions) > 0 {
 			resp["suggestions"] = suggestions
 		}
 	}
@@ -584,10 +585,10 @@ func (h *BookHandler) AddBookToLibrary(w http.ResponseWriter, r *http.Request) {
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 type bookRequestBody struct {
-	Title       string `json:"title"`
-	Subtitle    string `json:"subtitle"`
-	MediaTypeID string `json:"media_type_id"`
-	Description string `json:"description"`
+	Title        string `json:"title"`
+	Subtitle     string `json:"subtitle"`
+	MediaTypeID  string `json:"media_type_id"`
+	Description  string `json:"description"`
 	Contributors []struct {
 		ContributorID string `json:"contributor_id"`
 		Role          string `json:"role"`
@@ -678,29 +679,29 @@ func bookBody(b *models.Book) map[string]any {
 		primaryLibraryID = b.Libraries[0].ID
 	}
 	return map[string]any{
-		"id":               b.ID,
-		"library_id":       primaryLibraryID,
-		"libraries":        b.Libraries,
-		"title":            b.Title,
-		"subtitle":         b.Subtitle,
-		"media_type_id":    b.MediaTypeID,
-		"media_type":       b.MediaType,
-		"description":      b.Description,
-		"contributors":     b.Contributors,
-		"tags":             b.Tags,
-		"genres":           b.Genres,
-		"cover_url":        coverURL,
-		"created_at":       b.CreatedAt,
-		"updated_at":       b.UpdatedAt,
-		"series":           b.Series,
-		"shelves":          b.Shelves,
-		"publisher":        b.Publisher,
-		"publish_year":     b.PublishYear,
-		"language":         b.Language,
-		"user_read_status":   b.UserReadStatus,
-		"user_rating":        b.UserRating,
-		"user_progress_pct":  b.UserProgressPct,
-		"active_loan_count":  b.ActiveLoanCount,
+		"id":                b.ID,
+		"library_id":        primaryLibraryID,
+		"libraries":         b.Libraries,
+		"title":             b.Title,
+		"subtitle":          b.Subtitle,
+		"media_type_id":     b.MediaTypeID,
+		"media_type":        b.MediaType,
+		"description":       b.Description,
+		"contributors":      b.Contributors,
+		"tags":              b.Tags,
+		"genres":            b.Genres,
+		"cover_url":         coverURL,
+		"created_at":        b.CreatedAt,
+		"updated_at":        b.UpdatedAt,
+		"series":            b.Series,
+		"shelves":           b.Shelves,
+		"publisher":         b.Publisher,
+		"publish_year":      b.PublishYear,
+		"language":          b.Language,
+		"user_read_status":  b.UserReadStatus,
+		"user_rating":       b.UserRating,
+		"user_progress_pct": b.UserProgressPct,
+		"active_loan_count": b.ActiveLoanCount,
 	}
 }
 

--- a/internal/repository/book_search_sql.go
+++ b/internal/repository/book_search_sql.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725 (Adaléa)
+
+package repository
+
+import "fmt"
+
+const (
+	asciiNormNoSpace = `[^a-z0-9]`
+	asciiNormSpace   = `[^a-z0-9 ]`
+)
+
+// titleContainsSQL matches title via ILIKE and, when the term retains Latin/
+// numeric characters after ASCII normalisation, a punctuation-insensitive
+// fallback (e.g. "spiderman" matches "Spider-Man"). The fallback is skipped
+// when normalisation yields an empty string so Cyrillic/CJK queries do not
+// degenerate to ILIKE '%%' and match every row.
+func titleContainsSQL(argIdx int, normPattern string) string {
+	return fmt.Sprintf(
+		`(b.title ILIKE '%%' || $%[1]d || '%%' `+
+			`OR (`+
+			`regexp_replace(lower($%[2]d), '%[3]s', '', 'g') <> '' `+
+			`AND regexp_replace(lower(b.title), '%[3]s', '', 'g') `+
+			`ILIKE '%%' || regexp_replace(lower($%[2]d), '%[3]s', '', 'g') || '%%'`+
+			`) `+
+			`OR EXISTS (`+
+			`SELECT 1 FROM book_contributors bc_q `+
+			`JOIN contributors c_q ON c_q.id = bc_q.contributor_id `+
+			`WHERE bc_q.book_id = b.id AND c_q.name ILIKE '%%' || $%[4]d || '%%'`+
+			`))`,
+		argIdx,
+		argIdx+1,
+		normPattern,
+		argIdx+2,
+	)
+}
+
+// titlePhraseSQL matches an exact substring in title or contributor name.
+func titlePhraseSQL(argIdx int) string {
+	return fmt.Sprintf(
+		`(b.title ILIKE '%%' || $%[1]d || '%%' `+
+			`OR EXISTS (`+
+			`SELECT 1 FROM book_contributors bc_q `+
+			`JOIN contributors c_q ON c_q.id = bc_q.contributor_id `+
+			`WHERE bc_q.book_id = b.id AND c_q.name ILIKE '%%' || $%[2]d || '%%'`+
+			`))`,
+		argIdx,
+		argIdx+1,
+	)
+}

--- a/internal/repository/book_search_sql_test.go
+++ b/internal/repository/book_search_sql_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725 (Adaléa)
+
+package repository
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTitleContainsSQLGuardsEmptyNormalisation(t *testing.T) {
+	sql := titleContainsSQL(2, asciiNormSpace)
+	if !strings.Contains(sql, "<> ''") {
+		t.Fatalf("expected empty-normalisation guard, got: %s", sql)
+	}
+	if !strings.Contains(sql, asciiNormSpace) {
+		t.Fatalf("expected norm pattern %q in SQL", asciiNormSpace)
+	}
+}
+
+func TestTitleContainsSQLUsesConsecutiveArguments(t *testing.T) {
+	sql := titleContainsSQL(2, asciiNormSpace)
+
+	for _, expected := range []string{"$2", "$3", "$4"} {
+		if !strings.Contains(sql, expected) {
+			t.Errorf("expected SQL to contain %s, got: %s", expected, sql)
+		}
+	}
+}
+
+func TestTitleContainsSQLGuardsNonAsciiQuery(t *testing.T) {
+	sql := titleContainsSQL(1, asciiNormSpace)
+
+	if !strings.Contains(sql, "regexp_replace(lower($2)") {
+		t.Fatalf("expected normalised fallback to use second argument, got: %s", sql)
+	}
+	if !strings.Contains(sql, "|| $3 ||") {
+		t.Fatalf("expected contributor search to use third argument, got: %s", sql)
+	}
+}
+
+func TestTitlePhraseSQLSkipsAsciiFallback(t *testing.T) {
+	sql := titlePhraseSQL(3)
+	if strings.Contains(sql, "regexp_replace") {
+		t.Fatalf("phrase match should not use regexp fallback: %s", sql)
+	}
+}
+
+func TestTitlePhraseSQLUsesConsecutiveArguments(t *testing.T) {
+	sql := titlePhraseSQL(3)
+
+	for _, expected := range []string{"$3", "$4"} {
+		if !strings.Contains(sql, expected) {
+			t.Errorf("expected SQL to contain %s, got: %s", expected, sql)
+		}
+	}
+}

--- a/internal/repository/books.go
+++ b/internal/repository/books.go
@@ -365,8 +365,8 @@ func (r *BookRepo) ListByContributor(ctx context.Context, libraryID, contributor
 // BookFingerprint summarizes the books collection in a library. Clients
 // compare this to a stored fingerprint to decide whether to resync.
 type BookFingerprint struct {
-	Total         int     `json:"total"`
-	MaxUpdatedAt  *string `json:"max_updated_at"` // RFC3339; nil when library is empty
+	Total        int     `json:"total"`
+	MaxUpdatedAt *string `json:"max_updated_at"` // RFC3339; nil when library is empty
 }
 
 // Fingerprint returns the total book count and the most recent updated_at
@@ -425,7 +425,7 @@ type FilterCondition struct {
 // ConditionGroup is a set of conditions with their own join mode.
 // Multiple groups in a query are always ANDed together at the top level.
 type ConditionGroup struct {
-	Mode       string            `json:"mode"`       // "AND" | "OR"
+	Mode       string            `json:"mode"` // "AND" | "OR"
 	Conditions []FilterCondition `json:"conditions"`
 }
 
@@ -433,12 +433,12 @@ type ListBooksOpts struct {
 	Query      string
 	Page       int
 	PerPage    int
-	Sort       string // "title" | "created_at" | "media_type"; default "title"
-	SortDir    string // "asc" | "desc"; default "asc"
-	Letter     string // single char: 'a'-'z' matches LIKE 'letter%'
-	TagFilter  string // filter to books that have a tag with this exact name (case-insensitive)
-	TypeFilter string // filter by media type display name (case-insensitive), e.g. "Novel"
-	IsRegex    bool   // if true, use b.title ~* $query instead of ILIKE
+	Sort       string           // "title" | "created_at" | "media_type"; default "title"
+	SortDir    string           // "asc" | "desc"; default "asc"
+	Letter     string           // single char: 'a'-'z' matches LIKE 'letter%'
+	TagFilter  string           // filter to books that have a tag with this exact name (case-insensitive)
+	TypeFilter string           // filter by media type display name (case-insensitive), e.g. "Novel"
+	IsRegex    bool             // if true, use b.title ~* $query instead of ILIKE
 	Groups     []ConditionGroup // from query language parser; groups are ANDed together
 	CallerID   uuid.UUID        // when non-zero, includes user_read_status for this user
 }
@@ -493,12 +493,7 @@ func (r *BookRepo) List(ctx context.Context, libraryID uuid.UUID, opts ListBooks
 			args = append(args, opts.Query)
 			argIdx++
 		} else {
-			conditions = append(conditions, fmt.Sprintf(
-				"(b.title ILIKE '%%' || $%d || '%%' "+
-					"OR regexp_replace(lower(b.title), '[^a-z0-9]', '', 'g') LIKE '%%' || regexp_replace(lower($%d), '[^a-z0-9]', '', 'g') || '%%' "+
-					"OR EXISTS (SELECT 1 FROM book_contributors bc_q JOIN contributors c_q ON c_q.id = bc_q.contributor_id WHERE bc_q.book_id = b.id AND c_q.name ILIKE '%%' || $%d || '%%'))",
-				argIdx, argIdx+1, argIdx+2,
-			))
+			conditions = append(conditions, titleContainsSQL(argIdx, asciiNormNoSpace))
 			args = append(args, opts.Query, opts.Query, opts.Query)
 			argIdx += 3
 		}
@@ -547,15 +542,14 @@ func (r *BookRepo) List(ctx context.Context, libraryID uuid.UUID, opts ListBooks
 			switch cond.Field {
 			case "title":
 				switch cond.Op {
-				case "contains", "phrase":
-					parts = append(parts, fmt.Sprintf(
-						"(b.title ILIKE '%%' || $%d || '%%' "+
-							"OR regexp_replace(lower(b.title), '[^a-z0-9 ]', '', 'g') ILIKE '%%' || regexp_replace(lower($%d), '[^a-z0-9 ]', '', 'g') || '%%' "+
-							"OR EXISTS (SELECT 1 FROM book_contributors bc_q JOIN contributors c_q ON c_q.id = bc_q.contributor_id WHERE bc_q.book_id = b.id AND c_q.name ILIKE '%%' || $%d || '%%'))",
-						argIdx, argIdx+1, argIdx+2,
-					))
+				case "contains":
+					parts = append(parts, titleContainsSQL(argIdx, asciiNormSpace))
 					args = append(args, cond.Value, cond.Value, cond.Value)
 					argIdx += 3
+				case "phrase":
+					parts = append(parts, titlePhraseSQL(argIdx))
+					args = append(args, cond.Value, cond.Value)
+					argIdx += 2
 				case "not_contains":
 					parts = append(parts, fmt.Sprintf("b.title NOT ILIKE '%%' || $%d || '%%'", argIdx))
 					args = append(args, cond.Value)


### PR DESCRIPTION
## Why

Non-ASCII search queries can become empty after ASCII-only normalization.

That makes the fallback condition effectively match every book, which causes unrelated results to be returned for Cyrillic and other non-ASCII queries.

## What changed

- Preserve the original search query for suggestions
- Guard the normalized fallback against empty values
- Use separate SQL helpers for contains and phrase matching
- Avoid punctuation-insensitive fallback for phrase searches
- Add tests for placeholder ordering and non-ASCII queries

## Testing

- `go test ./...`
- `go vet ./...`
- Built the API Docker image locally
- Deployed the image to a self-hosted Librarium installation
- Verified Cyrillic and non-ASCII searches against real data