### PR TITLE
fix(series): don't let one bad volume row abort the whole sync

### DIFF
--- a/internal/repository/series_volumes.go
+++ b/internal/repository/series_volumes.go
@@ -5,6 +5,7 @@ package repository
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/fireball1725/librarium-api/internal/models"
@@ -64,6 +65,14 @@ func (r *SeriesVolumesRepo) List(ctx context.Context, seriesID uuid.UUID) ([]*mo
 
 // Sync upserts the provider-fetched volumes. Does NOT delete volumes already in the table
 // that are not in the provider list (so manually-added data is preserved).
+//
+// Continues past a single volume's failure instead of aborting the whole
+// sync — a provider returning one malformed row (e.g. a ReleaseDate that
+// doesn't actually match the "YYYY-MM-DD" the VolumeResult contract
+// promises) previously discarded every other volume in the series along
+// with it, since each row failing an INSERT stopped the loop immediately.
+// Failures are collected and returned together so the caller still knows
+// something was wrong, but whatever did parse is persisted regardless.
 func (r *SeriesVolumesRepo) Sync(ctx context.Context, seriesID uuid.UUID, volumes []providers.VolumeResult) error {
 	const q = `
 		INSERT INTO series_volumes (id, series_id, position, title, release_date, cover_url, external_id)
@@ -75,6 +84,7 @@ func (r *SeriesVolumesRepo) Sync(ctx context.Context, seriesID uuid.UUID, volume
 		    external_id  = COALESCE(EXCLUDED.external_id, series_volumes.external_id),
 		    updated_at   = NOW()`
 
+	var errs []error
 	for _, v := range volumes {
 		id := uuid.New()
 		var releaseDate *string
@@ -82,10 +92,10 @@ func (r *SeriesVolumesRepo) Sync(ctx context.Context, seriesID uuid.UUID, volume
 			releaseDate = &v.ReleaseDate
 		}
 		if _, err := r.db.Exec(ctx, q, id, seriesID, v.Position, v.Title, releaseDate, v.CoverURL, v.ExternalID); err != nil {
-			return fmt.Errorf("upserting series volume at position %v: %w", v.Position, err)
+			errs = append(errs, fmt.Errorf("upserting series volume at position %v: %w", v.Position, err))
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 // ListSeriesWithExternalSource returns all series that have an external_source set.


### PR DESCRIPTION
## Summary

`SeriesVolumesRepo.Sync` inserts one row per volume in a loop and returns on the first error — a single bad row previously discarded every other volume in the series along with it.

## Found live

Syncing a real 9-volume ISFDB series (Alex Benedict / Jack McDevitt) synced **zero** volumes, because the first volume's release date (`"1989-02"` — valid, just month precision, not day-precision) failed Postgres's `::date` cast and the loop returned immediately, before ever attempting volumes 2 through 9.

```
ERROR: invalid input syntax for type date: "1989-02" (SQLSTATE 22007)
```

The date-precision root cause is fixed separately (the offending provider should never have passed an invalid value in the first place — see the companion ISFDB/Hardcover fixes), but this file has the same defect independent of what triggers it: **any** single row a provider can't cleanly represent takes out the entire series' sync, silently, for reasons that have nothing to do with the other 8+ rows.

## Fix

Collect per-row failures and continue instead of returning immediately. Whatever does parse is persisted; the caller still learns something was wrong via a combined `errors.Join` error, so a partial sync isn't silently reported as a full success.

## Test plan

- `go build ./...`, `go vet ./...`, `go test ./...` all clean.
- No repository-layer test added — this package has no existing DB-integration test harness (the one existing test in `internal/repository`, `api_tokens_test.go`, tests a pure function, not a live-DB query), so there's no established pattern to extend for a single query fix without introducing new test infrastructure disproportionate to the change.
- Verified live against the reproduction above: after this fix (deployed alongside the companion date-normalization fix), the same series correctly synced all 9 volumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
