### PR TITLE
feat(providers): let metadata providers declare structured config fields

### DIFF
--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -20,6 +20,20 @@ const (
 	CapContributor   = "contributor"
 )
 
+// ConfigField describes a single config input the admin settings page should
+// render for a provider. Mirrors internal/ai.ConfigField (kept as a separate
+// type rather than a shared import so the two provider plugin systems stay
+// independent) — needed for providers whose config is more than a single API
+// key, e.g. a self-hosted mirror that only needs a base URL.
+type ConfigField struct {
+	Key         string `json:"key"`
+	Label       string `json:"label"`
+	Type        string `json:"type"` // "password" | "text" | "url"
+	Required    bool   `json:"required"`
+	Placeholder string `json:"placeholder,omitempty"`
+	HelpText    string `json:"help_text,omitempty"`
+}
+
 // ProviderInfo describes a provider's static metadata.
 type ProviderInfo struct {
 	Name         string
@@ -31,6 +45,11 @@ type ProviderInfo struct {
 	HelpText string
 	// HelpURL links to the page where users can obtain the API key.
 	HelpURL string
+	// ConfigFields declares the config inputs the settings page should render.
+	// Optional — a provider that only needs the legacy single API key can
+	// leave this nil and rely on RequiresKey; the settings page falls back
+	// to the existing single-API-key form in that case.
+	ConfigFields []ConfigField
 }
 
 // BookResult is a normalised book record returned by a BookISBNProvider.

--- a/internal/service/providers.go
+++ b/internal/service/providers.go
@@ -61,18 +61,45 @@ func (s *ProviderService) GetAllProviderStatus(ctx context.Context) ([]ProviderS
 			Capabilities: info.Capabilities,
 			HelpText:     info.HelpText,
 			HelpURL:      info.HelpURL,
+			ConfigFields: info.ConfigFields,
 			Enabled:      p.Enabled(),
 		}
-
-		// Mask API key but indicate whether one is set
-		if key, ok := cfg["api_key"]; ok && key != "" {
-			status.Config = map[string]string{"api_key": "***"}
-			status.HasAPIKey = true
-		}
+		status.Config, status.HasAPIKey = maskProviderConfig(info, cfg)
 
 		out = append(out, status)
 	}
 	return out, nil
+}
+
+// maskProviderConfig builds the display-safe config map for a provider's
+// current settings. When the provider declares ConfigFields, every
+// "password"-type field present in cfg is masked and every other field
+// (e.g. a mirror's base_url) passes through in the clear; hasAPIKey is true
+// if any password field is set. Providers with no ConfigFields fall back to
+// the legacy single api_key convention, unchanged from before ConfigFields
+// existed.
+func maskProviderConfig(info providers.ProviderInfo, cfg map[string]string) (config map[string]string, hasAPIKey bool) {
+	if len(info.ConfigFields) > 0 {
+		masked := make(map[string]string, len(info.ConfigFields))
+		for _, field := range info.ConfigFields {
+			val, ok := cfg[field.Key]
+			if !ok || val == "" {
+				continue
+			}
+			if field.Type == "password" {
+				masked[field.Key] = "***"
+				hasAPIKey = true
+			} else {
+				masked[field.Key] = val
+			}
+		}
+		return masked, hasAPIKey
+	}
+
+	if key, ok := cfg["api_key"]; ok && key != "" {
+		return map[string]string{"api_key": "***"}, true
+	}
+	return nil, false
 }
 
 // ConfigureProvider saves config to the DB and reconfigures the live provider.
@@ -383,14 +410,15 @@ func (s *ProviderService) loadConfig(ctx context.Context, name string) (map[stri
 // ─── DTO ──────────────────────────────────────────────────────────────────────
 
 type ProviderStatus struct {
-	Name         string            `json:"name"`
-	DisplayName  string            `json:"display_name"`
-	Description  string            `json:"description"`
-	RequiresKey  bool              `json:"requires_key"`
-	Capabilities []string          `json:"capabilities"`
-	HelpText     string            `json:"help_text,omitempty"`
-	HelpURL      string            `json:"help_url,omitempty"`
-	Enabled      bool              `json:"enabled"`
-	HasAPIKey    bool              `json:"has_api_key"`
-	Config       map[string]string `json:"config,omitempty"`
+	Name         string                  `json:"name"`
+	DisplayName  string                  `json:"display_name"`
+	Description  string                  `json:"description"`
+	RequiresKey  bool                    `json:"requires_key"`
+	Capabilities []string                `json:"capabilities"`
+	HelpText     string                  `json:"help_text,omitempty"`
+	HelpURL      string                  `json:"help_url,omitempty"`
+	Enabled      bool                    `json:"enabled"`
+	HasAPIKey    bool                    `json:"has_api_key"`
+	Config       map[string]string       `json:"config,omitempty"`
+	ConfigFields []providers.ConfigField `json:"config_fields,omitempty"`
 }

--- a/internal/service/providers_test.go
+++ b/internal/service/providers_test.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725 (Adaléa)
+
+package service
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/fireball1725/librarium-api/internal/providers"
+)
+
+func TestMaskProviderConfig(t *testing.T) {
+	fieldsCfg := providers.ProviderInfo{
+		ConfigFields: []providers.ConfigField{
+			{Key: "base_url", Type: "url"},
+			{Key: "api_key", Type: "password"},
+		},
+	}
+
+	cases := []struct {
+		name    string
+		info    providers.ProviderInfo
+		cfg     map[string]string
+		wantCfg map[string]string
+		wantKey bool
+	}{
+		{
+			name:    "no config fields, no api_key set — legacy path, nothing saved",
+			info:    providers.ProviderInfo{},
+			cfg:     map[string]string{},
+			wantCfg: nil,
+			wantKey: false,
+		},
+		{
+			name:    "no config fields, api_key set — legacy path masks it",
+			info:    providers.ProviderInfo{},
+			cfg:     map[string]string{"api_key": "sk-secret"},
+			wantCfg: map[string]string{"api_key": "***"},
+			wantKey: true,
+		},
+		{
+			name:    "config fields, base_url only — passes through in the clear",
+			info:    fieldsCfg,
+			cfg:     map[string]string{"base_url": "http://isfdb-adapter:8080"},
+			wantCfg: map[string]string{"base_url": "http://isfdb-adapter:8080"},
+			wantKey: false,
+		},
+		{
+			name:    "config fields, password field set — masked, hasAPIKey true",
+			info:    fieldsCfg,
+			cfg:     map[string]string{"api_key": "sk-secret"},
+			wantCfg: map[string]string{"api_key": "***"},
+			wantKey: true,
+		},
+		{
+			name:    "config fields, both set — url clear, key masked",
+			info:    fieldsCfg,
+			cfg:     map[string]string{"base_url": "http://x:8080", "api_key": "sk-secret"},
+			wantCfg: map[string]string{"base_url": "http://x:8080", "api_key": "***"},
+			wantKey: true,
+		},
+		{
+			name:    "config fields, empty string value is treated as unset",
+			info:    fieldsCfg,
+			cfg:     map[string]string{"base_url": "", "api_key": ""},
+			wantCfg: map[string]string{},
+			wantKey: false,
+		},
+		{
+			name:    "config fields, unrelated cfg key ignored",
+			info:    fieldsCfg,
+			cfg:     map[string]string{"enabled": "true"},
+			wantCfg: map[string]string{},
+			wantKey: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotCfg, gotKey := maskProviderConfig(tc.info, tc.cfg)
+			if !reflect.DeepEqual(gotCfg, tc.wantCfg) {
+				t.Errorf("config = %#v, want %#v", gotCfg, tc.wantCfg)
+			}
+			if gotKey != tc.wantKey {
+				t.Errorf("hasAPIKey = %v, want %v", gotKey, tc.wantKey)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

AI providers already declare a `ConfigFields` list that the settings page (`AIPage.tsx`) renders generically — Ollama's `base_url`+`model`, Anthropic's `api_key`+`model`, etc. Metadata providers (`MetadataPage.tsx`) never got the same treatment: they're hardcoded to a single API-key input, gated by `RequiresKey bool`.

This adds the same mechanism to `providers.ProviderInfo` (as an independent `providers.ConfigField` type, not shared with `internal/ai` — keeping the two provider plugin systems decoupled, matching the existing architecture).

## Why

I'm working on a metadata provider for a self-hosted data source that's configured by base URL, not an API key (companion frontend PR: fireball1725/librarium-web#44, provider PR: #46). There's currently no way to express that in the provider settings UI. Rather than special-case it, this generalizes the existing single-purpose mechanism to the same shape AI providers already use.

## Backward compatibility

Fully additive. A provider that leaves `ConfigFields` nil (Open Library, Google Books, Hardcover, ISBNdb, MangaDex — all untouched in this PR) keeps using the existing single-API-key path: the new `maskProviderConfig` helper falls back to the old `api_key`-only masking logic exactly as before when `ConfigFields` is empty.

## Test plan

- [x] `go build ./...`, `go vet ./...` pass
- [x] `go test ./...` passes, including new `TestMaskProviderConfig` table test covering both the legacy and generic masking paths
- [x] `gofmt -l` clean on changed files
- [x] Exercised against a real provider using the new field (see #46 — ISFDB, configured entirely via the new `base_url` field)
- [ ] `make docs` — attempted, but hit a pre-existing swag parse error (`cannot find type definition: responses.UserResponse`) that reproduces identically on a clean `main` checkout with the pinned swag v1.16.6, so it's unrelated to this change. Didn't want to hand-edit generated docs around a tool failure I couldn't reproduce a fix for — flagging in case there's a known workaround, happy to regenerate once sorted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)