### PR TITLE
fix(dashboard): stop counting recently-edited rows as recently-read

### DIFF
--- a/internal/repository/books.go
+++ b/internal/repository/books.go
@@ -1266,6 +1266,14 @@ type MonthlyReadBucket struct {
 
 // GetDashboardStats returns aggregate book and reading counts for the user across
 // all libraries they are a member of.
+//
+// "Read this year" / the monthly sparkline only count interactions with a
+// known date_finished. There is no fallback to updated_at: that column
+// reflects whenever the row was last written for any reason (an import, a
+// metadata refresh, an unrelated bulk correction), not when the book was
+// actually finished, and using it as a stand-in silently misattributes
+// books with no known finish date to "just read" the moment anything
+// touches their row.
 func (r *BookRepo) GetDashboardStats(ctx context.Context, userID uuid.UUID) (*DashboardStats, error) {
 	var s DashboardStats
 	err := r.db.QueryRow(ctx, `
@@ -1282,7 +1290,8 @@ func (r *BookRepo) GetDashboardStats(ctx context.Context, userID uuid.UUID) (*Da
 			COUNT(DISTINCT CASE WHEN ub.added_at >= date_trunc('year', NOW()) THEN b.id END) AS added_this_year,
 			COUNT(DISTINCT CASE
 				WHEN ubi.read_status = 'read'
-				 AND COALESCE(ubi.date_finished::timestamptz, ubi.updated_at) >= date_trunc('year', NOW())
+				 AND ubi.date_finished IS NOT NULL
+				 AND ubi.date_finished::timestamptz >= date_trunc('year', NOW())
 				THEN b.id END) AS read_this_year,
 			COUNT(DISTINCT CASE WHEN ubi.is_favorite THEN b.id END) AS favorites_count
 		FROM books b
@@ -1308,7 +1317,7 @@ func (r *BookRepo) GetDashboardStats(ctx context.Context, userID uuid.UUID) (*Da
 		),
 		reads AS (
 			SELECT
-				date_trunc('month', COALESCE(ubi.date_finished::timestamptz, ubi.updated_at)) AS m,
+				date_trunc('month', ubi.date_finished::timestamptz) AS m,
 				COUNT(DISTINCT b.id) AS c
 			FROM books b
 			JOIN library_books lb ON lb.book_id = b.id
@@ -1316,7 +1325,8 @@ func (r *BookRepo) GetDashboardStats(ctx context.Context, userID uuid.UUID) (*Da
 			JOIN book_editions be ON be.book_id = b.id
 			JOIN user_book_interactions ubi ON ubi.book_edition_id = be.id AND ubi.user_id = $1
 			WHERE ubi.read_status = 'read'
-			  AND COALESCE(ubi.date_finished::timestamptz, ubi.updated_at) >= date_trunc('month', NOW()) - INTERVAL '11 months'
+			  AND ubi.date_finished IS NOT NULL
+			  AND ubi.date_finished::timestamptz >= date_trunc('month', NOW()) - INTERVAL '11 months'
 			GROUP BY 1
 		)
 		SELECT to_char(months.m, 'YYYY-MM'), COALESCE(reads.c, 0)

--- a/internal/repository/books.go
+++ b/internal/repository/books.go
@@ -1484,6 +1484,8 @@ type FinishedBook struct {
 
 // RecentlyFinished returns the most recently finished books for the user.
 // De-duplicates by book (multiple editions read collapse to a single row).
+// Only considers interactions with a known date_finished — see the
+// GetDashboardStats comment on why there is no updated_at fallback.
 func (r *BookRepo) RecentlyFinished(ctx context.Context, userID uuid.UUID, limit int) ([]*FinishedBook, error) {
 	q := `
 		WITH user_book AS (
@@ -1497,15 +1499,15 @@ func (r *BookRepo) RecentlyFinished(ctx context.Context, userID uuid.UUID, limit
 				b.id AS book_id,
 				ub.library_id,
 				b.title,
-				COALESCE(ubi.date_finished::timestamptz, ubi.updated_at) AS finished_at,
+				ubi.date_finished::timestamptz AS finished_at,
 				ubi.rating,
 				ubi.is_favorite
 			FROM books b
 			JOIN user_book ub ON ub.book_id = b.id
 			JOIN book_editions be ON be.book_id = b.id
 			JOIN user_book_interactions ubi ON ubi.book_edition_id = be.id AND ubi.user_id = $1
-			WHERE ubi.read_status = 'read'
-			ORDER BY b.id, COALESCE(ubi.date_finished::timestamptz, ubi.updated_at) DESC
+			WHERE ubi.read_status = 'read' AND ubi.date_finished IS NOT NULL
+			ORDER BY b.id, ubi.date_finished DESC
 		)
 		SELECT
 			f.book_id, f.library_id, l.name, f.title, f.finished_at, f.rating, f.is_favorite,


### PR DESCRIPTION
## Summary

Fixes `GetDashboardStats` (dashboard "read this year" stat + monthly sparkline) counting books as recently-read purely because their row was recently *edited*, not because they were recently *finished*.

## Why

Both queries used:

```sql
COALESCE(ubi.date_finished::timestamptz, ubi.updated_at) >= date_trunc('year', NOW())
```

`updated_at` is bumped on any write to the row — an import, a metadata refresh, an unrelated bulk correction script — regardless of whether it has anything to do with when the book was finished. Using it as a stand-in for a missing `date_finished` silently misattributes every row with an unknown finish date to "just read" the moment anything touches it.

This is easy to trigger with a normal workflow: a Goodreads-style CSV import commonly has a "read" shelf where many books have no per-book finish date recorded at all (Goodreads lets you shelve something as read without ever setting a date). Any later bulk operation on those rows — even one unrelated to reading dates, like a metadata-enrichment pass — makes the dashboard report all of them as read in the current period.

Found via a live instance: an unrelated bulk metadata-enrichment run touched hundreds of `user_book_interactions` rows with no `date_finished`, and the "books read this year" stat immediately jumped to reflect all of them, in a single day, instead of the actual ~30 books read that year.

## Fix

Drop the `updated_at` fallback in both the headline stat and the monthly bucket query. A row with no known `date_finished` is now excluded from these time-windowed counts entirely, rather than guessed at via an unrelated timestamp.

## Test plan

- `go build ./...`, `go vet ./...`, `go test ./...` all clean.
- Verified against a real dataset with the exact failure mode (many `read_status='read'` rows with `date_finished IS NULL`, recently bulk-updated for an unrelated reason): before the fix, "read this year" reported 483; after, it correctly reports 32 (the actual count of interactions with a real `date_finished` in the current year).
- No repository-layer test added: this package has no existing DB-integration test harness (checked — the only test file in `internal/repository`, `api_tokens_test.go`, tests a pure token-generation function, not a query against a live database), so there's no established pattern to add one to for a single query fix without introducing new test infrastructure disproportionate to the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
