### PR TITLE
fix(dashboard): give read books a date_finished

### DIFF
--- a/internal/db/migrations/000022_backfill_date_finished.down.sql
+++ b/internal/db/migrations/000022_backfill_date_finished.down.sql
@@ -1,0 +1,16 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Copyright (C) 2026 fireball1725
+--
+-- Deliberately a no-op.
+--
+-- The up migration writes a date onto rows that had none. Reversing it would
+-- mean nulling date_finished for read books, and nothing here distinguishes a
+-- date this backfill wrote from one the user typed in afterwards. That query
+-- would destroy real data to undo a guess.
+--
+-- Rolling back past this point leaves the backfilled dates in place. They stay
+-- harmless: the pre-000022 dashboard reads COALESCE(date_finished, updated_at)
+-- and the backfilled value is the same value that COALESCE was already
+-- returning, so the numbers do not change on the way down either.
+
+SELECT 1;

--- a/internal/db/migrations/000022_backfill_date_finished.up.sql
+++ b/internal/db/migrations/000022_backfill_date_finished.up.sql
@@ -1,0 +1,29 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Copyright (C) 2026 fireball1725
+--
+-- Gives every already-read book a date_finished, so the dashboard can stop
+-- falling back to updated_at at query time.
+--
+-- The dashboard currently reads COALESCE(date_finished, updated_at). That is
+-- wrong as a query: updated_at moves whenever the row is written for any
+-- reason, so an import or a metadata refresh silently drags an old book into
+-- "read this year", and does it again on the next write. Nothing sets
+-- date_finished when a book is marked read from the UI, so a large share of
+-- rows depend on that fallback.
+--
+-- Dropping the fallback without this backfill would empty out "read this
+-- year", the twelve-month sparkline, and "recently finished" for anyone who
+-- marked books read without typing a date.
+--
+-- Using updated_at once, here, is a different thing from using it at query
+-- time. This is a one-time best guess at history that was never recorded,
+-- frozen at the value the dashboard is already showing today, so the numbers
+-- do not move. Query-time COALESCE keeps re-deciding the answer forever.
+--
+-- Only rows that are actually finished and have no date are touched. A row
+-- with a real date_finished is left alone.
+
+UPDATE user_book_interactions
+SET date_finished = updated_at::date
+WHERE read_status = 'read'
+  AND date_finished IS NULL;

--- a/internal/repository/editions.go
+++ b/internal/repository/editions.go
@@ -280,14 +280,21 @@ func (r *EditionRepo) UpsertInteraction(ctx context.Context, userID, editionID u
 		INSERT INTO user_book_interactions
 			(id, user_id, book_edition_id, read_status, rating, notes, review, date_started, date_finished, is_favorite, progress)
 		VALUES
-			($1, $2, $3, $4, $5, NULLIF($6,''), NULLIF($7,''), $8, $9, $10, $11)
+			($1, $2, $3, $4, $5, NULLIF($6,''), NULLIF($7,''), $8,
+			 COALESCE($9, CASE WHEN $4 = 'read' THEN CURRENT_DATE END), $10, $11)
 		ON CONFLICT (user_id, book_edition_id) DO UPDATE
 		SET read_status   = EXCLUDED.read_status,
 		    rating        = EXCLUDED.rating,
 		    notes         = EXCLUDED.notes,
 		    review        = EXCLUDED.review,
 		    date_started  = EXCLUDED.date_started,
-		    date_finished = EXCLUDED.date_finished,
+		    -- Marking a book read without naming a day stamps today. The
+		    -- dashboard counts finished books by date_finished alone, so a
+		    -- read row with no date is invisible to it. See migration 000022.
+		    date_finished = COALESCE(
+		        EXCLUDED.date_finished,
+		        CASE WHEN EXCLUDED.read_status = 'read' THEN CURRENT_DATE END
+		    ),
 		    is_favorite   = EXCLUDED.is_favorite,
 		    progress      = EXCLUDED.progress,
 		    updated_at    = NOW()
@@ -330,14 +337,23 @@ func (r *EditionRepo) MergeInteraction(
 		INSERT INTO user_book_interactions
 			(id, user_id, book_edition_id, read_status, rating, notes, review, date_started, date_finished, is_favorite, progress)
 		VALUES
-			($1, $2, $3, COALESCE(NULLIF($4,''),''), $5, NULLIF($6,''), NULLIF($7,''), $8, $9, COALESCE($10, false), $11)
+			($1, $2, $3, COALESCE(NULLIF($4,''),''), $5, NULLIF($6,''), NULLIF($7,''), $8,
+			 COALESCE($9, CASE WHEN NULLIF($4,'') = 'read' THEN CURRENT_DATE END), COALESCE($10, false), $11)
 		ON CONFLICT (user_id, book_edition_id) DO UPDATE
 		SET read_status   = COALESCE(NULLIF(EXCLUDED.read_status,''), user_book_interactions.read_status),
 		    rating        = COALESCE(EXCLUDED.rating, user_book_interactions.rating),
 		    notes         = COALESCE(EXCLUDED.notes, user_book_interactions.notes),
 		    review        = COALESCE(EXCLUDED.review, user_book_interactions.review),
 		    date_started  = COALESCE(EXCLUDED.date_started, user_book_interactions.date_started),
-		    date_finished = COALESCE(EXCLUDED.date_finished, user_book_interactions.date_finished),
+		    -- Same rule as UpsertInteraction: a row that ends up read with no
+		    -- date gets today, so the dashboard can see it. Only fires on the
+		    -- transition, since an existing date_finished wins first.
+		    date_finished = COALESCE(
+		        EXCLUDED.date_finished,
+		        user_book_interactions.date_finished,
+		        CASE WHEN COALESCE(NULLIF(EXCLUDED.read_status,''), user_book_interactions.read_status) = 'read'
+		             THEN CURRENT_DATE END
+		    ),
 		    is_favorite   = COALESCE($10, user_book_interactions.is_favorite),
 		    progress      = COALESCE(EXCLUDED.progress, user_book_interactions.progress),
 		    updated_at    = NOW()


### PR DESCRIPTION
Prerequisite for #48. That PR correctly drops the `COALESCE(date_finished, updated_at)` fallback from the dashboard queries, but nothing in the codebase sets `date_finished` when a book is marked read from the UI, so merging it alone would empty out "read this year", the twelve-month sparkline, and "recently finished" for existing users.

- Migration `000022` backfills `date_finished` from `updated_at` for read rows that have none. Using `updated_at` once as a backfill is different from using it at query time: it is a one-time guess at history nobody recorded, frozen at the value the dashboard already displays, so no number changes when this lands. The down migration is a deliberate no-op, since nothing distinguishes a backfilled date from one the user typed afterwards.
- Both upsert paths in `editions.go` now stamp `CURRENT_DATE` when a row ends up read with no date, so new rows stop recreating the problem.

Verified against Postgres 16 rather than by eye: the backfill updates only read rows with a null date and leaves a real `2019-07-01` alone; a new read row gets today; a `reading` row stays null; an explicit date beats the stamp; and a merge update touching only the rating leaves the date put.

Note for #46: this takes migration number `000022`, so `000022_import_needs_review` will need renumbering to `000023`.

Merge order: this, then #48.