### PR TITLE
chore: ignore the gofmt sweep in git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,10 @@
+# Revisions to skip when running `git blame`.
+#
+# GitHub reads this file automatically. Locally, opt in once with:
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+# Only pure-formatting commits belong here. Never add a commit that changes
+# behaviour, or blame will quietly point at the wrong author.
+
+# ci: gate formatting with gofmt, and bring the tree to a clean baseline (#52)
+c1243b9481c0ba847f0e7b3d6a390abb59c66130


### PR DESCRIPTION
Follow-up to #52. Adds `.git-blame-ignore-revs` pointing at the squashed formatting commit, so blame on those 39 files skips it and lands on the last real change. GitHub picks this up automatically; locally it needs `git config blame.ignoreRevsFile .git-blame-ignore-revs` once.