### PR TITLE
feat(providers): add ISFDB metadata provider

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -132,6 +132,7 @@ func main() {
 	registry.Register(bookProviders.NewGoogleBooksProvider())
 	registry.Register(bookProviders.NewISBNdbProvider())
 	registry.Register(bookProviders.NewHardcoverProvider())
+	registry.Register(bookProviders.NewISFDBProvider())
 	registry.Register(mangaProviders.NewMangaDexProvider())
 	providerSvc := service.NewProviderService(registry, settingsRepo)
 	if err := providerSvc.LoadAll(baseCtx); err != nil {

--- a/internal/providers/books/isfdb.go
+++ b/internal/providers/books/isfdb.go
@@ -67,7 +67,15 @@ func (p *ISFDBProvider) Info() providers.ProviderInfo {
 }
 
 func (p *ISFDBProvider) Configure(cfg map[string]string) {
-	p.baseURL = strings.TrimRight(cfg["base_url"], "/")
+	raw := strings.TrimRight(cfg["base_url"], "/")
+	if u, err := url.Parse(raw); err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		// Reject anything that isn't a well-formed http(s) URL rather than
+		// concatenating it straight into fetchJSON's request — base_url is
+		// admin-supplied, and the /providers/{name}/test endpoint would
+		// otherwise let it probe any scheme/host the API server can reach.
+		raw = ""
+	}
+	p.baseURL = raw
 	if v, ok := cfg["enabled"]; ok {
 		p.enabled = v != "false" && p.baseURL != ""
 	} else {

--- a/internal/providers/books/isfdb.go
+++ b/internal/providers/books/isfdb.go
@@ -51,8 +51,8 @@ func (p *ISFDBProvider) Info() providers.ProviderInfo {
 			providers.CapSeriesVolumes,
 			providers.CapContributor,
 		},
-		HelpText: "ISFDB doesn't offer a public API. Point this at the base URL of your own ISFDB mirror adapter (MariaDB import of ISFDB's weekly backup, fronted by a small JSON API) — leave disabled if you don't run one.",
-		HelpURL:  "https://www.isfdb.org/wiki/index.php/ISFDB:Home",
+		HelpText: "ISFDB doesn't offer a public API. Point this at the base URL of your own ISFDB mirror adapter (MariaDB import of ISFDB's weekly backup, fronted by a small JSON API) — leave disabled if you don't run one. Reference implementation: github.com/ennui2342/isfdb-adapter.",
+		HelpURL:  "https://github.com/ennui2342/isfdb-adapter",
 		ConfigFields: []providers.ConfigField{
 			{
 				Key:         "base_url",

--- a/internal/providers/books/isfdb.go
+++ b/internal/providers/books/isfdb.go
@@ -1,0 +1,341 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725 (Adaléa)
+
+package books
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/fireball1725/librarium-api/internal/providers"
+)
+
+// ISFDBProvider looks up books via a self-hosted mirror of the Internet
+// Speculative Fiction Database (ISFDB). Unlike the other book providers,
+// ISFDB has no public API — the site is Cloudflare-protected and its own
+// weekly backups are only distributed as a MySQL dump on Google Drive — so
+// this provider talks to a small adapter service that fronts your own
+// mirror of that data, configured via base_url rather than an API key.
+//
+// ISFDB's real strength is depth: older, small-press, and non-US editions
+// that Open Library / Google Books / Hardcover often don't carry at all,
+// plus unusually strong series and contributor (pseudonym-aware) data.
+type ISFDBProvider struct {
+	base
+	client  *http.Client
+	baseURL string
+}
+
+func NewISFDBProvider() *ISFDBProvider {
+	return &ISFDBProvider{
+		base:   base{enabled: false}, // disabled until a base_url is configured
+		client: &http.Client{Timeout: 20 * time.Second},
+	}
+}
+
+func (p *ISFDBProvider) Info() providers.ProviderInfo {
+	return providers.ProviderInfo{
+		Name:        "isfdb",
+		DisplayName: "ISFDB",
+		Description: "Internet Speculative Fiction Database. Deep bibliographic data for SFF — especially older, small-press, and non-US editions other providers miss. Requires a self-hosted mirror (ISFDB has no public API).",
+		RequiresKey: false,
+		Capabilities: []string{
+			providers.CapBookISBN,
+			providers.CapBookSearch,
+			providers.CapSeriesName,
+			providers.CapSeriesVolumes,
+			providers.CapContributor,
+		},
+		HelpText: "ISFDB doesn't offer a public API. Point this at the base URL of your own ISFDB mirror adapter (MariaDB import of ISFDB's weekly backup, fronted by a small JSON API) — leave disabled if you don't run one.",
+		HelpURL:  "https://www.isfdb.org/wiki/index.php/ISFDB:Home",
+		ConfigFields: []providers.ConfigField{
+			{
+				Key:         "base_url",
+				Label:       "Mirror base URL",
+				Type:        "url",
+				Required:    true,
+				Placeholder: "http://isfdb-adapter:8080",
+				HelpText:    "Base URL of your self-hosted ISFDB mirror adapter.",
+			},
+		},
+	}
+}
+
+func (p *ISFDBProvider) Configure(cfg map[string]string) {
+	p.baseURL = strings.TrimRight(cfg["base_url"], "/")
+	if v, ok := cfg["enabled"]; ok {
+		p.enabled = v != "false" && p.baseURL != ""
+	} else {
+		p.enabled = p.baseURL != ""
+	}
+}
+
+// ─── wire types (adapter JSON shapes) ──────────────────────────────────────────
+
+type isfdbBook struct {
+	Title       string   `json:"title"`
+	Subtitle    string   `json:"subtitle"`
+	Authors     []string `json:"authors"`
+	Publisher   string   `json:"publisher"`
+	PublishDate string   `json:"publish_date"`
+	ISBN10      string   `json:"isbn_10"`
+	ISBN13      string   `json:"isbn_13"`
+	Description string   `json:"description"`
+	CoverURL    string   `json:"cover_url"`
+	Language    string   `json:"language"`
+	PageCount   *int     `json:"page_count"`
+	Categories  []string `json:"categories"`
+}
+
+type isfdbSeries struct {
+	Name             string   `json:"name"`
+	Description      string   `json:"description"`
+	TotalCount       *int     `json:"total_count"`
+	IsComplete       bool     `json:"is_complete"`
+	CoverURL         string   `json:"cover_url"`
+	ExternalID       string   `json:"external_id"`
+	Status           string   `json:"status"`
+	OriginalLanguage string   `json:"original_language"`
+	PublicationYear  *int     `json:"publication_year"`
+	Demographic      string   `json:"demographic"`
+	Genres           []string `json:"genres"`
+	URL              string   `json:"url"`
+}
+
+type isfdbVolume struct {
+	Position    float64 `json:"position"`
+	Title       string  `json:"title"`
+	ReleaseDate string  `json:"release_date"`
+	CoverURL    string  `json:"cover_url"`
+	ExternalID  string  `json:"external_id"`
+}
+
+type isfdbAuthorSearchResult struct {
+	ExternalID string `json:"external_id"`
+	Name       string `json:"name"`
+	Bio        string `json:"bio"`
+	PhotoURL   string `json:"photo_url"`
+}
+
+type isfdbAuthorWork struct {
+	Title       string `json:"title"`
+	ISBN13      string `json:"isbn_13"`
+	ISBN10      string `json:"isbn_10"`
+	PublishYear *int   `json:"publish_year"`
+	CoverURL    string `json:"cover_url"`
+}
+
+type isfdbAuthor struct {
+	ExternalID string            `json:"external_id"`
+	Name       string            `json:"name"`
+	Bio        string            `json:"bio"`
+	BornDate   string            `json:"born_date"`
+	DiedDate   string            `json:"died_date"`
+	PhotoURL   string            `json:"photo_url"`
+	Works      []isfdbAuthorWork `json:"works"`
+}
+
+// ─── HTTP helper ────────────────────────────────────────────────────────────────
+
+// errNotFound is returned by fetchJSON on a 404; callers translate it to a
+// nil result (not found is not an error, per the other providers' convention).
+type errNotFound struct{}
+
+func (errNotFound) Error() string { return "not found" }
+
+func (p *ISFDBProvider) fetchJSON(ctx context.Context, path string, out any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.baseURL+path, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return errNotFound{}
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("isfdb mirror: status %d for %s", resp.StatusCode, path)
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+func parseDate(s string) *time.Time {
+	if s == "" {
+		return nil
+	}
+	for _, layout := range []string{"2006-01-02", "2006-01", "2006"} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return &t
+		}
+	}
+	return nil
+}
+
+// ─── BookISBNProvider ───────────────────────────────────────────────────────────
+
+func (p *ISFDBProvider) LookupByISBN(ctx context.Context, isbn string) (*providers.BookResult, error) {
+	var book isfdbBook
+	if err := p.fetchJSON(ctx, "/isbn/"+url.PathEscape(isbn), &book); err != nil {
+		if _, ok := err.(errNotFound); ok {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return book.toBookResult(), nil
+}
+
+func (b *isfdbBook) toBookResult() *providers.BookResult {
+	return &providers.BookResult{
+		Provider:        "isfdb",
+		ProviderDisplay: "ISFDB",
+		Title:           b.Title,
+		Subtitle:        b.Subtitle,
+		Authors:         b.Authors,
+		Publisher:       b.Publisher,
+		PublishDate:     b.PublishDate,
+		ISBN10:          b.ISBN10,
+		ISBN13:          b.ISBN13,
+		Description:     b.Description,
+		CoverURL:        b.CoverURL,
+		Language:        b.Language,
+		PageCount:       b.PageCount,
+		Categories:      b.Categories,
+	}
+}
+
+// ─── BookSearchProvider ─────────────────────────────────────────────────────────
+
+func (p *ISFDBProvider) SearchBooks(ctx context.Context, query string) ([]*providers.BookResult, error) {
+	var books []isfdbBook
+	if err := p.fetchJSON(ctx, "/search?q="+url.QueryEscape(query), &books); err != nil {
+		if _, ok := err.(errNotFound); ok {
+			return nil, nil
+		}
+		return nil, err
+	}
+	out := make([]*providers.BookResult, 0, len(books))
+	for i := range books {
+		out = append(out, books[i].toBookResult())
+	}
+	return out, nil
+}
+
+// ─── SeriesSearchProvider ───────────────────────────────────────────────────────
+
+func (p *ISFDBProvider) SearchSeries(ctx context.Context, query string) ([]providers.SeriesResult, error) {
+	var series []isfdbSeries
+	if err := p.fetchJSON(ctx, "/series/search?q="+url.QueryEscape(query), &series); err != nil {
+		if _, ok := err.(errNotFound); ok {
+			return nil, nil
+		}
+		return nil, err
+	}
+	out := make([]providers.SeriesResult, 0, len(series))
+	for _, s := range series {
+		out = append(out, providers.SeriesResult{
+			Provider:         "isfdb",
+			ProviderDisplay:  "ISFDB",
+			Name:             s.Name,
+			Description:      s.Description,
+			TotalCount:       s.TotalCount,
+			IsComplete:       s.IsComplete,
+			CoverURL:         s.CoverURL,
+			ExternalID:       s.ExternalID,
+			ExternalSource:   "isfdb",
+			Status:           s.Status,
+			OriginalLanguage: s.OriginalLanguage,
+			PublicationYear:  s.PublicationYear,
+			Demographic:      s.Demographic,
+			Genres:           s.Genres,
+			URL:              s.URL,
+		})
+	}
+	return out, nil
+}
+
+// ─── SeriesVolumesProvider ──────────────────────────────────────────────────────
+
+func (p *ISFDBProvider) FetchSeriesVolumes(ctx context.Context, externalID string) ([]providers.VolumeResult, error) {
+	var volumes []isfdbVolume
+	if err := p.fetchJSON(ctx, "/series/"+url.PathEscape(externalID)+"/volumes", &volumes); err != nil {
+		if _, ok := err.(errNotFound); ok {
+			return nil, nil
+		}
+		return nil, err
+	}
+	out := make([]providers.VolumeResult, 0, len(volumes))
+	for _, v := range volumes {
+		out = append(out, providers.VolumeResult{
+			Position:    v.Position,
+			Title:       v.Title,
+			ReleaseDate: v.ReleaseDate,
+			CoverURL:    v.CoverURL,
+			ExternalID:  v.ExternalID,
+		})
+	}
+	return out, nil
+}
+
+// ─── ContributorProvider ────────────────────────────────────────────────────────
+
+func (p *ISFDBProvider) SearchContributors(ctx context.Context, name string) ([]*providers.ContributorSearchResult, error) {
+	var authors []isfdbAuthorSearchResult
+	if err := p.fetchJSON(ctx, "/authors/search?q="+url.QueryEscape(name), &authors); err != nil {
+		if _, ok := err.(errNotFound); ok {
+			return nil, nil
+		}
+		return nil, err
+	}
+	out := make([]*providers.ContributorSearchResult, 0, len(authors))
+	for _, a := range authors {
+		out = append(out, &providers.ContributorSearchResult{
+			ExternalID: a.ExternalID,
+			Name:       a.Name,
+			Bio:        a.Bio,
+			PhotoURL:   a.PhotoURL,
+		})
+	}
+	return out, nil
+}
+
+func (p *ISFDBProvider) FetchContributor(ctx context.Context, externalID string) (*providers.ContributorData, error) {
+	var author isfdbAuthor
+	if err := p.fetchJSON(ctx, "/authors/"+url.PathEscape(externalID), &author); err != nil {
+		if _, ok := err.(errNotFound); ok {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	works := make([]providers.ContributorWorkResult, 0, len(author.Works))
+	for _, w := range author.Works {
+		works = append(works, providers.ContributorWorkResult{
+			Title:       w.Title,
+			ISBN13:      w.ISBN13,
+			ISBN10:      w.ISBN10,
+			PublishYear: w.PublishYear,
+			CoverURL:    w.CoverURL,
+		})
+	}
+
+	return &providers.ContributorData{
+		Provider:    "isfdb",
+		ExternalID:  author.ExternalID,
+		Name:        author.Name,
+		Bio:         author.Bio,
+		BornDate:    parseDate(author.BornDate),
+		DiedDate:    parseDate(author.DiedDate),
+		Nationality: "", // ISFDB doesn't track this directly
+		PhotoURL:    author.PhotoURL,
+		Works:       works,
+	}, nil
+}

--- a/internal/providers/books/isfdb_test.go
+++ b/internal/providers/books/isfdb_test.go
@@ -41,6 +41,21 @@ func TestISFDBProvider_Configure(t *testing.T) {
 	}
 }
 
+func TestISFDBProvider_Configure_RejectsNonHTTPScheme(t *testing.T) {
+	for _, raw := range []string{
+		"file:///etc/passwd",
+		"gopher://internal.example/1",
+		"not a url",
+		"",
+	} {
+		p := NewISFDBProvider()
+		p.Configure(map[string]string{"base_url": raw})
+		if p.Enabled() || p.baseURL != "" {
+			t.Errorf("base_url %q: got enabled=%v baseURL=%q, want disabled with empty baseURL", raw, p.Enabled(), p.baseURL)
+		}
+	}
+}
+
 func TestISFDBProvider_LookupByISBN(t *testing.T) {
 	pages := 158
 	p := newTestISFDBProvider(t, func(w http.ResponseWriter, r *http.Request) {

--- a/internal/providers/books/isfdb_test.go
+++ b/internal/providers/books/isfdb_test.go
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725 (Adaléa)
+
+package books
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func newTestISFDBProvider(t *testing.T, handler http.HandlerFunc) *ISFDBProvider {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	p := NewISFDBProvider()
+	p.Configure(map[string]string{"base_url": srv.URL})
+	return p
+}
+
+func TestISFDBProvider_Configure(t *testing.T) {
+	p := NewISFDBProvider()
+	if p.Enabled() {
+		t.Fatal("provider should start disabled with no base_url configured")
+	}
+
+	p.Configure(map[string]string{"base_url": "http://example.invalid:8080/"})
+	if !p.Enabled() {
+		t.Fatal("provider should be enabled once base_url is set")
+	}
+	if p.baseURL != "http://example.invalid:8080" {
+		t.Errorf("baseURL = %q, want trailing slash trimmed", p.baseURL)
+	}
+
+	p.Configure(map[string]string{"base_url": "http://example.invalid:8080", "enabled": "false"})
+	if p.Enabled() {
+		t.Fatal("explicit enabled=false should disable the provider even with a base_url set")
+	}
+}
+
+func TestISFDBProvider_LookupByISBN(t *testing.T) {
+	pages := 158
+	p := newTestISFDBProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/isbn/0586028463" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(isfdbBook{
+			Title:       "Camp Concentration",
+			Authors:     []string{"Thomas M. Disch"},
+			Publisher:   "Panther",
+			PublishDate: "1973-00-00",
+			ISBN10:      "0586028463",
+			ISBN13:      "9780586028469",
+			PageCount:   &pages,
+		})
+	})
+
+	got, err := p.LookupByISBN(context.Background(), "0586028463")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil || got.Title != "Camp Concentration" || got.Provider != "isfdb" {
+		t.Errorf("got %+v, want Camp Concentration/isfdb", got)
+	}
+	if got.PageCount == nil || *got.PageCount != 158 {
+		t.Errorf("PageCount = %v, want 158", got.PageCount)
+	}
+}
+
+func TestISFDBProvider_LookupByISBN_NotFound(t *testing.T) {
+	p := newTestISFDBProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	})
+
+	got, err := p.LookupByISBN(context.Background(), "0000000000")
+	if err != nil {
+		t.Fatalf("not-found should not be an error, got: %v", err)
+	}
+	if got != nil {
+		t.Errorf("got %+v, want nil result for a 404", got)
+	}
+}
+
+func TestISFDBProvider_LookupByISBN_ServerError(t *testing.T) {
+	p := newTestISFDBProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	})
+
+	got, err := p.LookupByISBN(context.Background(), "0586028463")
+	if err == nil {
+		t.Fatal("expected an error for a 500 response, got nil")
+	}
+	if got != nil {
+		t.Errorf("got %+v, want nil result alongside the error", got)
+	}
+}
+
+func TestISFDBProvider_FetchSeriesVolumes_Ordering(t *testing.T) {
+	p := newTestISFDBProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/series/869/volumes" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode([]isfdbVolume{
+			{Position: 1, Title: "Dune", ExternalID: "2036"},
+			{Position: 2, Title: "Dune Messiah", ExternalID: "2037"},
+			{Position: 0, Title: "Dune Trilogy (omnibus)", ExternalID: "179019"},
+		})
+	})
+
+	got, err := p.FetchSeriesVolumes(context.Background(), "869")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 3 || got[0].Title != "Dune" || got[1].Title != "Dune Messiah" {
+		t.Errorf("got %+v, want Dune then Dune Messiah first (adapter is responsible for ordering)", got)
+	}
+}
+
+func TestISFDBProvider_FetchContributor_DateParsing(t *testing.T) {
+	p := newTestISFDBProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(isfdbAuthor{
+			ExternalID: "821",
+			Name:       "Thomas M. Disch",
+			BornDate:   "1940-02-02",
+			DiedDate:   "2008-07-04",
+			Works: []isfdbAuthorWork{
+				{Title: "Camp Concentration", ISBN13: "9780586028469"},
+			},
+		})
+	})
+
+	got, err := p.FetchContributor(context.Background(), "821")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("got nil, want a contributor")
+	}
+	wantBorn := time.Date(1940, 2, 2, 0, 0, 0, 0, time.UTC)
+	if got.BornDate == nil || !got.BornDate.Equal(wantBorn) {
+		t.Errorf("BornDate = %v, want %v", got.BornDate, wantBorn)
+	}
+	if len(got.Works) != 1 || got.Works[0].Title != "Camp Concentration" {
+		t.Errorf("Works = %+v, want one entry for Camp Concentration", got.Works)
+	}
+}
+
+func TestParseDate(t *testing.T) {
+	cases := []struct {
+		in      string
+		wantNil bool
+	}{
+		{"", true},
+		{"1940-02-02", false},
+		{"1978-02", false},
+		{"1978", false},
+		{"1973-00-00", true}, // ISFDB's zero-day/month placeholder — not a valid date
+		{"garbage", true},
+	}
+	for _, tc := range cases {
+		got := parseDate(tc.in)
+		if (got == nil) != tc.wantNil {
+			t.Errorf("parseDate(%q) = %v, wantNil %v", tc.in, got, tc.wantNil)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds ISFDB (Internet Speculative Fiction Database) as a metadata provider, implementing all five capability interfaces (`BookISBNProvider`, `BookSearchProvider`, `SeriesSearchProvider`, `SeriesVolumesProvider`, `ContributorProvider`).

**Depends on #45** — this branch is stacked on `feat/metadata-provider-config-fields`, since ISFDB is configured by a mirror `base_url` rather than an API key. Will rebase automatically once #45 merges.

## Why ISFDB

It has no public API (Cloudflare-protected site, backups only distributed as a weekly MySQL dump on Google Drive), but its bibliographic depth is genuinely unmatched among the sources already in this codebase — older, small-press, and non-US editions that Open Library / Google Books / Hardcover frequently don't carry at all, per-printing cover scans (a UK paperback reprinted three times has three different scanned covers, one per printing, even under the same ISBN), and unusually strong series (with correct volume ordering) and pseudonym-aware contributor data.

Because there's no API, this provider talks to a small self-hosted adapter (a thin JSON API in front of a MariaDB mirror, refreshed weekly from ISFDB's own backup) rather than isfdb.org directly — configured via the new `ConfigFields.base_url` from #45. Users without a mirror simply leave it unconfigured/disabled, same as any other provider without credentials.

**The adapter itself is published at [github.com/ennui2342/isfdb-adapter](https://github.com/ennui2342/isfdb-adapter)** — a reference implementation (Python/FastAPI, MariaDB, Dockerfile + docker-compose, full API contract documented) anyone can self-host to enable this provider. Not required reading to review the Go side, but it's what makes this feature actually usable rather than configurable-but-dead-endable.

## Endpoints called

| Interface | Adapter endpoint |
|---|---|
| `LookupByISBN` | `GET /isbn/{isbn}` |
| `SearchBooks` | `GET /search?q=` |
| `SearchSeries` | `GET /series/search?q=` |
| `FetchSeriesVolumes` | `GET /series/{id}/volumes` |
| `SearchContributors` / `FetchContributor` | `GET /authors/search?q=` / `GET /authors/{id}` |

A 404 from the adapter maps to `(nil, nil)`, matching the not-found convention the other providers already use; a real server error still propagates as an error.

## Test plan

**Unit tests** (`isfdb_test.go`, `httptest`-mocked — none of the sibling book providers currently have test files, but CONTRIBUTING.md asks for tests on behavior changes and this was straightforward to add):
- [x] `Configure` — disabled with no `base_url`, enabled once set, explicit `enabled=false` respected
- [x] `LookupByISBN` — happy path, 404 → `(nil, nil)`, 500 → real error
- [x] `FetchSeriesVolumes` — ordering passed through as-is (adapter's responsibility, provider doesn't re-sort)
- [x] `FetchContributor` — date parsing for a valid `YYYY-MM-DD`
- [x] `parseDate` — table test including ISFDB's `"1973-00-00"` zero-day placeholder (correctly rejected, not a valid date)

**End-to-end**, against a live self-hosted mirror (2.5M+ title rows, real production data):
- [x] `LookupByISBN` — a specific UK paperback, exact publisher/pages/cover match
- [x] `SearchBooks` — title+author freetext search
- [x] `SearchSeries` — found 13 Dune-related series entries
- [x] `FetchSeriesVolumes` — Dune's 6 core novels returned in correct reading order
- [x] `SearchContributors` / `FetchContributor` — author profile with correctly-parsed birth/death dates and a 94-entry bibliography

**Tooling**: `go build ./...`, `go vet ./...`, `go test ./...`, `gofmt -l` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
