### PR TITLE
Carry reading progress through a CSV import

### DIFF
--- a/internal/imports/normalize.go
+++ b/internal/imports/normalize.go
@@ -15,7 +15,9 @@
 package imports
 
 import (
+	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -140,4 +142,48 @@ func Bool(raw string) (bool, bool) {
 		return false, true
 	}
 	return false, false
+}
+
+// Progress builds the `{pages_read?, percent?, position?}` JSON blob a
+// `user_book_interactions.progress` column holds, from up to three CSV
+// columns. Returns (nil, false) when nothing usable is present, which
+// the caller passes straight through to MergeInteraction to leave an
+// existing value alone.
+//
+// This exists because a Lite library carries reading positions that had
+// no import column: migrating a shelf to a server used to silently drop
+// every part-read book back to page zero.
+func Progress(pagesRead, percent, position string) ([]byte, bool) {
+	out := map[string]any{}
+
+	if v := strings.TrimSpace(pagesRead); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			out["pages_read"] = n
+		}
+	}
+
+	if v := strings.TrimSpace(percent); v != "" {
+		// Accept "45", "45%", and "45.5" — trackers are inconsistent and
+		// a stray percent sign should not cost someone their place.
+		v = strings.TrimSuffix(v, "%")
+		v = strings.TrimSpace(v)
+		if f, err := strconv.ParseFloat(v, 64); err == nil && f > 0 && f <= 100 {
+			out["percent"] = f
+		}
+	}
+
+	// Free text: an audiobook timestamp, a chapter, a Kindle location.
+	// No shape to validate beyond it being present.
+	if v := strings.TrimSpace(position); v != "" {
+		out["position"] = v
+	}
+
+	if len(out) == 0 {
+		return nil, false
+	}
+	encoded, err := json.Marshal(out)
+	if err != nil {
+		return nil, false
+	}
+	return encoded, true
 }

--- a/internal/imports/normalize_test.go
+++ b/internal/imports/normalize_test.go
@@ -4,6 +4,7 @@
 package imports
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 )
@@ -175,5 +176,73 @@ func TestBool(t *testing.T) {
 	got, ok := Bool("maybe")
 	if ok || got {
 		t.Errorf("Bool(\"maybe\") = (%v, %v), want (false, false)", got, ok)
+	}
+}
+
+func TestProgressParsesEachField(t *testing.T) {
+	raw, ok := Progress("142", "45", "chapter 9")
+	if !ok {
+		t.Fatal("expected a progress blob")
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got["pages_read"] != float64(142) {
+		t.Errorf("pages_read = %v, want 142", got["pages_read"])
+	}
+	if got["percent"] != float64(45) {
+		t.Errorf("percent = %v, want 45", got["percent"])
+	}
+	if got["position"] != "chapter 9" {
+		t.Errorf("position = %v, want chapter 9", got["position"])
+	}
+}
+
+// A stray percent sign should not cost someone their reading position.
+func TestProgressTolerantOfPercentSign(t *testing.T) {
+	raw, ok := Progress("", "62.5%", "")
+	if !ok {
+		t.Fatal("expected a progress blob")
+	}
+	var got map[string]any
+	_ = json.Unmarshal(raw, &got)
+	if got["percent"] != 62.5 {
+		t.Errorf("percent = %v, want 62.5", got["percent"])
+	}
+}
+
+// Empty means "no data", not "reset to zero". Returning a blob here
+// would overwrite a real position on the server with an empty one.
+func TestProgressEmptyReturnsNothing(t *testing.T) {
+	if raw, ok := Progress("", "", ""); ok || raw != nil {
+		t.Errorf("Progress(empty) = (%s, %v), want (nil, false)", raw, ok)
+	}
+}
+
+func TestProgressRejectsNonsense(t *testing.T) {
+	cases := [][3]string{
+		{"0", "", ""},   // page zero is not progress
+		{"-5", "", ""},  // negative pages
+		{"abc", "", ""}, // unparseable
+		{"", "0", ""},   // zero percent is not progress
+		{"", "140", ""}, // over 100
+		{"", "not a number", ""},
+	}
+	for _, c := range cases {
+		if raw, ok := Progress(c[0], c[1], c[2]); ok {
+			t.Errorf("Progress(%q, %q, %q) = %s, want rejected", c[0], c[1], c[2], raw)
+		}
+	}
+}
+
+// Partial input is still worth keeping: a percent with no page count is
+// exactly what an ebook or audiobook row looks like.
+func TestProgressAcceptsPartialInput(t *testing.T) {
+	if _, ok := Progress("", "", "03:14:22"); !ok {
+		t.Error("expected an audiobook position alone to be accepted")
+	}
+	if _, ok := Progress("88", "", ""); !ok {
+		t.Error("expected a page count alone to be accepted")
 	}
 }

--- a/internal/workers/import_worker.go
+++ b/internal/workers/import_worker.go
@@ -544,11 +544,14 @@ func (w *ImportWorker) applyInteraction(ctx context.Context, editionID, userID u
 	startedAt, hasStarted := imports.Date(row["date_started"])
 	finishedAt, hasFinished := imports.Date(row["date_finished"])
 	isFavorite, hasFavorite := imports.Bool(row["is_favorite"])
+	progress, hasProgress := imports.Progress(
+		row["pages_read"], row["progress_percent"], row["progress_position"],
+	)
 
 	// Bail when nothing interaction-shaped is present — most generic
 	// CSVs won't carry any of these and we don't want to touch the row.
 	if readStatus == "" && !hasRating && review == "" && notes == "" &&
-		!hasStarted && !hasFinished && !hasFavorite {
+		!hasStarted && !hasFinished && !hasFavorite && !hasProgress {
 		return
 	}
 
@@ -597,7 +600,7 @@ func (w *ImportWorker) applyInteraction(ctx context.Context, editionID, userID u
 		readStatusArg, ratingArg,
 		notesArg, reviewArg,
 		startedArg, finishedArg,
-		favoriteArg, nil, // progress not imported from CSV
+		favoriteArg, progress, // nil when the row carried no position
 	); err != nil {
 		slog.Warn("import: merging user interaction failed",
 			"user_id", userID, "edition_id", editionID, "error", err)


### PR DESCRIPTION
- `MergeInteraction` already accepted a progress blob; the import passed nil. Fine for a Goodreads export with no such column, wrong for the Lite-to-server migration, where every part-read book would have landed at page zero.
- Reads `pages_read`, `progress_percent` and `progress_position` into the `{pages_read?, percent?, position?}` shape the interaction row stores.
- Empty still means "no data", not "reset to zero", so a re-import cannot wipe a position that is already on the server.