### PR TITLE
fix(providers): start SearchBooks' deadline after the first result, not at search start

### DIFF
--- a/internal/providers/registry.go
+++ b/internal/providers/registry.go
@@ -134,7 +134,9 @@ func (r *Registry) BookSearchProviders() []BookSearchProvider {
 // searchDeadline is how long SearchBooks waits for lagging providers once at
 // least one provider has already returned results.  A slow provider (e.g. Open
 // Library search timing out at 15 s) will not hold up results from fast ones.
-const searchDeadline = 5 * time.Second
+// var, not const, so tests can shrink it rather than sleeping several real
+// seconds per case.
+var searchDeadline = 5 * time.Second
 
 // SearchBooks queries all enabled BookSearchProviders concurrently and returns
 // as soon as every provider has responded OR the deadline is reached.
@@ -165,8 +167,15 @@ func (r *Registry) SearchBooks(ctx context.Context, query string) []*BookResult 
 		}(p)
 	}
 
-	deadline := time.NewTimer(searchDeadline)
-	defer deadline.Stop()
+	// deadlineC stays nil (blocks forever in the select below) until the
+	// first result arrives, matching searchDeadline's doc comment: lagging
+	// providers get searchDeadline *after* a fast one has already
+	// responded, not a flat searchDeadline from the start of the search.
+	// Before any result exists there's no fast provider to protect, so we
+	// wait unboundedly for the first one — each provider's own HTTP client
+	// timeout is still the real worst-case bound, since every goroutine
+	// below sends to ch when its call returns, success or error.
+	var deadlineC <-chan time.Time
 
 	var out []*BookResult
 	remaining := len(providers)
@@ -175,7 +184,12 @@ func (r *Registry) SearchBooks(ctx context.Context, query string) []*BookResult 
 		case res := <-ch:
 			out = append(out, res.items...)
 			remaining--
-		case <-deadline.C:
+			if deadlineC == nil {
+				deadline := time.NewTimer(searchDeadline)
+				defer deadline.Stop()
+				deadlineC = deadline.C
+			}
+		case <-deadlineC:
 			slog.InfoContext(ctx, "book search deadline reached, returning partial results",
 				"query", query, "waiting_on", remaining, "results_so_far", len(out))
 			slog.InfoContext(ctx, "book search done", "query", query, "total", len(out))

--- a/internal/providers/registry_test.go
+++ b/internal/providers/registry_test.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725 (Adaléa)
+
+package providers
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// fakeSearchProvider is a BookSearchProvider whose SearchBooks call blocks
+// for `delay` before returning a single result named after the provider.
+type fakeSearchProvider struct {
+	name  string
+	delay time.Duration
+}
+
+func (p *fakeSearchProvider) Info() ProviderInfo {
+	return ProviderInfo{Name: p.name, DisplayName: p.name, Capabilities: []string{CapBookSearch}}
+}
+func (p *fakeSearchProvider) Configure(map[string]string) {}
+func (p *fakeSearchProvider) Enabled() bool               { return true }
+func (p *fakeSearchProvider) SearchBooks(ctx context.Context, query string) ([]*BookResult, error) {
+	select {
+	case <-time.After(p.delay):
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	return []*BookResult{{Provider: p.name, Title: p.name}}, nil
+}
+
+// withSearchDeadline temporarily shrinks the package-level deadline so tests
+// don't have to sleep several real seconds per case, restoring it after.
+func withSearchDeadline(t *testing.T, d time.Duration) {
+	t.Helper()
+	orig := searchDeadline
+	searchDeadline = d
+	t.Cleanup(func() { searchDeadline = orig })
+}
+
+// Regression test for the bug found live 2026-07-26: the deadline timer was
+// started unconditionally at the top of SearchBooks, so if the *fastest*
+// provider itself took longer than searchDeadline, the deadline could fire
+// before any result at all arrived — the opposite of the doc comment's
+// intent ("waits for lagging providers once at least one provider has
+// already returned results").
+func TestSearchBooks_DeadlineStartsAfterFirstResult_NotAtSearchStart(t *testing.T) {
+	withSearchDeadline(t, 50*time.Millisecond)
+
+	r := NewRegistry()
+	// Both providers are individually slower than searchDeadline on their
+	// own — under the old flat-from-start timer, the deadline would fire
+	// at 50ms, before either had a chance to respond, yielding zero results.
+	r.Register(&fakeSearchProvider{name: "slow-first", delay: 60 * time.Millisecond})
+	r.Register(&fakeSearchProvider{name: "slow-second", delay: 100 * time.Millisecond})
+
+	start := time.Now()
+	out := r.SearchBooks(context.Background(), "query")
+	elapsed := time.Since(start)
+
+	if len(out) != 2 {
+		t.Fatalf("got %d results, want 2 (both providers, since the deadline should only start counting after the first response) — results: %+v", len(out), out)
+	}
+	// Sanity bound: should finish well before the two providers' delays
+	// summed, proving they ran concurrently rather than serially.
+	if elapsed > 200*time.Millisecond {
+		t.Fatalf("took %s, expected well under 200ms for two concurrent providers", elapsed)
+	}
+}
+
+func TestSearchBooks_DropsStragglerPastGracePeriodAfterFirstResult(t *testing.T) {
+	withSearchDeadline(t, 50*time.Millisecond)
+
+	r := NewRegistry()
+	r.Register(&fakeSearchProvider{name: "fast", delay: 0})
+	// Arrives 150ms after the fast provider — well past fast's 0+50ms grace
+	// window — so it must be dropped even though the fix removed the flat
+	// from-search-start timer.
+	r.Register(&fakeSearchProvider{name: "straggler", delay: 150 * time.Millisecond})
+
+	out := r.SearchBooks(context.Background(), "query")
+
+	if len(out) != 1 || out[0].Provider != "fast" {
+		t.Fatalf("got %+v, want exactly the fast provider's result — the straggler should have been dropped", out)
+	}
+}


### PR DESCRIPTION
## Summary

`searchDeadline`'s own doc comment says lagging providers get `searchDeadline` *after at least one provider has already returned results*, but the timer was actually started unconditionally at the top of `SearchBooks`, before any provider goroutine had a chance to respond.

If every enabled provider individually takes longer than `searchDeadline` (5s), the deadline could fire before *any* result arrived, silently returning zero results even though every provider was about to succeed.

In practice this showed up as a moderately slow provider (e.g. Google Books, which has its own 15s HTTP client timeout) intermittently appearing and disappearing from search results — it was racing against a deadline timed from the whole search's start rather than getting the documented grace period after a faster provider had already responded.

## Fix

The deadline timer now only starts once the first result lands — a `nil` channel blocks forever in the `select` until then, so `SearchBooks` waits unboundedly for the first response. This isn't actually unbounded in practice: every provider goroutine sends to the results channel when its own call returns, success or error, so each provider's own HTTP client timeout remains the real worst-case bound for that first response. Once any provider has responded, the documented `searchDeadline` grace period kicks in for the rest, same as before.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] Added `internal/providers/registry_test.go` (no prior test file existed for this package):
  - `TestSearchBooks_DeadlineStartsAfterFirstResult_NotAtSearchStart` — two providers each individually slower than `searchDeadline` on their own; under the old flat-from-start timer this returned zero results, under the fix both are included.
  - `TestSearchBooks_DropsStragglerPastGracePeriodAfterFirstResult` — confirms the deadline still correctly drops a genuine straggler once the grace period (measured from the first result) elapses.
- [x] Verified live against the deployed instance with a real slow-provider scenario before opening this PR.