### PR TITLE
feat(ai): optional API key for the Ollama provider

### DIFF
--- a/internal/ai/ollama.go
+++ b/internal/ai/ollama.go
@@ -25,10 +25,16 @@ const (
 )
 
 // OllamaProvider calls a local or self-hosted Ollama instance via /api/chat.
-// No API key — the server is trusted by virtue of being on the user's network.
+//
+// Ollama itself has no auth, but it's often reached through something that
+// does: a reverse proxy, or a management front end like Ollama Admin, whose
+// path-preserving /api/proxy gateway forwards to the real server and requires
+// a bearer token of its own. apiKey is optional and only sent when set, so a
+// bare Ollama on the local network keeps working untouched.
 type OllamaProvider struct {
 	base
 	baseURL string
+	apiKey  string
 	model   string
 	client  *http.Client
 }
@@ -46,7 +52,7 @@ func (p *OllamaProvider) Info() ProviderInfo {
 	return ProviderInfo{
 		Name:        "ollama",
 		DisplayName: "Ollama",
-		Description: "Local LLM inference via Ollama. No API key, no per-request cost.",
+		Description: "Local LLM inference via Ollama. No per-request cost.",
 		HelpText:    "Point this at a running Ollama server (default http://localhost:11434) and name a model you've pulled locally (e.g. llama3, mistral, qwen2).",
 		HelpURL:     "https://ollama.com/",
 		ConfigFields: []ConfigField{
@@ -59,6 +65,14 @@ func (p *OllamaProvider) Info() ProviderInfo {
 				Placeholder: defaultOllamaModel,
 				HelpText:    "Any model you've pulled locally. Run `ollama list` on the Ollama host to see what's available.",
 			},
+			{
+				Key:         "api_key",
+				Label:       "API key (optional)",
+				Type:        "password",
+				Required:    false,
+				Placeholder: "only if fronted by an auth proxy",
+				HelpText:    "Sent as `Authorization: Bearer <key>`. Leave blank for a bare Ollama server. Needed when the base URL points at a gateway that authenticates, e.g. Ollama Admin's /api/proxy.",
+			},
 		},
 	}
 }
@@ -70,6 +84,7 @@ func (p *OllamaProvider) Configure(cfg map[string]string) {
 	if p.baseURL == "" {
 		p.baseURL = defaultOllamaBaseURL
 	}
+	p.apiKey = cfg["api_key"]
 	if m, ok := cfg["model"]; ok && m != "" {
 		p.model = m
 	}
@@ -118,6 +133,9 @@ func (p *OllamaProvider) Generate(ctx context.Context, req GenerateRequest) (*Ge
 		return nil, err
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
+	if p.apiKey != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+p.apiKey)
+	}
 
 	// Ollama can hang for a long time: the model may still be loading, a dead
 	// TCP connection from the pool may need to time out, or a thinking model
@@ -200,6 +218,9 @@ func (p *OllamaProvider) ListModels(ctx context.Context) ([]OllamaModel, error) 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, p.baseURL+"/api/tags", nil)
 	if err != nil {
 		return nil, err
+	}
+	if p.apiKey != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+p.apiKey)
 	}
 
 	resp, err := p.client.Do(httpReq)

--- a/internal/ai/ollama_test.go
+++ b/internal/ai/ollama_test.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725 (Adaléa)
+
+package ai
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// newOllamaTestServer stands up a fake Ollama that records the Authorization
+// header of the last request it saw and answers both endpoints the provider
+// calls. Returns the provider pointed at it and a pointer to the captured
+// header, so a test can assert on what actually went over the wire rather
+// than on the struct field.
+func newOllamaTestServer(t *testing.T, cfg map[string]string) (*OllamaProvider, *string) {
+	t.Helper()
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/chat":
+			_, _ = w.Write([]byte(`{"message":{"role":"assistant","content":"ok"},"done_reason":"stop"}`))
+		case "/api/tags":
+			_, _ = w.Write([]byte(`{"models":[]}`))
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	p := NewOllamaProvider()
+	full := map[string]string{"base_url": srv.URL, "model": "llama3"}
+	for k, v := range cfg {
+		full[k] = v
+	}
+	p.Configure(full)
+	return p, &gotAuth
+}
+
+// An Ollama fronted by something that authenticates (Ollama Admin's
+// path-preserving /api/proxy, a reverse proxy) rejects an unauthenticated
+// call outright, so the key has to reach both endpoints, not just chat.
+func TestOllamaSendsBearerTokenOnBothEndpoints(t *testing.T) {
+	const key = "oa-test-key"
+
+	t.Run("generate", func(t *testing.T) {
+		p, gotAuth := newOllamaTestServer(t, map[string]string{"api_key": key})
+		if _, err := p.Generate(context.Background(), GenerateRequest{Prompt: "hi"}); err != nil {
+			t.Fatalf("Generate: %v", err)
+		}
+		if want := "Bearer " + key; *gotAuth != want {
+			t.Errorf("Authorization = %q, want %q", *gotAuth, want)
+		}
+	})
+
+	t.Run("list models", func(t *testing.T) {
+		p, gotAuth := newOllamaTestServer(t, map[string]string{"api_key": key})
+		if _, err := p.ListModels(context.Background()); err != nil {
+			t.Fatalf("ListModels: %v", err)
+		}
+		if want := "Bearer " + key; *gotAuth != want {
+			t.Errorf("Authorization = %q, want %q", *gotAuth, want)
+		}
+	})
+}
+
+// A bare Ollama on the LAN has no auth. Sending an empty bearer token would
+// be worse than sending nothing, so the header must be absent entirely.
+func TestOllamaOmitsAuthorizationWithoutKey(t *testing.T) {
+	p, gotAuth := newOllamaTestServer(t, nil)
+	if _, err := p.Generate(context.Background(), GenerateRequest{Prompt: "hi"}); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if *gotAuth != "" {
+		t.Errorf("Authorization = %q, want no header at all", *gotAuth)
+	}
+}
+
+// The key is declared password-typed so GET /admin/ai/providers masks it.
+// Without this the settings page would echo the token back in the clear.
+func TestOllamaAPIKeyFieldIsPasswordTyped(t *testing.T) {
+	var found bool
+	for _, f := range NewOllamaProvider().Info().ConfigFields {
+		if f.Key != "api_key" {
+			continue
+		}
+		found = true
+		if f.Type != "password" {
+			t.Errorf("api_key field type = %q, want password", f.Type)
+		}
+		if f.Required {
+			t.Error("api_key must stay optional; a bare Ollama has no key")
+		}
+	}
+	if !found {
+		t.Fatal("no api_key config field declared")
+	}
+}


### PR DESCRIPTION
Ollama has no auth of its own, but it's often reached through something that does, and the provider had no way to send a token. Pointing it at a gateway like Ollama Admin's `/api/proxy` got a 401 on every call.

- Adds an optional password-typed `api_key` config field, sent as `Authorization: Bearer <key>` on both `/api/chat` and `/api/tags`. Only sent when set, so a bare Ollama on the LAN is unaffected.
- Mirrors the `osaurus` provider, which already carried this for the same reason.
- First tests in `internal/ai`: they assert on the header that actually goes over the wire via `httptest`, cover both endpoints and the no-key case, and pin the field as password-typed so the settings page keeps masking it.