### PR TITLE
docs: link the README back to fireball1725.ca

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,9 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md). PRs must sign off on the [Developer Ce
 ## License
 
 AGPL-3.0-only. See [LICENSE](./LICENSE) for the full text.
+
+## Who builds this
+
+Created and maintained by [FireBall1725](https://fireball1725.ca) in Ontario, Canada. More projects and writing there, including [why Librarium exists](https://fireball1725.ca/blog/why-i-wrote-librarium).
+
+Patches welcome; see [CONTRIBUTING.md](./CONTRIBUTING.md). Everyone who has landed code is on the [contributors list](https://github.com/fireball1725/librarium-api/graphs/contributors).


### PR DESCRIPTION
Adds a short "Who builds this" section. The READMEs linked to librarium.press in several places and to the person building it nowhere.

Points at the [contributors list](https://github.com/fireball1725/librarium-api/graphs/contributors) rather than naming people, so it stays correct as that list grows. All links verified 200.