### PR TITLE
ci: gate formatting with gofmt, and bring the tree to a clean baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,11 @@ jobs:
       # golangci-lint subsumes `go vet` (it runs vet plus errcheck,
       # staticcheck, ineffassign, unused, bodyclose, misspell). The
       # action handles tool install + cache.
+      #
+      # It also gates formatting: .golangci.yml enables the gofmt
+      # formatter, so an unformatted file fails this step. Fix with
+      # `golangci-lint fmt` — plain `gofmt -w` can disagree, since the
+      # pinned linter version formats with its own bundled Go.
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -53,6 +53,16 @@ linters:
         # I/O failure surfaces via the writer, not the encoder return.
         - (*encoding/json.Encoder).Encode
 
+# gofmt is enforced in CI (see .github/workflows/ci.yml). The tree was
+# brought to a clean baseline in one sweep; this keeps it there so outside
+# PRs stop carrying unrelated whitespace churn from editors that format on
+# save. Run `golangci-lint fmt` to fix locally.
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -443,11 +443,11 @@ func main() {
 		ProviderSvc: providerSvc,
 	})
 	srv := &http.Server{
-		Addr:           addr,
-		Handler:        handler,
-		ReadTimeout:    15 * time.Second,
-		WriteTimeout:   15 * time.Second,
-		IdleTimeout:    60 * time.Second,
+		Addr:         addr,
+		Handler:      handler,
+		ReadTimeout:  15 * time.Second,
+		WriteTimeout: 15 * time.Second,
+		IdleTimeout:  60 * time.Second,
 		// Cap request headers at 1 MiB so a malformed client can't pin a
 		// goroutine on an unbounded header read. Per-handler limits cover
 		// bodies (multipart, JSON); this catches everything else.

--- a/internal/api/handlers/ai_suggestions.go
+++ b/internal/api/handlers/ai_suggestions.go
@@ -521,11 +521,11 @@ type RunView struct {
 // SteeringView hydrates stored steering IDs to {id, name} objects for direct
 // UI consumption. Notes is free-form text and flows through unchanged.
 type SteeringView struct {
-	Authors []NamedRef        `json:"authors,omitempty"`
-	Series  []NamedRef        `json:"series,omitempty"`
-	Genres  []NamedRef        `json:"genres,omitempty"`
-	Tags    []NamedTagRef     `json:"tags,omitempty"`
-	Notes   string            `json:"notes,omitempty"`
+	Authors []NamedRef    `json:"authors,omitempty"`
+	Series  []NamedRef    `json:"series,omitempty"`
+	Genres  []NamedRef    `json:"genres,omitempty"`
+	Tags    []NamedTagRef `json:"tags,omitempty"`
+	Notes   string        `json:"notes,omitempty"`
 }
 
 type NamedRef struct {
@@ -932,4 +932,3 @@ func parseRelativeDays(s string) (int, bool) {
 	}
 	return n, true
 }
-

--- a/internal/api/handlers/books.go
+++ b/internal/api/handlers/books.go
@@ -27,10 +27,10 @@ import (
 
 type BookHandler struct {
 	svc               *service.BookService
-	books             *repository.BookRepo             // used for TitlesByIDs at batch creation
-	loans             *repository.LoanRepo             // active loans on GetBook responses
-	riverClient       *river.Client[pgx.Tx]            // may be nil; used for enrichment batch jobs
-	enrichmentBatches *repository.EnrichmentBatchRepo  // may be nil; required for bulk enrich/cover
+	books             *repository.BookRepo            // used for TitlesByIDs at batch creation
+	loans             *repository.LoanRepo            // active loans on GetBook responses
+	riverClient       *river.Client[pgx.Tx]           // may be nil; used for enrichment batch jobs
+	enrichmentBatches *repository.EnrichmentBatchRepo // may be nil; required for bulk enrich/cover
 	editionFiles      *service.EditionFileService
 }
 
@@ -584,10 +584,10 @@ func (h *BookHandler) AddBookToLibrary(w http.ResponseWriter, r *http.Request) {
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 type bookRequestBody struct {
-	Title       string `json:"title"`
-	Subtitle    string `json:"subtitle"`
-	MediaTypeID string `json:"media_type_id"`
-	Description string `json:"description"`
+	Title        string `json:"title"`
+	Subtitle     string `json:"subtitle"`
+	MediaTypeID  string `json:"media_type_id"`
+	Description  string `json:"description"`
 	Contributors []struct {
 		ContributorID string `json:"contributor_id"`
 		Role          string `json:"role"`
@@ -678,29 +678,29 @@ func bookBody(b *models.Book) map[string]any {
 		primaryLibraryID = b.Libraries[0].ID
 	}
 	return map[string]any{
-		"id":               b.ID,
-		"library_id":       primaryLibraryID,
-		"libraries":        b.Libraries,
-		"title":            b.Title,
-		"subtitle":         b.Subtitle,
-		"media_type_id":    b.MediaTypeID,
-		"media_type":       b.MediaType,
-		"description":      b.Description,
-		"contributors":     b.Contributors,
-		"tags":             b.Tags,
-		"genres":           b.Genres,
-		"cover_url":        coverURL,
-		"created_at":       b.CreatedAt,
-		"updated_at":       b.UpdatedAt,
-		"series":           b.Series,
-		"shelves":          b.Shelves,
-		"publisher":        b.Publisher,
-		"publish_year":     b.PublishYear,
-		"language":         b.Language,
-		"user_read_status":   b.UserReadStatus,
-		"user_rating":        b.UserRating,
-		"user_progress_pct":  b.UserProgressPct,
-		"active_loan_count":  b.ActiveLoanCount,
+		"id":                b.ID,
+		"library_id":        primaryLibraryID,
+		"libraries":         b.Libraries,
+		"title":             b.Title,
+		"subtitle":          b.Subtitle,
+		"media_type_id":     b.MediaTypeID,
+		"media_type":        b.MediaType,
+		"description":       b.Description,
+		"contributors":      b.Contributors,
+		"tags":              b.Tags,
+		"genres":            b.Genres,
+		"cover_url":         coverURL,
+		"created_at":        b.CreatedAt,
+		"updated_at":        b.UpdatedAt,
+		"series":            b.Series,
+		"shelves":           b.Shelves,
+		"publisher":         b.Publisher,
+		"publish_year":      b.PublishYear,
+		"language":          b.Language,
+		"user_read_status":  b.UserReadStatus,
+		"user_rating":       b.UserRating,
+		"user_progress_pct": b.UserProgressPct,
+		"active_loan_count": b.ActiveLoanCount,
 	}
 }
 

--- a/internal/api/handlers/docs.go
+++ b/internal/api/handlers/docs.go
@@ -6,8 +6,8 @@ package handlers
 import (
 	"net/http"
 
-	"github.com/swaggo/swag"
 	_ "github.com/fireball1725/librarium-api/docs"
+	"github.com/swaggo/swag"
 )
 
 // ServeOpenAPISpec serves the generated OpenAPI JSON spec.

--- a/internal/api/handlers/shelves.go
+++ b/internal/api/handlers/shelves.go
@@ -518,4 +518,3 @@ func tagBody(t *models.Tag) map[string]any {
 		"created_at": t.CreatedAt,
 	}
 }
-

--- a/internal/api/middleware/errors.go
+++ b/internal/api/middleware/errors.go
@@ -16,4 +16,3 @@ import (
 func SetHandlerError(ctx context.Context, err error) {
 	respond.SetHandlerError(ctx, err)
 }
-

--- a/internal/api/middleware/rate_limit.go
+++ b/internal/api/middleware/rate_limit.go
@@ -23,9 +23,9 @@ type RateLimiter struct {
 	mu       sync.Mutex
 	buckets  map[string]*bucket
 	burst    float64
-	refill   float64        // tokens per second
-	interval time.Duration  // window used for human-readable config
-	idleTTL  time.Duration  // garbage-collect buckets unseen this long
+	refill   float64       // tokens per second
+	interval time.Duration // window used for human-readable config
+	idleTTL  time.Duration // garbage-collect buckets unseen this long
 }
 
 type bucket struct {

--- a/internal/api/responses/responses.go
+++ b/internal/api/responses/responses.go
@@ -204,7 +204,7 @@ type EditionResponse struct {
 	EditionName     string    `json:"edition_name"`
 	Narrator        string    `json:"narrator"`
 	Publisher       string    `json:"publisher"`
-	PublishDate     *string   `json:"publish_date"`     // YYYY-MM-DD
+	PublishDate     *string   `json:"publish_date"` // YYYY-MM-DD
 	ISBN10          string    `json:"isbn_10"`
 	ISBN13          string    `json:"isbn_13"`
 	CopyCount       int       `json:"copy_count"`
@@ -336,9 +336,9 @@ type LoanResponse struct {
 	BookID     uuid.UUID `json:"book_id"`
 	BookTitle  string    `json:"book_title"`
 	LoanedTo   string    `json:"loaned_to"`
-	LoanedAt   string    `json:"loaned_at"`    // YYYY-MM-DD
-	DueDate    *string   `json:"due_date"`     // YYYY-MM-DD
-	ReturnedAt *string   `json:"returned_at"`  // YYYY-MM-DD
+	LoanedAt   string    `json:"loaned_at"`   // YYYY-MM-DD
+	DueDate    *string   `json:"due_date"`    // YYYY-MM-DD
+	ReturnedAt *string   `json:"returned_at"` // YYYY-MM-DD
 	Notes      string    `json:"notes"`
 	Tags       []TagRef  `json:"tags"`
 	CreatedAt  time.Time `json:"created_at"`

--- a/internal/api/responses/sync.go
+++ b/internal/api/responses/sync.go
@@ -45,8 +45,8 @@ type SyncOp struct {
 // discarded_stale results since the timestamps no longer beat what's
 // in the database.
 type SyncApplyRequest struct {
-	ClientID uuid.UUID      `json:"client_id,omitempty"`
-	Ops      []SyncApplyOp  `json:"ops"`
+	ClientID uuid.UUID     `json:"client_id,omitempty"`
+	Ops      []SyncApplyOp `json:"ops"`
 }
 
 // SyncApplyOp mirrors SyncOp but is what the client sends back to the

--- a/internal/api/uploads/sniff.go
+++ b/internal/api/uploads/sniff.go
@@ -36,20 +36,20 @@ var allowedImageTypes = map[string]struct{}{
 // allowed because EPUB/CBZ files are detected as zip by net/http; the
 // service layer pins format more narrowly via the explicit `format` field.
 var allowedEditionFileTypes = map[string]struct{}{
-	"application/pdf":  {},
+	"application/pdf":      {},
 	"application/epub+zip": {},
-	"application/zip":  {},
-	"audio/mpeg":       {},
-	"audio/mp4":        {},
-	"audio/m4a":        {},
-	"audio/x-m4a":      {},
-	"audio/x-m4b":      {},
-	"audio/aac":        {},
-	"audio/ogg":        {},
-	"audio/flac":       {},
-	"audio/x-flac":     {},
-	"audio/wav":        {},
-	"audio/x-wav":      {},
+	"application/zip":      {},
+	"audio/mpeg":           {},
+	"audio/mp4":            {},
+	"audio/m4a":            {},
+	"audio/x-m4a":          {},
+	"audio/x-m4b":          {},
+	"audio/aac":            {},
+	"audio/ogg":            {},
+	"audio/flac":           {},
+	"audio/x-flac":         {},
+	"audio/wav":            {},
+	"audio/x-wav":          {},
 }
 
 // SniffImage validates that `r` is one of the allowed image types and

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,14 +11,14 @@ import (
 )
 
 type Config struct {
-	Host                string
-	Port                string
-	DatabaseURL         string
-	JWTSecret           string
-	JWTAccessTTL        time.Duration
-	JWTRefreshTTL       time.Duration
-	RegistrationEnabled bool
-	LogLevel            slog.Level
+	Host                  string
+	Port                  string
+	DatabaseURL           string
+	JWTSecret             string
+	JWTAccessTTL          time.Duration
+	JWTRefreshTTL         time.Duration
+	RegistrationEnabled   bool
+	LogLevel              slog.Level
 	CoverStoragePath      string
 	EbookStoragePath      string
 	AudiobookStoragePath  string
@@ -29,20 +29,20 @@ type Config struct {
 
 func Load() *Config {
 	return &Config{
-		Host:                 getEnv("HOST", "0.0.0.0"),
-		Port:                 getEnv("PORT", "8080"),
-		DatabaseURL:          getEnv("DATABASE_URL", "postgres://librarium:librarium@localhost:5432/librarium?sslmode=disable"),
-		JWTSecret:            getEnv("JWT_SECRET", ""),
-		JWTAccessTTL:         parseDuration(getEnv("JWT_ACCESS_TTL", "30m")),
-		JWTRefreshTTL:        parseDuration(getEnv("JWT_REFRESH_TTL", "720h")),
-		RegistrationEnabled:  getEnv("REGISTRATION_ENABLED", "true") != "false",
-		LogLevel:             parseLogLevel(getEnv("LOG_LEVEL", "info")),
+		Host:                  getEnv("HOST", "0.0.0.0"),
+		Port:                  getEnv("PORT", "8080"),
+		DatabaseURL:           getEnv("DATABASE_URL", "postgres://librarium:librarium@localhost:5432/librarium?sslmode=disable"),
+		JWTSecret:             getEnv("JWT_SECRET", ""),
+		JWTAccessTTL:          parseDuration(getEnv("JWT_ACCESS_TTL", "30m")),
+		JWTRefreshTTL:         parseDuration(getEnv("JWT_REFRESH_TTL", "720h")),
+		RegistrationEnabled:   getEnv("REGISTRATION_ENABLED", "true") != "false",
+		LogLevel:              parseLogLevel(getEnv("LOG_LEVEL", "info")),
 		CoverStoragePath:      getEnv("COVER_STORAGE_PATH", "./data/covers"),
 		EbookStoragePath:      getEnv("EBOOK_STORAGE_PATH", "./data/media/ebooks"),
 		AudiobookStoragePath:  getEnv("AUDIOBOOK_STORAGE_PATH", "./data/media/audiobooks"),
 		EbookPathTemplate:     getEnv("EBOOK_PATH_TEMPLATE", "{title}"),
 		AudiobookPathTemplate: getEnv("AUDIOBOOK_PATH_TEMPLATE", "{title}"),
-		TUI:                  getEnv("TUI", "false") == "true",
+		TUI:                   getEnv("TUI", "false") == "true",
 	}
 }
 

--- a/internal/imports/normalize.go
+++ b/internal/imports/normalize.go
@@ -141,4 +141,3 @@ func Bool(raw string) (bool, bool) {
 	}
 	return false, false
 }
-

--- a/internal/jobs/registry.go
+++ b/internal/jobs/registry.go
@@ -25,10 +25,10 @@ type Kind string
 // Built-in kinds. New kinds can declare their own constants alongside
 // their worker package and register from there.
 const (
-	KindImport         Kind = "import"
-	KindEnrichment     Kind = "enrichment"
-	KindAISuggestions  Kind = "ai_suggestions"
-	KindCoverBackfill  Kind = "cover_backfill"
+	KindImport        Kind = "import"
+	KindEnrichment    Kind = "enrichment"
+	KindAISuggestions Kind = "ai_suggestions"
+	KindCoverBackfill Kind = "cover_backfill"
 )
 
 // TriggerCtx is everything the Enqueue hook of a Definition needs

--- a/internal/models/ai_metadata.go
+++ b/internal/models/ai_metadata.go
@@ -25,10 +25,10 @@ const (
 	AIMetaRunStatusFailed    = "failed"
 	AIMetaRunStatusSkipped   = "skipped"
 
-	AIMetaProposalStatusPending            = "pending"
-	AIMetaProposalStatusAccepted           = "accepted"
-	AIMetaProposalStatusRejected           = "rejected"
-	AIMetaProposalStatusPartiallyAccepted  = "partially_accepted"
+	AIMetaProposalStatusPending           = "pending"
+	AIMetaProposalStatusAccepted          = "accepted"
+	AIMetaProposalStatusRejected          = "rejected"
+	AIMetaProposalStatusPartiallyAccepted = "partially_accepted"
 )
 
 // AIMetadataRun is one AI call recorded for audit + cost accounting +
@@ -77,11 +77,11 @@ type AIMetadataProposal struct {
 // proposals. Each field is optional — the AI may have evidence for some and
 // not others. Genres is always non-nil but may be empty.
 type SeriesMetadataPayload struct {
-	Status      *string  `json:"status,omitempty"`       // ongoing | completed | hiatus | cancelled
+	Status      *string  `json:"status,omitempty"` // ongoing | completed | hiatus | cancelled
 	TotalCount  *int     `json:"total_count,omitempty"`
-	Demographic *string  `json:"demographic,omitempty"`  // shounen | seinen | shoujo | josei | etc
+	Demographic *string  `json:"demographic,omitempty"` // shounen | seinen | shoujo | josei | etc
 	Genres      []string `json:"genres"`
-	Description *string  `json:"description,omitempty"`  // cleaned-up description
+	Description *string  `json:"description,omitempty"` // cleaned-up description
 }
 
 // SeriesArcsPayload is the shape persisted for kind=series_arcs proposals.

--- a/internal/models/book.go
+++ b/internal/models/book.go
@@ -36,20 +36,20 @@ type BookShelfRef struct {
 // is expressed via the library_books junction (see LibraryBook); a book row
 // no longer carries a single library_id.
 type Book struct {
-	ID           uuid.UUID
-	Title        string
-	Subtitle     string
-	MediaTypeID  uuid.UUID
-	MediaType    string // display_name from joined media_types row
-	Description  string
-	CreatedAt    time.Time
-	UpdatedAt    time.Time
-	Contributors []BookContributor
-	Tags         []Tag
-	Genres       []Genre
-	HasCover     bool
-	Series       []BookSeriesRef
-	Shelves      []BookShelfRef
+	ID             uuid.UUID
+	Title          string
+	Subtitle       string
+	MediaTypeID    uuid.UUID
+	MediaType      string // display_name from joined media_types row
+	Description    string
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+	Contributors   []BookContributor
+	Tags           []Tag
+	Genres         []Genre
+	HasCover       bool
+	Series         []BookSeriesRef
+	Shelves        []BookShelfRef
 	Publisher      string
 	PublishYear    *int
 	Language       string

--- a/internal/models/edition.go
+++ b/internal/models/edition.go
@@ -38,22 +38,22 @@ func NormalizeEditionFormat(s string) string {
 }
 
 type BookEdition struct {
-	ID                     uuid.UUID
-	BookID                 uuid.UUID
-	Format                 string // paperback | hardcover | ebook | audiobook | digital
-	Language               string
-	EditionName            string
-	Narrator               string
-	Publisher              string
-	PublishDate            *time.Time
-	ISBN10                 string
-	ISBN13                 string
-	Description            string
-	DurationSeconds        *int
-	PageCount              *int
-	IsPrimary              bool
-	CreatedAt              time.Time
-	UpdatedAt              time.Time
+	ID                      uuid.UUID
+	BookID                  uuid.UUID
+	Format                  string // paperback | hardcover | ebook | audiobook | digital
+	Language                string
+	EditionName             string
+	Narrator                string
+	Publisher               string
+	PublishDate             *time.Time
+	ISBN10                  string
+	ISBN13                  string
+	Description             string
+	DurationSeconds         *int
+	PageCount               *int
+	IsPrimary               bool
+	CreatedAt               time.Time
+	UpdatedAt               time.Time
 	NarratorContributorID   *uuid.UUID
 	NarratorContributorName string
 	// Files is populated by the service layer — not a DB column on book_editions.
@@ -87,7 +87,7 @@ type UserBookInteraction struct {
 	// {pages_read?: int, percent?: float, position?: string} — pages for
 	// print, percent for ebook readers, position free text for audio.
 	// Empty []byte (or nil) when never set; raw JSON bytes otherwise.
-	Progress      []byte
-	CreatedAt     time.Time
-	UpdatedAt     time.Time
+	Progress  []byte
+	CreatedAt time.Time
+	UpdatedAt time.Time
 }

--- a/internal/models/enrichment_batch.go
+++ b/internal/models/enrichment_batch.go
@@ -54,25 +54,25 @@ type EnrichmentBatchItem struct {
 // EnrichmentBatch is the application-level tracking record for a bulk
 // metadata or cover refresh operation.
 type EnrichmentBatch struct {
-	ID             uuid.UUID              `json:"id"`
+	ID uuid.UUID `json:"id"`
 	// LibraryID scopes the batch to a library when set. Null for
 	// floating-book batches (e.g. re-enriching a suggestion-backed book not
 	// yet held by any library).
-	LibraryID      *uuid.UUID             `json:"library_id,omitempty"`
-	LibraryName    string                 `json:"library_name,omitempty"`
-	CreatedBy      uuid.UUID              `json:"created_by"`
-	Type           EnrichmentBatchType    `json:"type"`
-	Force          bool                   `json:"force"`
-	UseAICleanup   bool                   `json:"use_ai_cleanup"`
-	Status         EnrichmentBatchStatus  `json:"status"`
-	BookIDs        []uuid.UUID            `json:"book_ids,omitempty"`
-	TotalBooks     int                    `json:"total_books"`
-	ProcessedBooks int                    `json:"processed_books"`
-	FailedBooks    int                    `json:"failed_books"`
-	SkippedBooks   int                    `json:"skipped_books"`
-	Items          []EnrichmentBatchItem  `json:"items,omitempty"`
-	CreatedAt      time.Time              `json:"created_at"`
-	UpdatedAt      time.Time              `json:"updated_at"`
+	LibraryID      *uuid.UUID            `json:"library_id,omitempty"`
+	LibraryName    string                `json:"library_name,omitempty"`
+	CreatedBy      uuid.UUID             `json:"created_by"`
+	Type           EnrichmentBatchType   `json:"type"`
+	Force          bool                  `json:"force"`
+	UseAICleanup   bool                  `json:"use_ai_cleanup"`
+	Status         EnrichmentBatchStatus `json:"status"`
+	BookIDs        []uuid.UUID           `json:"book_ids,omitempty"`
+	TotalBooks     int                   `json:"total_books"`
+	ProcessedBooks int                   `json:"processed_books"`
+	FailedBooks    int                   `json:"failed_books"`
+	SkippedBooks   int                   `json:"skipped_books"`
+	Items          []EnrichmentBatchItem `json:"items,omitempty"`
+	CreatedAt      time.Time             `json:"created_at"`
+	UpdatedAt      time.Time             `json:"updated_at"`
 }
 
 // EnrichmentBatchJobArgs is the River job payload for a batch enrichment run.

--- a/internal/models/import_job.go
+++ b/internal/models/import_job.go
@@ -30,10 +30,10 @@ const (
 type ImportItemStatus string
 
 const (
-	ImportItemPending  ImportItemStatus = "pending"
-	ImportItemDone     ImportItemStatus = "done"
-	ImportItemSkipped  ImportItemStatus = "skipped"
-	ImportItemFailed   ImportItemStatus = "failed"
+	ImportItemPending ImportItemStatus = "pending"
+	ImportItemDone    ImportItemStatus = "done"
+	ImportItemSkipped ImportItemStatus = "skipped"
+	ImportItemFailed  ImportItemStatus = "failed"
 )
 
 // ImportOptions holds per-import configuration stored in the DB. The
@@ -91,15 +91,15 @@ type ImportJob struct {
 }
 
 type ImportJobItem struct {
-	ID          uuid.UUID        `json:"id"`
-	ImportJobID uuid.UUID        `json:"import_job_id"`
-	RowNumber   int              `json:"row_number"`
+	ID          uuid.UUID         `json:"id"`
+	ImportJobID uuid.UUID         `json:"import_job_id"`
+	RowNumber   int               `json:"row_number"`
 	RawData     map[string]string `json:"raw_data"`
-	Status      ImportItemStatus `json:"status"`
-	Title       string           `json:"title"`
-	ISBN        string           `json:"isbn"`
-	Message     string           `json:"message"`
-	BookID      *uuid.UUID       `json:"book_id,omitempty"`
-	CreatedAt   time.Time        `json:"created_at"`
-	UpdatedAt   time.Time        `json:"updated_at"`
+	Status      ImportItemStatus  `json:"status"`
+	Title       string            `json:"title"`
+	ISBN        string            `json:"isbn"`
+	Message     string            `json:"message"`
+	BookID      *uuid.UUID        `json:"book_id,omitempty"`
+	CreatedAt   time.Time         `json:"created_at"`
+	UpdatedAt   time.Time         `json:"updated_at"`
 }

--- a/internal/models/job.go
+++ b/internal/models/job.go
@@ -51,11 +51,11 @@ type Job struct {
 	// Progress is a kind-specific JSON blob for summary UI. Import uses
 	// {processed,failed,skipped,total}; enrichment similar; AI suggestions
 	// uses {tokens_in,tokens_out,cost_usd}. Kept opaque at this layer.
-	Progress    json.RawMessage
-	StartedAt   *time.Time
-	FinishedAt  *time.Time
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
+	Progress   json.RawMessage
+	StartedAt  *time.Time
+	FinishedAt *time.Time
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
 }
 
 // JobEvent is one entry in a job's progress log. Type is free-form per

--- a/internal/models/series.go
+++ b/internal/models/series.go
@@ -25,18 +25,18 @@ type Series struct {
 	ExternalSource   string     `json:"external_source"`
 	LastReleaseDate  *time.Time `json:"last_release_date"`
 	NextReleaseDate  *time.Time `json:"next_release_date"`
-	BookCount        int                  `json:"book_count"`
-	ArcCount         int                  `json:"arc_count"`
+	BookCount        int        `json:"book_count"`
+	ArcCount         int        `json:"arc_count"`
 	// Caller-relative reading state. Only populated when the caller is known
 	// (List / FindByID receive a non-zero callerID). Both default to 0 when
 	// not populated, which is fine because clients gate the indicator behind
 	// the user's `show_read_badges` preference anyway.
-	ReadCount        int                  `json:"read_count"`
-	ReadingCount     int                  `json:"reading_count"`
-	PreviewBooks     []SeriesPreviewBook  `json:"preview_books"`
-	Tags             []*Tag               `json:"tags"`
-	CreatedAt        time.Time            `json:"created_at"`
-	UpdatedAt        time.Time            `json:"updated_at"`
+	ReadCount    int                 `json:"read_count"`
+	ReadingCount int                 `json:"reading_count"`
+	PreviewBooks []SeriesPreviewBook `json:"preview_books"`
+	Tags         []*Tag              `json:"tags"`
+	CreatedAt    time.Time           `json:"created_at"`
+	UpdatedAt    time.Time           `json:"updated_at"`
 }
 
 // SeriesPreviewBook is the trimmed shape used to assemble a series cover

--- a/internal/providers/books/hardcover.go
+++ b/internal/providers/books/hardcover.go
@@ -598,58 +598,58 @@ func (p *HardcoverProvider) FetchSeriesVolumes(ctx context.Context, externalID s
 // Hardcover returns e.g. "English" where every other provider returns "en".
 func normalizeHardcoverLanguage(name string) string {
 	codes := map[string]string{
-		"Afrikaans":           "af",
-		"Albanian":            "sq",
-		"Arabic":              "ar",
-		"Basque":              "eu",
-		"Belarusian":          "be",
-		"Bengali":             "bn",
-		"Bulgarian":           "bg",
-		"Catalan":             "ca",
-		"Chinese":             "zh",
-		"Croatian":            "hr",
-		"Czech":               "cs",
-		"Danish":              "da",
-		"Dutch":               "nl",
-		"English":             "en",
-		"Estonian":            "et",
-		"Finnish":             "fi",
-		"French":              "fr",
-		"Galician":            "gl",
-		"German":              "de",
-		"Greek":               "el",
-		"Hebrew":              "he",
-		"Hindi":               "hi",
-		"Hungarian":           "hu",
-		"Icelandic":           "is",
-		"Indonesian":          "id",
-		"Irish":               "ga",
-		"Italian":             "it",
-		"Japanese":            "ja",
-		"Korean":              "ko",
-		"Latvian":             "lv",
-		"Lithuanian":          "lt",
-		"Macedonian":          "mk",
-		"Malay":               "ms",
-		"Maltese":             "mt",
-		"Norwegian":           "no",
-		"Persian":             "fa",
-		"Polish":              "pl",
-		"Portuguese":          "pt",
-		"Romanian":            "ro",
-		"Russian":             "ru",
-		"Serbian":             "sr",
-		"Slovak":              "sk",
-		"Slovenian":           "sl",
-		"Spanish":             "es",
-		"Swahili":             "sw",
-		"Swedish":             "sv",
-		"Thai":                "th",
-		"Turkish":             "tr",
-		"Ukrainian":           "uk",
-		"Urdu":                "ur",
-		"Vietnamese":          "vi",
-		"Welsh":               "cy",
+		"Afrikaans":  "af",
+		"Albanian":   "sq",
+		"Arabic":     "ar",
+		"Basque":     "eu",
+		"Belarusian": "be",
+		"Bengali":    "bn",
+		"Bulgarian":  "bg",
+		"Catalan":    "ca",
+		"Chinese":    "zh",
+		"Croatian":   "hr",
+		"Czech":      "cs",
+		"Danish":     "da",
+		"Dutch":      "nl",
+		"English":    "en",
+		"Estonian":   "et",
+		"Finnish":    "fi",
+		"French":     "fr",
+		"Galician":   "gl",
+		"German":     "de",
+		"Greek":      "el",
+		"Hebrew":     "he",
+		"Hindi":      "hi",
+		"Hungarian":  "hu",
+		"Icelandic":  "is",
+		"Indonesian": "id",
+		"Irish":      "ga",
+		"Italian":    "it",
+		"Japanese":   "ja",
+		"Korean":     "ko",
+		"Latvian":    "lv",
+		"Lithuanian": "lt",
+		"Macedonian": "mk",
+		"Malay":      "ms",
+		"Maltese":    "mt",
+		"Norwegian":  "no",
+		"Persian":    "fa",
+		"Polish":     "pl",
+		"Portuguese": "pt",
+		"Romanian":   "ro",
+		"Russian":    "ru",
+		"Serbian":    "sr",
+		"Slovak":     "sk",
+		"Slovenian":  "sl",
+		"Spanish":    "es",
+		"Swahili":    "sw",
+		"Swedish":    "sv",
+		"Thai":       "th",
+		"Turkish":    "tr",
+		"Ukrainian":  "uk",
+		"Urdu":       "ur",
+		"Vietnamese": "vi",
+		"Welsh":      "cy",
 	}
 	if code, ok := codes[name]; ok {
 		return code
@@ -718,14 +718,14 @@ type hcGQLResponse struct {
 }
 
 type hcEdition struct {
-	ISBN13      string          `json:"isbn_13"`
-	ISBN10      string          `json:"isbn_10"`
-	PageCount   *int            `json:"pages"`
-	ReleaseDate string          `json:"release_date"`
-	Image       *hcImage        `json:"image"`
-	Publisher   *hcNameField    `json:"publisher"`
-	Language    *hcLanguage     `json:"language"`
-	Book        *hcBook         `json:"book"`
+	ISBN13      string       `json:"isbn_13"`
+	ISBN10      string       `json:"isbn_10"`
+	PageCount   *int         `json:"pages"`
+	ReleaseDate string       `json:"release_date"`
+	Image       *hcImage     `json:"image"`
+	Publisher   *hcNameField `json:"publisher"`
+	Language    *hcLanguage  `json:"language"`
+	Book        *hcBook      `json:"book"`
 }
 
 type hcImage struct {

--- a/internal/providers/books/hardcover_contributors.go
+++ b/internal/providers/books/hardcover_contributors.go
@@ -185,7 +185,6 @@ func (p *HardcoverProvider) FetchContributor(ctx context.Context, externalID str
 	return cd, nil
 }
 
-
 func parseHardcoverAuthorDocs(raw json.RawMessage) ([]hcAuthorSearchDoc, error) {
 	if len(raw) == 0 {
 		return nil, nil
@@ -240,11 +239,11 @@ type hcAuthorDetailResponse struct {
 }
 
 type hcAuthorDetail struct {
-	ID            int              `json:"id"`
-	Name          string           `json:"name"`
-	Bio           string           `json:"bio"`
-	Image         *hcImage         `json:"image"`
-	Contributions []hcAuthorBook   `json:"contributions"`
+	ID            int            `json:"id"`
+	Name          string         `json:"name"`
+	Bio           string         `json:"bio"`
+	Image         *hcImage       `json:"image"`
+	Contributions []hcAuthorBook `json:"contributions"`
 }
 
 type hcAuthorBook struct {

--- a/internal/providers/books/open_library_contributors.go
+++ b/internal/providers/books/open_library_contributors.go
@@ -187,7 +187,7 @@ func (p *OpenLibraryProvider) FetchContributor(ctx context.Context, externalID s
 type olAuthor struct {
 	Key       string          `json:"key"`
 	Name      string          `json:"name"`
-	Bio       json.RawMessage `json:"bio"`        // string or {"type":"...","value":"..."}
+	Bio       json.RawMessage `json:"bio"` // string or {"type":"...","value":"..."}
 	BirthDate string          `json:"birth_date"`
 	DeathDate string          `json:"death_date"`
 	Photos    []int64         `json:"photos"`
@@ -255,4 +255,3 @@ func olParsePersonDate(s string) *time.Time {
 	}
 	return nil
 }
-

--- a/internal/providers/manga/mangadex.go
+++ b/internal/providers/manga/mangadex.go
@@ -240,8 +240,8 @@ type mdResponse struct {
 }
 
 type mdManga struct {
-	ID           string          `json:"id"`
-	Attributes   mdMangaAttrs    `json:"attributes"`
+	ID            string           `json:"id"`
+	Attributes    mdMangaAttrs     `json:"attributes"`
 	Relationships []mdRelationship `json:"relationships"`
 }
 
@@ -266,9 +266,9 @@ type mdTagAttrs struct {
 }
 
 type mdRelationship struct {
-	Type       string         `json:"type"`
-	ID         string         `json:"id"`
-	Attributes *mdCoverAttrs  `json:"attributes,omitempty"`
+	Type       string        `json:"type"`
+	ID         string        `json:"id"`
+	Attributes *mdCoverAttrs `json:"attributes,omitempty"`
 }
 
 type mdCoverAttrs struct {
@@ -294,7 +294,7 @@ type mdChaptersResponse struct {
 }
 
 type mdChapterData struct {
-	ID         string             `json:"id"`
+	ID         string              `json:"id"`
 	Attributes mdChapterAttributes `json:"attributes"`
 }
 

--- a/internal/repository/ai_suggestions.go
+++ b/internal/repository/ai_suggestions.go
@@ -524,7 +524,7 @@ func (r *AISuggestionsRepo) ListNewSuggestionKeys(ctx context.Context, userID uu
 }
 
 // ListSuggestions returns the caller's current suggestions. Filter by type
-// ('buy' | 'read_next' | '' for all), status ('new' | '' for all), and
+// ('buy' | 'read_next' | empty for all), status ('new' | empty for all), and
 // optionally scope to a specific run (non-nil runID). When runID is set, the
 // status filter is ignored — scoped views surface every suggestion the run
 // produced, including ones the user later dismissed or saved.

--- a/internal/repository/api_tokens_test.go
+++ b/internal/repository/api_tokens_test.go
@@ -115,9 +115,9 @@ func TestAPITokenActive(t *testing.T) {
 	future := now.Add(1 * time.Hour)
 
 	cases := []struct {
-		name    string
-		tok     models.APIToken
-		wantOK  bool
+		name   string
+		tok    models.APIToken
+		wantOK bool
 	}{
 		{
 			name:   "fresh, no expiry",

--- a/internal/repository/books.go
+++ b/internal/repository/books.go
@@ -365,8 +365,8 @@ func (r *BookRepo) ListByContributor(ctx context.Context, libraryID, contributor
 // BookFingerprint summarizes the books collection in a library. Clients
 // compare this to a stored fingerprint to decide whether to resync.
 type BookFingerprint struct {
-	Total         int     `json:"total"`
-	MaxUpdatedAt  *string `json:"max_updated_at"` // RFC3339; nil when library is empty
+	Total        int     `json:"total"`
+	MaxUpdatedAt *string `json:"max_updated_at"` // RFC3339; nil when library is empty
 }
 
 // Fingerprint returns the total book count and the most recent updated_at
@@ -425,7 +425,7 @@ type FilterCondition struct {
 // ConditionGroup is a set of conditions with their own join mode.
 // Multiple groups in a query are always ANDed together at the top level.
 type ConditionGroup struct {
-	Mode       string            `json:"mode"`       // "AND" | "OR"
+	Mode       string            `json:"mode"` // "AND" | "OR"
 	Conditions []FilterCondition `json:"conditions"`
 }
 
@@ -433,12 +433,12 @@ type ListBooksOpts struct {
 	Query      string
 	Page       int
 	PerPage    int
-	Sort       string // "title" | "created_at" | "media_type"; default "title"
-	SortDir    string // "asc" | "desc"; default "asc"
-	Letter     string // single char: 'a'-'z' matches LIKE 'letter%'
-	TagFilter  string // filter to books that have a tag with this exact name (case-insensitive)
-	TypeFilter string // filter by media type display name (case-insensitive), e.g. "Novel"
-	IsRegex    bool   // if true, use b.title ~* $query instead of ILIKE
+	Sort       string           // "title" | "created_at" | "media_type"; default "title"
+	SortDir    string           // "asc" | "desc"; default "asc"
+	Letter     string           // single char: 'a'-'z' matches LIKE 'letter%'
+	TagFilter  string           // filter to books that have a tag with this exact name (case-insensitive)
+	TypeFilter string           // filter by media type display name (case-insensitive), e.g. "Novel"
+	IsRegex    bool             // if true, use b.title ~* $query instead of ILIKE
 	Groups     []ConditionGroup // from query language parser; groups are ANDed together
 	CallerID   uuid.UUID        // when non-zero, includes user_read_status for this user
 }

--- a/internal/repository/enrichment_batches.go
+++ b/internal/repository/enrichment_batches.go
@@ -237,8 +237,8 @@ func (r *EnrichmentBatchRepo) UpdateStatus(ctx context.Context, id uuid.UUID, st
 		WHERE  id = $1 AND status != 'cancelled'
 		RETURNING job_id, processed_books, failed_books, skipped_books, total_books`
 	var (
-		pgJobID                            pgtype.UUID
-		processed, failed, skipped, total  int
+		pgJobID                           pgtype.UUID
+		processed, failed, skipped, total int
 	)
 	if err := r.db.QueryRow(ctx, q, id, string(status)).Scan(&pgJobID, &processed, &failed, &skipped, &total); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -358,8 +358,8 @@ func (r *EnrichmentBatchRepo) Cancel(ctx context.Context, batchID, userID uuid.U
 		WHERE  id = $1 AND created_by = $2 AND status IN ('pending', 'processing')
 		RETURNING job_id, processed_books, failed_books, skipped_books, total_books`
 	var (
-		pgJobID                            pgtype.UUID
-		processed, failed, skipped, total  int
+		pgJobID                           pgtype.UUID
+		processed, failed, skipped, total int
 	)
 	if err := r.db.QueryRow(ctx, q, batchID, userID).Scan(&pgJobID, &processed, &failed, &skipped, &total); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {

--- a/internal/repository/jobs.go
+++ b/internal/repository/jobs.go
@@ -130,15 +130,15 @@ func (r *JobRepo) GetJob(ctx context.Context, id uuid.UUID) (*models.Job, error)
 
 // ListJobsOpts filters ListJobs. Zero-value = no filter for that field.
 type ListJobsOpts struct {
-	Kind      string      // empty = any kind
+	Kind string // empty = any kind
 	// Subtype only applies when Kind=='enrichment' — filters
 	// enrichment_batches.type so the UI can split Metadata vs Covers without
 	// exposing kind=enrichment&subtype=foo as a polluted filter combo.
 	Subtype   string
-	Status    string      // empty = any status
-	CreatedBy *uuid.UUID  // nil = any caller
-	Since     *time.Time  // nil = no time floor
-	Limit     int         // 0 = default 50
+	Status    string     // empty = any status
+	CreatedBy *uuid.UUID // nil = any caller
+	Since     *time.Time // nil = no time floor
+	Limit     int        // 0 = default 50
 	Offset    int
 }
 
@@ -425,9 +425,9 @@ func scanJob(s scanner) (*models.Job, error) {
 
 func scanSchedule(s scanner) (*models.JobSchedule, error) {
 	var (
-		pgID    pgtype.UUID
-		config  []byte
-		sched   models.JobSchedule
+		pgID   pgtype.UUID
+		config []byte
+		sched  models.JobSchedule
 	)
 	if err := s.Scan(
 		&pgID, &sched.Kind, &sched.Cron, &sched.Enabled, &config,

--- a/internal/repository/library_books.go
+++ b/internal/repository/library_books.go
@@ -111,11 +111,11 @@ func (r *LibraryBookRepo) FindLibraryBook(ctx context.Context, libraryID, bookID
 		FROM library_books
 		WHERE library_id = $1 AND book_id = $2`
 	var (
-		lb         models.LibraryBook
-		pgID       pgtype.UUID
-		pgLibID    pgtype.UUID
-		pgBookID   pgtype.UUID
-		pgAddedBy  pgtype.UUID
+		lb        models.LibraryBook
+		pgID      pgtype.UUID
+		pgLibID   pgtype.UUID
+		pgBookID  pgtype.UUID
+		pgAddedBy pgtype.UUID
 	)
 	err := r.db.QueryRow(ctx, q, libraryID, bookID).Scan(&pgID, &pgLibID, &pgBookID, &pgAddedBy, &lb.AddedAt)
 	if errors.Is(err, pgx.ErrNoRows) {

--- a/internal/repository/media_types.go
+++ b/internal/repository/media_types.go
@@ -57,8 +57,8 @@ func (r *MediaTypeRepo) Create(ctx context.Context, id uuid.UUID, name, displayN
 		VALUES ($1, $2, $3, $4)
 		RETURNING id, name, display_name, COALESCE(description, '')`
 	var (
-		pgID        pgtype.UUID
-		mt          models.MediaType
+		pgID pgtype.UUID
+		mt   models.MediaType
 	)
 	err := r.db.QueryRow(ctx, q, id, name, displayName, description).Scan(
 		&pgID, &mt.Name, &mt.DisplayName, &mt.Description,

--- a/internal/repository/series.go
+++ b/internal/repository/series.go
@@ -360,10 +360,10 @@ func (r *SeriesRepo) ListMatchCandidates(ctx context.Context, libraryID, seriesI
 	var out []*MatchCandidate
 	for rows.Next() {
 		var (
-			c            MatchCandidate
-			pgBookID     pgtype.UUID
-			otherJSON    []byte
-			otherParsed  []struct {
+			c           MatchCandidate
+			pgBookID    pgtype.UUID
+			otherJSON   []byte
+			otherParsed []struct {
 				SeriesID   string  `json:"series_id"`
 				SeriesName string  `json:"series_name"`
 				Position   float64 `json:"position"`
@@ -497,18 +497,18 @@ func (r *SeriesRepo) RemoveBook(ctx context.Context, seriesID, bookID uuid.UUID)
 
 func scanSeries(s scanner) (*models.Series, error) {
 	var (
-		pgID            pgtype.UUID
-		pgLibraryID     pgtype.UUID
-		pgTotal         pgtype.Int4
-		pgOrigLang      pgtype.Text
-		pgPubYear       pgtype.Int4
-		pgDemographic   pgtype.Text
-		genres          []string
-		pgLastDate      pgtype.Date
-		pgNextDate      pgtype.Date
-		previewJSON     []byte
-		tagsJSON        []byte
-		ser             models.Series
+		pgID          pgtype.UUID
+		pgLibraryID   pgtype.UUID
+		pgTotal       pgtype.Int4
+		pgOrigLang    pgtype.Text
+		pgPubYear     pgtype.Int4
+		pgDemographic pgtype.Text
+		genres        []string
+		pgLastDate    pgtype.Date
+		pgNextDate    pgtype.Date
+		previewJSON   []byte
+		tagsJSON      []byte
+		ser           models.Series
 	)
 	err := s.Scan(
 		&pgID, &pgLibraryID, &ser.Name, &ser.Description,

--- a/internal/repository/sync.go
+++ b/internal/repository/sync.go
@@ -70,17 +70,17 @@ func (r *SyncRepo) UserBookInteractionChanges(ctx context.Context, userID uuid.U
 	var ops []responses.SyncOp
 	for rows.Next() {
 		var (
-			id             uuid.UUID
-			rating         *int16
-			ratingTS       *time.Time
-			readStatus     string
-			readStatusTS   *time.Time
-			progressRaw    []byte
-			progressTS     *time.Time
-			isFavorite     bool
-			isFavoriteTS   *time.Time
-			updatedAt      time.Time
-			deletedAt      *time.Time
+			id           uuid.UUID
+			rating       *int16
+			ratingTS     *time.Time
+			readStatus   string
+			readStatusTS *time.Time
+			progressRaw  []byte
+			progressTS   *time.Time
+			isFavorite   bool
+			isFavoriteTS *time.Time
+			updatedAt    time.Time
+			deletedAt    *time.Time
 		)
 		if err := rows.Scan(
 			&id,

--- a/internal/service/ai.go
+++ b/internal/service/ai.go
@@ -274,14 +274,14 @@ func maskedConfig(fields []ConfigFieldView, cfg map[string]string) map[string]st
 type ConfigFieldView = ai.ConfigField
 
 type AIProviderStatus struct {
-	Name         string             `json:"name"`
-	DisplayName  string             `json:"display_name"`
-	Description  string             `json:"description"`
-	HelpText     string             `json:"help_text,omitempty"`
-	HelpURL      string             `json:"help_url,omitempty"`
-	ConfigFields []ConfigFieldView  `json:"config_fields"`
-	Enabled      bool               `json:"enabled"`
-	Active       bool               `json:"active"`
-	HasAPIKey    bool               `json:"has_api_key"`
-	Config       map[string]string  `json:"config,omitempty"`
+	Name         string            `json:"name"`
+	DisplayName  string            `json:"display_name"`
+	Description  string            `json:"description"`
+	HelpText     string            `json:"help_text,omitempty"`
+	HelpURL      string            `json:"help_url,omitempty"`
+	ConfigFields []ConfigFieldView `json:"config_fields"`
+	Enabled      bool              `json:"enabled"`
+	Active       bool              `json:"active"`
+	HasAPIKey    bool              `json:"has_api_key"`
+	Config       map[string]string `json:"config,omitempty"`
 }

--- a/internal/service/ai_suggestions.go
+++ b/internal/service/ai_suggestions.go
@@ -240,15 +240,15 @@ func (s *SuggestionsService) RunForUser(ctx context.Context, userID uuid.UUID, t
 	start := time.Now()
 
 	s.emit(ctx, runID, "pipeline_start", map[string]any{
-		"triggered_by":    triggeredBy,
-		"provider":        info.Name,
-		"model":           modelID,
-		"library_titles":  len(titles),
-		"blocks":          len(blocks),
-		"permissions":     perms,
-		"max_buy":         cfg.MaxBuyPerUser,
-		"max_read_next":   cfg.MaxReadNextPerUser,
-		"include_taste":   cfg.IncludeTasteProfile,
+		"triggered_by":   triggeredBy,
+		"provider":       info.Name,
+		"model":          modelID,
+		"library_titles": len(titles),
+		"blocks":         len(blocks),
+		"permissions":    perms,
+		"max_buy":        cfg.MaxBuyPerUser,
+		"max_read_next":  cfg.MaxReadNextPerUser,
+		"include_taste":  cfg.IncludeTasteProfile,
 	})
 	s.emit(ctx, runID, "prompt", map[string]any{
 		"pass":       "initial",
@@ -293,13 +293,13 @@ func (s *SuggestionsService) RunForUser(ctx context.Context, userID uuid.UUID, t
 	totalOut += resp.Usage.OutputTokens
 	totalCost += resp.Usage.EstimatedCostUSD
 	s.emit(ctx, runID, "ai_response", map[string]any{
-		"pass":             "initial",
-		"model":            resp.Usage.ModelID,
-		"text":             resp.Text,
-		"tokens_in":        resp.Usage.InputTokens,
-		"tokens_out":       resp.Usage.OutputTokens,
-		"cost_usd":         resp.Usage.EstimatedCostUSD,
-		"truncated":        resp.Truncated,
+		"pass":       "initial",
+		"model":      resp.Usage.ModelID,
+		"text":       resp.Text,
+		"tokens_in":  resp.Usage.InputTokens,
+		"tokens_out": resp.Usage.OutputTokens,
+		"cost_usd":   resp.Usage.EstimatedCostUSD,
+		"truncated":  resp.Truncated,
 	})
 
 	if err := s.checkCancelled(ctx, runID); err != nil {
@@ -378,10 +378,10 @@ func (s *SuggestionsService) RunForUser(ctx context.Context, userID uuid.UUID, t
 		if bfResp.Truncated {
 			slog.Warn("ai suggestions backfill truncated", "user_id", userID, "attempt", backfillAttempts, "max_tokens", cfg.MaxTokensBackfill)
 			s.emit(ctx, runID, "error", map[string]any{
-				"stage":     "ai_generate_backfill",
-				"attempt":   backfillAttempts,
-				"error":     fmt.Sprintf("backfill stopped at max_tokens (%d)", cfg.MaxTokensBackfill),
-				"reason":    "max_tokens",
+				"stage":   "ai_generate_backfill",
+				"attempt": backfillAttempts,
+				"error":   fmt.Sprintf("backfill stopped at max_tokens (%d)", cfg.MaxTokensBackfill),
+				"reason":  "max_tokens",
 			})
 			break
 		}
@@ -743,7 +743,7 @@ func (s *SuggestionsService) resolveFloatingBook(ctx context.Context, callerID u
 
 	if err := s.editions.Create(ctx, tx, editionID, bookID,
 		models.EditionFormatPaperback, // placeholder until real enrichment
-		meta.Language, "", "", // language, edition_name, narrator
+		meta.Language, "", "",         // language, edition_name, narrator
 		meta.Publisher, publishDate,
 		meta.ISBN10, meta.ISBN13, "", // description lives on book, not edition
 		nil,            // duration_seconds

--- a/internal/service/ai_suggestions_parser.go
+++ b/internal/service/ai_suggestions_parser.go
@@ -21,9 +21,9 @@ type ParsedSuggestion struct {
 
 // suggestionLinePattern parses lines of the shape:
 //
-//	1. Title — ISBN — Reason
-//	1) Title - 9781234567890 - Reason goes here
-//	- Title | ISBN-10 | reason text
+//  1. Title — ISBN — Reason
+//  1. Title - 9781234567890 - Reason goes here
+//     - Title | ISBN-10 | reason text
 //
 // All three separators (em-dash, hyphen-dash, pipe) are accepted. Leading list
 // numbering is optional. ISBN is captured only when it looks like an ISBN —

--- a/internal/service/edition_files.go
+++ b/internal/service/edition_files.go
@@ -97,11 +97,11 @@ func resolveTemplate(tmpl string, book *models.Book, edition *models.BookEdition
 	}
 
 	replacer := strings.NewReplacer(
-		"{title}",   sanitizeName(book.Title),
-		"{author}",  sanitizeName(author),
-		"{year}",    year,
-		"{isbn13}",  edition.ISBN13,
-		"{isbn10}",  edition.ISBN10,
+		"{title}", sanitizeName(book.Title),
+		"{author}", sanitizeName(author),
+		"{year}", year,
+		"{isbn13}", edition.ISBN13,
+		"{isbn10}", edition.ISBN10,
 		"{edition}", sanitizeName(edition.EditionName),
 	)
 	result := replacer.Replace(tmpl)

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -18,31 +18,31 @@ import (
 // ─── Styles ──────────────────────────────────────────────────────────────────
 
 var (
-	styleBorder   = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color("240"))
-	styleTitle    = lipgloss.NewStyle().Foreground(lipgloss.Color("99")).Bold(true)
-	styleDim      = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
-	styleBar      = lipgloss.NewStyle().Foreground(lipgloss.Color("63"))  // soft purple
-	styleBarPeak  = lipgloss.NewStyle().Foreground(lipgloss.Color("99"))  // bright purple for recent
-	styleAxisLine = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
-	styleDebug    = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
-	styleInfo     = lipgloss.NewStyle().Foreground(lipgloss.Color("252"))
-	styleWarn     = lipgloss.NewStyle().Foreground(lipgloss.Color("214")).Bold(true)
-	styleError    = lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Bold(true)
-	style2xx      = lipgloss.NewStyle().Foreground(lipgloss.Color("82"))
-	style3xx      = lipgloss.NewStyle().Foreground(lipgloss.Color("81"))
-	style4xx      = lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
-	style5xx      = lipgloss.NewStyle().Foreground(lipgloss.Color("196"))
-	styleMethod   = lipgloss.NewStyle().Foreground(lipgloss.Color("39"))
-	styleTimeCol  = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
-	styleClient   = lipgloss.NewStyle().Foreground(lipgloss.Color("141")) // soft lavender
-	styleIP       = lipgloss.NewStyle().Foreground(lipgloss.Color("248"))
+	styleBorder    = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color("240"))
+	styleTitle     = lipgloss.NewStyle().Foreground(lipgloss.Color("99")).Bold(true)
+	styleDim       = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+	styleBar       = lipgloss.NewStyle().Foreground(lipgloss.Color("63")) // soft purple
+	styleBarPeak   = lipgloss.NewStyle().Foreground(lipgloss.Color("99")) // bright purple for recent
+	styleAxisLine  = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+	styleDebug     = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+	styleInfo      = lipgloss.NewStyle().Foreground(lipgloss.Color("252"))
+	styleWarn      = lipgloss.NewStyle().Foreground(lipgloss.Color("214")).Bold(true)
+	styleError     = lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Bold(true)
+	style2xx       = lipgloss.NewStyle().Foreground(lipgloss.Color("82"))
+	style3xx       = lipgloss.NewStyle().Foreground(lipgloss.Color("81"))
+	style4xx       = lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
+	style5xx       = lipgloss.NewStyle().Foreground(lipgloss.Color("196"))
+	styleMethod    = lipgloss.NewStyle().Foreground(lipgloss.Color("39"))
+	styleTimeCol   = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+	styleClient    = lipgloss.NewStyle().Foreground(lipgloss.Color("141")) // soft lavender
+	styleIP        = lipgloss.NewStyle().Foreground(lipgloss.Color("248"))
 	styleMark      = lipgloss.NewStyle().Foreground(lipgloss.Color("226")).Bold(true) // bright yellow
 	styleScroll    = lipgloss.NewStyle().Foreground(lipgloss.Color("214"))            // orange scroll indicator
 	styleQueueIdle = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
 	styleProgress  = lipgloss.NewStyle().Foreground(lipgloss.Color("63"))
 	styleProgressD = lipgloss.NewStyle().Foreground(lipgloss.Color("237"))
-	styleRunning   = lipgloss.NewStyle().Foreground(lipgloss.Color("82"))             // green ► running
-	stylePending   = lipgloss.NewStyle().Foreground(lipgloss.Color("214"))            // orange ● waiting
+	styleRunning   = lipgloss.NewStyle().Foreground(lipgloss.Color("82"))  // green ► running
+	stylePending   = lipgloss.NewStyle().Foreground(lipgloss.Color("214")) // orange ● waiting
 )
 
 // sub-block runes: index 0 = empty, 1-8 = ▁▂▃▄▅▆▇█
@@ -390,7 +390,7 @@ func renderBarChart(buckets []int, height, maxVal int) []string {
 	rows := make([]string, height)
 	for row := 0; row < height; row++ {
 		// row 0 = topmost display row, row height-1 = bottommost
-		level := height - 1 - row // 0 at bottom, height-1 at top
+		level := height - 1 - row  // 0 at bottom, height-1 at top
 		floor := level * 8         // sub-units at cell bottom
 		ceiling := (level + 1) * 8 // sub-units at cell top
 
@@ -515,7 +515,7 @@ func hScrollLine(s string, skip int) string {
 		return s
 	}
 	var out strings.Builder
-	vis := 0     // visible columns counted so far
+	vis := 0 // visible columns counted so far
 	inEsc := false
 	inCSI := false
 	for _, r := range s {

--- a/internal/workers/import_worker.go
+++ b/internal/workers/import_worker.go
@@ -219,11 +219,11 @@ func (w *ImportWorker) spawnEnrichmentBatch(
 
 	libraryID := importJob.LibraryID
 	batch := &models.EnrichmentBatch{
-		ID:           batchID,
-		LibraryID:    &libraryID,
-		CreatedBy:    importJob.CreatedBy,
-		Type:         batchType,
-		Force:        false,
+		ID:        batchID,
+		LibraryID: &libraryID,
+		CreatedBy: importJob.CreatedBy,
+		Type:      batchType,
+		Force:     false,
 		// AI cleanup applies to metadata batches only; cover-only batches don't
 		// touch description text.
 		UseAICleanup: batchType == models.EnrichmentBatchTypeMetadata && importJob.Options.UseAICleanup,


### PR DESCRIPTION
`main` had 39 files failing gofmt and CI never checked, so editors that format on save were rewriting whole files on contact and outside PRs arrived carrying hundreds of lines of unrelated whitespace churn.

- Enables the gofmt formatter in `.golangci.yml`, so the existing lint step now fails on unformatted code. Verified it catches a deliberately misformatted file.
- One isolated sweep commit with `golangci-lint fmt`, listed in a new `.git-blame-ignore-revs` so blame skips it.
- Whitespace only apart from two doc comments Go's comment formatter rewrote; the `''` in `ai_suggestions.go` became a curly quote, so the empty-string filter is spelled out as a word instead.