### PR TITLE
Deploy rc and stable to the homelab automatically

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,4 +37,7 @@ jobs:
       channel: ${{ inputs.channel }}
       dry-run: ${{ inputs.dry-run }}
       force-version: ${{ inputs.force-version }}
+      # rc and stable pin themselves into homelab-applications via an
+      # auto-merging PR. Nightly never deploys, whatever this says.
+      deploy-app: librarium-api
     secrets: inherit


### PR DESCRIPTION
Sets `deploy-app` so a release writes its new tag into `homelab-applications` through an auto-merging PR, and ArgoCD picks it up.

Also keeps `Chart.yaml` `appVersion` in step with `image.tag`, which had drifted.

**Nightly never deploys** — enforced in the shared workflow.