### PR TITLE
fix(providers): bound the ISBNdb and MangaDex HTTP clients

### DIFF
--- a/internal/providers/books/client_timeout_test.go
+++ b/internal/providers/books/client_timeout_test.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725 (Adaléa)
+
+package books
+
+import (
+	"net/http"
+	"testing"
+)
+
+// TestProviderClientsAreBounded pins the BookSearchProvider contract: every
+// provider must bound its own HTTP calls.
+//
+// Registry.SearchBooks starts its deadline only after some provider has
+// already responded, so before the first result the sole backstops are a
+// provider returning and the request context being cancelled. A provider
+// built on a zero-value http.Client has no timeout at all, and one hung
+// connection then stalls every search that includes it for as long as the
+// caller is willing to wait.
+//
+// ISBNdb doesn't implement SearchBooks today, so it isn't on that path yet.
+// It's covered here anyway — the cost of a timeout is nothing, and the cost
+// of remembering this rule when adding SearchBooks later is where bugs live.
+func TestProviderClientsAreBounded(t *testing.T) {
+	cases := []struct {
+		name   string
+		client *http.Client
+	}{
+		{"google_books", NewGoogleBooksProvider().client},
+		{"hardcover", NewHardcoverProvider().client},
+		{"isbndb", NewISBNdbProvider().client},
+		{"open_library", NewOpenLibraryProvider().client},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.client == nil {
+				t.Fatal("provider has a nil http.Client")
+			}
+			if tc.client.Timeout <= 0 {
+				t.Errorf("http.Client has no timeout; an unbounded provider stalls every search it takes part in")
+			}
+		})
+	}
+}

--- a/internal/providers/books/isbndb.go
+++ b/internal/providers/books/isbndb.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/fireball1725/librarium-api/internal/providers"
 )
@@ -23,7 +24,7 @@ type ISBNdbProvider struct {
 func NewISBNdbProvider() *ISBNdbProvider {
 	return &ISBNdbProvider{
 		base:   base{enabled: false},
-		client: &http.Client{},
+		client: &http.Client{Timeout: 15 * time.Second},
 	}
 }
 

--- a/internal/providers/manga/client_timeout_test.go
+++ b/internal/providers/manga/client_timeout_test.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725 (Adaléa)
+
+package manga
+
+import "testing"
+
+// TestMangaDexClientIsBounded — see the BookSearchProvider doc comment in
+// internal/providers/provider.go. MangaDex only does series lookups today,
+// but a zero-value http.Client never gives up on a hung connection, and
+// that's not a property worth relying on staying off the search path.
+func TestMangaDexClientIsBounded(t *testing.T) {
+	c := NewMangaDexProvider().client
+	if c == nil {
+		t.Fatal("provider has a nil http.Client")
+	}
+	if c.Timeout <= 0 {
+		t.Error("http.Client has no timeout")
+	}
+}

--- a/internal/providers/manga/mangadex.go
+++ b/internal/providers/manga/mangadex.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"sort"
 	"strconv"
+	"time"
 
 	"github.com/fireball1725/librarium-api/internal/providers"
 )
@@ -25,7 +26,7 @@ type MangaDexProvider struct {
 
 func NewMangaDexProvider() *MangaDexProvider {
 	return &MangaDexProvider{
-		client:  &http.Client{},
+		client:  &http.Client{Timeout: 15 * time.Second},
 		enabled: true, // enabled by default (free, no key)
 	}
 }

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -89,6 +89,13 @@ type BookISBNProvider interface {
 }
 
 // BookSearchProvider can search for books by freetext query.
+//
+// Implementations must bound SearchBooks themselves, via an http.Client
+// Timeout or equivalent. Registry.SearchBooks only starts its deadline once
+// some provider has already responded, so before the first result the only
+// things that can end the wait are a provider returning and the request
+// context being cancelled. A provider that can hang indefinitely holds up
+// every search that includes it.
 type BookSearchProvider interface {
 	MetadataProvider
 	SearchBooks(ctx context.Context, query string) ([]*BookResult, error)


### PR DESCRIPTION
Follow-up to #51. Both providers were built on a zero-value `http.Client`, which never gives up on a hung connection.

- Neither implements `SearchBooks`, so neither is reachable from `Registry.SearchBooks` today. #51 made that deadline start only after some provider has responded, so an unbounded provider on that path would stall every search including it until the request context is cancelled. This closes the gap before a future provider walks into it.
- Documents the requirement on `BookSearchProvider` and adds a test per package. Confirmed the tests fail against the pre-fix files with the intended assertion, not a build error.