### PR TITLE
Strip a pasted Bearer prefix from the Hardcover API key

### DIFF
--- a/internal/providers/books/hardcover.go
+++ b/internal/providers/books/hardcover.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/fireball1725/librarium-api/internal/providers"
@@ -45,12 +46,37 @@ func (p *HardcoverProvider) Info() providers.ProviderInfo {
 }
 
 func (p *HardcoverProvider) Configure(cfg map[string]string) {
-	p.apiKey = cfg["api_key"]
+	p.apiKey = normalizeHardcoverKey(cfg["api_key"])
 	if v, ok := cfg["enabled"]; ok {
 		p.enabled = v == "true" && p.apiKey != ""
 	} else {
 		p.enabled = p.apiKey != ""
 	}
+}
+
+// normalizeHardcoverKey strips a "Bearer " prefix the admin may have
+// pasted along with the token.
+//
+// hardcover.app/account/api presents the key already prefixed, so
+// copying it verbatim is the obvious thing to do. Every request here
+// then adds its own prefix and the header goes out as
+// "Bearer Bearer eyJ...", which Hardcover rejects with "Malformed
+// Authorization header" — an error that reads like a bad key rather
+// than a doubled prefix. Normalising once here covers all seven call
+// sites across this file and hardcover_contributors.go.
+// Splitting on whitespace rather than trimming a literal prefix handles
+// every paste shape in one pass: any casing, a tab or newline instead of
+// a space, a doubled prefix, and the case where the value is the word
+// "bearer" and nothing else (which must come back empty, or Configure
+// would enable the provider with no token). Hardcover keys are JWTs and
+// never contain whitespace, so rejoining what is left is safe.
+func normalizeHardcoverKey(key string) string {
+	fields := strings.Fields(key)
+	i := 0
+	for i < len(fields) && strings.EqualFold(fields[i], "bearer") {
+		i++
+	}
+	return strings.Join(fields[i:], " ")
 }
 
 const hardcoverEndpoint = "https://api.hardcover.app/v1/graphql"

--- a/internal/providers/books/hardcover_test.go
+++ b/internal/providers/books/hardcover_test.go
@@ -88,3 +88,59 @@ func TestFetchSeriesVolumes_BookSeriesKey(t *testing.T) {
 		t.Errorf("volume 1 = %+v, want title=The Naked Sun cover set", got[1])
 	}
 }
+
+func TestNormalizeHardcoverKeyStripsBearerPrefix(t *testing.T) {
+	const token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.payload.sig"
+
+	cases := map[string]string{
+		"bare token":         token,
+		"prefixed":           "Bearer " + token,
+		"lowercase prefix":   "bearer " + token,
+		"mixed case prefix":  "BeArEr " + token,
+		"surrounding spaces": "  Bearer " + token + "  ",
+		"doubled prefix":     "Bearer Bearer " + token,
+		"newline from paste": "Bearer " + token + "\n",
+	}
+	for name, input := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := normalizeHardcoverKey(input); got != token {
+				t.Errorf("normalizeHardcoverKey(%q) = %q, want %q", input, got, token)
+			}
+		})
+	}
+}
+
+// An empty or whitespace-only key must stay empty: Configure keys the
+// provider's enabled flag off it, so returning anything non-empty would
+// enable a provider with no credentials.
+func TestNormalizeHardcoverKeyEmpty(t *testing.T) {
+	for _, input := range []string{"", "   ", "Bearer ", "bearer   "} {
+		if got := normalizeHardcoverKey(input); got != "" {
+			t.Errorf("normalizeHardcoverKey(%q) = %q, want empty", input, got)
+		}
+	}
+}
+
+// Configure is the only place the key is normalised, so the doubled
+// prefix must be gone by the time any request builds its header.
+func TestConfigureNormalizesKey(t *testing.T) {
+	p := NewHardcoverProvider()
+	p.Configure(map[string]string{"api_key": "Bearer abc123"})
+	if p.apiKey != "abc123" {
+		t.Errorf("apiKey = %q, want %q", p.apiKey, "abc123")
+	}
+	if !p.enabled {
+		t.Error("expected provider to be enabled with a key present")
+	}
+}
+
+func TestConfigureLeavesProviderDisabledWithoutKey(t *testing.T) {
+	p := NewHardcoverProvider()
+	p.Configure(map[string]string{"api_key": "Bearer "})
+	if p.apiKey != "" {
+		t.Errorf("apiKey = %q, want empty", p.apiKey)
+	}
+	if p.enabled {
+		t.Error("expected provider to stay disabled when the key is only a prefix")
+	}
+}


### PR DESCRIPTION
- hardcover.app/account/api shows the key already prefixed, so pasting it verbatim sends `Bearer Bearer eyJ...` and Hardcover answers "Malformed Authorization header", which reads like a bad key rather than a doubled prefix.
- Normalising in `Configure` covers all seven request sites across hardcover.go and hardcover_contributors.go.
- A value of just "Bearer" now normalises to empty, so it can no longer enable the provider with no token behind it.