### PR TITLE
Drop the cancelled Plus tier from the README, add the Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # librarium-api
 
-The backend service for **[Librarium](https://librarium.press)**, a self-hosted, privacy-focused tracker for your physical book, manga, and comic collection. A self-hosted alternative to Libib and similar cloud catalog services. iOS Lite and Librarium Plus (hosted) are on the roadmap.
+The backend service for **[Librarium](https://librarium.press)**, a self-hosted, privacy-focused tracker for your physical book, manga, and comic collection. A self-hosted alternative to Libib and similar cloud catalog services. Free and AGPL 3.0; there is no paid tier. iOS Lite is next up.
 
 Go 1.25 · PostgreSQL 16 · [River](https://riverqueue.com) for background jobs · Swagger-generated OpenAPI docs.
+
+Questions, updates, and works in progress: [FireBall Codes on Discord](https://discord.gg/QpV82CFfVD).
 
 > ⚠︎ **Early beta.** Things are changing fast, some edges are rough, and self-hosters should expect to read release notes before upgrading.
 


### PR DESCRIPTION
Plus was cancelled: running a hosted service means being on call for other people's servers. The README was still listing it as on the roadmap.

- Editions are two and both free. The answer for people who do not want to run a server is a cloud host running the same containers, with deploy templates on the way.
- Adds the FireBall Codes Discord near the top, before the beta callout, where someone with a problem will see it rather than after the install instructions.