### PR TITLE
Browse across libraries, and report the server's components

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -2140,7 +2140,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/responses.UserResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.UserResponse"
                         }
                     },
                     "401": {
@@ -2196,7 +2196,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/responses.UserResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.UserResponse"
                         }
                     },
                     "400": {
@@ -2682,6 +2682,53 @@ const docTemplate = `{
                 }
             }
         },
+        "/components": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Every Go module linked into this API binary, with its version and SPDX licence identifier. Clients render this on their licences page so the notices cover the server as well as the client. A component whose licence is unknown is returned with an empty licence rather than omitted.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "health"
+                ],
+                "summary": "List server components",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "components": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "licence": {
+                                                "type": "string"
+                                            },
+                                            "name": {
+                                                "type": "string"
+                                            },
+                                            "version": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                },
+                                "version": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/contributors": {
             "get": {
                 "security": [
@@ -2712,7 +2759,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/responses.ContributorItem"
+                                "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.ContributorItem"
                             }
                         }
                     },
@@ -2766,7 +2813,7 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/responses.ContributorItem"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.ContributorItem"
                         }
                     },
                     "400": {
@@ -3431,7 +3478,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/responses.GenreResponse"
+                                "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.GenreResponse"
                             }
                         }
                     },
@@ -3485,7 +3532,7 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/responses.GenreResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.GenreResponse"
                         }
                     },
                     "400": {
@@ -3569,7 +3616,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/responses.GenreResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.GenreResponse"
                         }
                     },
                     "400": {
@@ -3930,7 +3977,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/responses.LibraryResponse"
+                                "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.LibraryResponse"
                             }
                         }
                     },
@@ -3993,7 +4040,7 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/responses.LibraryResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.LibraryResponse"
                         }
                     },
                     "400": {
@@ -4060,7 +4107,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/responses.LibraryResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.LibraryResponse"
                         }
                     },
                     "400": {
@@ -4148,7 +4195,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/responses.LibraryResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.LibraryResponse"
                         }
                     },
                     "400": {
@@ -4281,7 +4328,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/responses.BookResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.BookResponse"
                         }
                     },
                     "400": {
@@ -4322,112 +4369,7 @@ const docTemplate = `{
         },
         "/libraries/{library_id}/books": {
             "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Returns a paginated, filtered, sorted list of books in the library.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "books"
-                ],
-                "summary": "List books in a library",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Library UUID",
-                        "name": "library_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Search query or query-language expression",
-                        "name": "q",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Page number",
-                        "name": "page",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Items per page",
-                        "name": "per_page",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Sort field",
-                        "name": "sort",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Sort direction (asc/desc)",
-                        "name": "sort_dir",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Filter by first letter",
-                        "name": "letter",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Filter by tag name",
-                        "name": "tag",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Filter by media type",
-                        "name": "type_filter",
-                        "in": "query"
-                    },
-                    {
-                        "type": "boolean",
-                        "description": "Treat q as regex",
-                        "name": "regex",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/responses.PagedBooksResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "object",
-                            "properties": {
-                                "error": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "type": "object",
-                            "properties": {
-                                "error": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                }
+                "responses": {}
             },
             "post": {
                 "security": [
@@ -4503,7 +4445,7 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/responses.BookResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.BookResponse"
                         }
                     },
                     "400": {
@@ -4710,6 +4652,74 @@ const docTemplate = `{
                 }
             }
         },
+        "/libraries/{library_id}/books/facets": {
+            "get": {
+                "description": "Counts books per facet value across the whole filtered set, not\nthe returned page, so a client can render a filter rail without\na request per value. Takes the same query parameters as the list\nendpoint and applies exactly the same filter.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "books"
+                ],
+                "summary": "Facet counts for a book search",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Library ID",
+                        "name": "library_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search query",
+                        "name": "q",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Structured filter JSON",
+                        "name": "filter",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_repository.BookFacets"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/libraries/{library_id}/books/fingerprint": {
             "get": {
                 "security": [
@@ -4860,7 +4870,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/responses.BookResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.BookResponse"
                         }
                     },
                     "400": {
@@ -4976,7 +4986,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/responses.BookResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.BookResponse"
                         }
                     },
                     "400": {
@@ -5430,7 +5440,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/responses.EditionResponse"
+                                "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.EditionResponse"
                             }
                         }
                     },
@@ -5548,7 +5558,7 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/responses.EditionResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.EditionResponse"
                         }
                     },
                     "400": {
@@ -5674,7 +5684,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/responses.EditionResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.EditionResponse"
                         }
                     },
                     "400": {
@@ -6155,7 +6165,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/responses.InteractionResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.InteractionResponse"
                         }
                     },
                     "400": {
@@ -6258,7 +6268,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/responses.InteractionResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.InteractionResponse"
                         }
                     },
                     "400": {
@@ -6473,7 +6483,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/responses.ShelfResponse"
+                                "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.ShelfResponse"
                             }
                         }
                     },
@@ -7002,7 +7012,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/responses.LoanResponse"
+                                "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.LoanResponse"
                             }
                         }
                     },
@@ -7086,7 +7096,7 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/responses.LoanResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.LoanResponse"
                         }
                     },
                     "400": {
@@ -7241,7 +7251,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/responses.LoanResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.LoanResponse"
                         }
                     },
                     "400": {
@@ -7322,7 +7332,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/responses.MemberResponse"
+                                "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.MemberResponse"
                             }
                         }
                     },
@@ -7785,7 +7795,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/responses.SeriesResponse"
+                                "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.SeriesResponse"
                             }
                         }
                     },
@@ -7896,7 +7906,7 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/responses.SeriesResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.SeriesResponse"
                         }
                     },
                     "400": {
@@ -8113,7 +8123,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/responses.SeriesResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.SeriesResponse"
                         }
                     },
                     "400": {
@@ -8241,7 +8251,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/responses.SeriesResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.SeriesResponse"
                         }
                     },
                     "400": {
@@ -8788,7 +8798,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/responses.SeriesEntryResponse"
+                                "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.SeriesEntryResponse"
                             }
                         }
                     },
@@ -9408,7 +9418,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/responses.SeriesVolumeResponse"
+                                "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.SeriesVolumeResponse"
                             }
                         }
                     },
@@ -9474,7 +9484,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/responses.SeriesVolumeResponse"
+                                "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.SeriesVolumeResponse"
                             }
                         }
                     },
@@ -9556,7 +9566,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/responses.ShelfResponse"
+                                "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.ShelfResponse"
                             }
                         }
                     },
@@ -9646,7 +9656,7 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/responses.ShelfResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.ShelfResponse"
                         }
                     },
                     "400": {
@@ -9744,7 +9754,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/responses.ShelfResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.ShelfResponse"
                         }
                     },
                     "400": {
@@ -9886,7 +9896,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/responses.BookResponse"
+                                "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.BookResponse"
                             }
                         }
                     },
@@ -10150,7 +10160,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/responses.TagResponse"
+                                "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.TagResponse"
                             }
                         }
                     },
@@ -10225,7 +10235,7 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/responses.TagResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.TagResponse"
                         }
                     },
                     "400": {
@@ -10308,7 +10318,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/responses.TagResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.TagResponse"
                         }
                     },
                     "400": {
@@ -10881,6 +10891,480 @@ const docTemplate = `{
                 }
             }
         },
+        "/me/authors/index": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "The cross-library Authors surface, with per-author book and\nread counts, cover thumbnails, and the letter each name files\nunder. Unpaged, for the same reason as the series index.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "me"
+                ],
+                "summary": "Authors across every library the caller can read",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Contributor roles, comma separated. Defaults to author.",
+                        "name": "role",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Library UUIDs, comma separated. Narrows the scope; cannot widen it.",
+                        "name": "lib",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "items": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_repository.AuthorIndexEntry"
+                                    }
+                                },
+                                "total": {
+                                    "type": "integer"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/me/books": {
+            "get": {
+                "description": "The default browse surface. Takes the same filters as the\nper-library list endpoint; library becomes one filter among\nseveral rather than part of the path.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "books"
+                ],
+                "summary": "Books across every library the caller can read",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Search query",
+                        "name": "q",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Results per page",
+                        "name": "per_page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Structured filter JSON",
+                        "name": "filter",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Library ids, comma separated",
+                        "name": "lib",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Read statuses, comma separated",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Media type names, comma separated",
+                        "name": "type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Genre names, comma separated",
+                        "name": "genre",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Tag names, comma separated",
+                        "name": "tag",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Ratings 0-5, comma separated",
+                        "name": "rating",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "items": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object"
+                                    }
+                                },
+                                "page": {
+                                    "type": "integer"
+                                },
+                                "per_page": {
+                                    "type": "integer"
+                                },
+                                "total": {
+                                    "type": "integer"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/me/books/facets": {
+            "get": {
+                "description": "Counts per facet value over the whole filtered set, so the\nfilter rail can be rendered in one request rather than one per\nvalue. Same filters as /me/books.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "books"
+                ],
+                "summary": "Facet counts across every library the caller can read",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Search query",
+                        "name": "q",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Structured filter JSON",
+                        "name": "filter",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_repository.BookFacets"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/me/books/grouped": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Same filters as /me/books, but each series becomes one entry so\na run and a standalone book are peers. Paging is over entries;\nbook_total reports how many books those entries stand for,\nbecause the facet rail still counts books.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "books"
+                ],
+                "summary": "Books across every readable library, series collapsed",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Search query",
+                        "name": "q",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Library UUIDs, comma separated",
+                        "name": "lib",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Ownership states, comma separated",
+                        "name": "own",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Read statuses, comma separated",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page, 1-based",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Entries per page",
+                        "name": "per_page",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "book_total": {
+                                    "type": "integer"
+                                },
+                                "items": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object"
+                                    }
+                                },
+                                "page": {
+                                    "type": "integer"
+                                },
+                                "per_page": {
+                                    "type": "integer"
+                                },
+                                "total": {
+                                    "type": "integer"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/me/counts": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Book, series and author counts across every library the caller\ncan read. One endpoint rather than three, because the sidebar\nneeds all of them on every page and none of them individually.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "me"
+                ],
+                "summary": "Totals for the navigation",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "authors": {
+                                    "type": "integer"
+                                },
+                                "books": {
+                                    "type": "integer"
+                                },
+                                "series": {
+                                    "type": "integer"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/me/libraries": {
+            "get": {
+                "description": "Returns every library the authenticated user can see and the\npermission names they hold in each, already capped by the\ntoken's scope. A client fetches this once and gates each row by\nthe library the row came from, rather than checking per book.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "libraries"
+                ],
+                "summary": "Libraries the caller can reach, with effective permissions",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_repository.LibraryAccess"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/me/loans": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "A loan is a book, a person and some dates; the library is where\nthe book happens to live. \"Who has my stuff\" is not a question\nanyone asks one library at a time, so this is the whole set,\neach row carrying the library it belongs to.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "me"
+                ],
+                "summary": "Loans across every library the caller can read",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Library UUIDs, comma separated. Narrows the scope; cannot widen it.",
+                        "name": "lib",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Match against borrower or book title",
+                        "name": "q",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Include loans already returned",
+                        "name": "include_returned",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Only loans past their due date",
+                        "name": "overdue",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "items": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.LoanResponse"
+                                    }
+                                },
+                                "total": {
+                                    "type": "integer"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/me/series": {
             "get": {
                 "security": [
@@ -10911,6 +11395,108 @@ const docTemplate = `{
                             "type": "array",
                             "items": {
                                 "$ref": "#/definitions/internal_api_handlers.MeSeriesResult"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/me/series/index": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "The cross-library Series surface. Unpaged: the A-Z bar has to\nknow which letters have series behind them, which means\ncounting the whole set anyway.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "me"
+                ],
+                "summary": "Series across every library the caller can read",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Name substring",
+                        "name": "q",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "items": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.SeriesResponse"
+                                    }
+                                },
+                                "total": {
+                                    "type": "integer"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/me/shelves": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "The rail lists shelves beside libraries and views, so it needs\nthem across the whole readable scope rather than one library at\na time. Each carries its library, colour and icon.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "me"
+                ],
+                "summary": "Shelves across every library the caller can read",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "items": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.ShelfResponse"
+                                    }
+                                },
+                                "total": {
+                                    "type": "integer"
+                                }
                             }
                         }
                     },
@@ -11499,7 +12085,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/responses.MediaTypeResponse"
+                                "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.MediaTypeResponse"
                             }
                         }
                     },
@@ -11559,7 +12145,7 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/responses.MediaTypeResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.MediaTypeResponse"
                         }
                     },
                     "400": {
@@ -11657,7 +12243,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/responses.MediaTypeResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.MediaTypeResponse"
                         }
                     },
                     "400": {
@@ -11897,6 +12483,129 @@ const docTemplate = `{
                 }
             }
         },
+        "/sync/apply": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Applies client ops with per-field last-writer-wins. Every op comes back with its own status, so a partial success is normal and the client clears only the ops it sees applied. Update-only in v1: create new rows through the per-resource endpoints.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "sync"
+                ],
+                "summary": "Push a batch of client changes",
+                "parameters": [
+                    {
+                        "description": "Ops to apply, at most 1000",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.SyncApplyRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.SyncApplyResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/sync/changes": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the caller's data changed since ` + "`" + `since` + "`" + `, oldest first. Advance ` + "`" + `since` + "`" + ` to the newest updated_at you applied. When has_more is true the response hit ` + "`" + `limit` + "`" + ` and you should call again straight away.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "sync"
+                ],
+                "summary": "Pull changes since a timestamp",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "RFC3339 timestamp; returns changes strictly newer than this",
+                        "name": "since",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Ops per response, 1 to 1000 (default 500)",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.SyncChangesResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/users": {
             "get": {
                 "security": [
@@ -11961,6 +12670,765 @@ const docTemplate = `{
         }
     },
     "definitions": {
+        "github_com_fireball1725_librarium-api_internal_api_responses.BookResponse": {
+            "type": "object",
+            "properties": {
+                "active_loan_count": {
+                    "description": "ActiveLoanCount is the number of active (not yet returned) loans for\nthis book — scoped to the library when the read is library-scoped,\nglobal otherwise. Always populated.",
+                    "type": "integer"
+                },
+                "active_loans": {
+                    "description": "ActiveLoans is the full list of active loans for this book. Only\npopulated by single-book reads (GetBook); list endpoints omit it to\nkeep payloads lean — use active_loan_count there for the badge.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.LoanResponse"
+                    }
+                },
+                "added_by": {
+                    "type": "string"
+                },
+                "contributors": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.ContributorRef"
+                    }
+                },
+                "cover_url": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "genres": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.GenreRef"
+                    }
+                },
+                "id": {
+                    "type": "string"
+                },
+                "language": {
+                    "type": "string"
+                },
+                "library_id": {
+                    "type": "string"
+                },
+                "media_type": {
+                    "type": "string"
+                },
+                "media_type_id": {
+                    "type": "string"
+                },
+                "publish_year": {
+                    "type": "integer"
+                },
+                "publisher": {
+                    "type": "string"
+                },
+                "series": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.SeriesRef"
+                    }
+                },
+                "shelves": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.ShelfRef"
+                    }
+                },
+                "subtitle": {
+                    "type": "string"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.TagRef"
+                    }
+                },
+                "title": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "user_progress_pct": {
+                    "description": "UserProgressPct is the caller's reading progress 0-100 (0 = none).",
+                    "type": "number"
+                },
+                "user_rating": {
+                    "description": "UserRating is the caller's rating (1-10 half-star integer; 0 = none).",
+                    "type": "integer"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.ContributorItem": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.ContributorRef": {
+            "type": "object",
+            "properties": {
+                "contributor_id": {
+                    "type": "string"
+                },
+                "display_order": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "role": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.EditionResponse": {
+            "type": "object",
+            "properties": {
+                "acquired_at": {
+                    "description": "YYYY-MM-DD",
+                    "type": "string"
+                },
+                "book_id": {
+                    "type": "string"
+                },
+                "copy_count": {
+                    "type": "integer"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "duration_seconds": {
+                    "type": "integer"
+                },
+                "edition_name": {
+                    "type": "string"
+                },
+                "format": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "is_primary": {
+                    "type": "boolean"
+                },
+                "isbn_10": {
+                    "type": "string"
+                },
+                "isbn_13": {
+                    "type": "string"
+                },
+                "language": {
+                    "type": "string"
+                },
+                "narrator": {
+                    "type": "string"
+                },
+                "page_count": {
+                    "type": "integer"
+                },
+                "publish_date": {
+                    "description": "YYYY-MM-DD",
+                    "type": "string"
+                },
+                "publisher": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.GenreRef": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.GenreResponse": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.InteractionResponse": {
+            "type": "object",
+            "properties": {
+                "book_edition_id": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "date_finished": {
+                    "description": "YYYY-MM-DD",
+                    "type": "string"
+                },
+                "date_started": {
+                    "description": "YYYY-MM-DD",
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "is_favorite": {
+                    "type": "boolean"
+                },
+                "notes": {
+                    "type": "string"
+                },
+                "rating": {
+                    "type": "integer"
+                },
+                "read_status": {
+                    "type": "string"
+                },
+                "reread_count": {
+                    "type": "integer"
+                },
+                "review": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "user_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.LibraryResponse": {
+            "type": "object",
+            "properties": {
+                "book_count": {
+                    "description": "BookCount is the total number of books in the library. ReadingCount\nand ReadCount are caller-scoped — the calling user's reading + read\nbooks in this library. Always populated on list endpoints; on single-\nlibrary endpoints they fall back to 0 unless the path was scoped.",
+                    "type": "integer"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "is_public": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "owner_id": {
+                    "type": "string"
+                },
+                "read_count": {
+                    "type": "integer"
+                },
+                "reading_count": {
+                    "type": "integer"
+                },
+                "slug": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.LoanResponse": {
+            "type": "object",
+            "properties": {
+                "book_id": {
+                    "type": "string"
+                },
+                "book_title": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "due_date": {
+                    "description": "YYYY-MM-DD",
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "library_id": {
+                    "type": "string"
+                },
+                "loaned_at": {
+                    "description": "YYYY-MM-DD",
+                    "type": "string"
+                },
+                "loaned_to": {
+                    "type": "string"
+                },
+                "notes": {
+                    "type": "string"
+                },
+                "returned_at": {
+                    "description": "YYYY-MM-DD",
+                    "type": "string"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.TagRef"
+                    }
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.MediaTypeResponse": {
+            "type": "object",
+            "properties": {
+                "book_count": {
+                    "type": "integer"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.MemberResponse": {
+            "type": "object",
+            "properties": {
+                "display_name": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "invited_by": {
+                    "type": "string"
+                },
+                "joined_at": {
+                    "type": "string"
+                },
+                "role": {
+                    "type": "string"
+                },
+                "role_id": {
+                    "type": "string"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.TagRef"
+                    }
+                },
+                "user_id": {
+                    "type": "string"
+                },
+                "username": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.SeriesEntryResponse": {
+            "type": "object",
+            "properties": {
+                "book_id": {
+                    "type": "string"
+                },
+                "contributors": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.ContributorRef"
+                    }
+                },
+                "media_type": {
+                    "type": "string"
+                },
+                "position": {
+                    "type": "number"
+                },
+                "subtitle": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.SeriesRef": {
+            "type": "object",
+            "properties": {
+                "position": {
+                    "type": "number"
+                },
+                "series_id": {
+                    "type": "string"
+                },
+                "series_name": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.SeriesResponse": {
+            "type": "object",
+            "properties": {
+                "book_count": {
+                    "type": "integer"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "demographic": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "external_id": {
+                    "type": "string"
+                },
+                "external_source": {
+                    "type": "string"
+                },
+                "genres": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "id": {
+                    "type": "string"
+                },
+                "is_complete": {
+                    "type": "boolean"
+                },
+                "last_release_date": {
+                    "description": "YYYY-MM-DD",
+                    "type": "string"
+                },
+                "library_id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "next_release_date": {
+                    "description": "YYYY-MM-DD",
+                    "type": "string"
+                },
+                "original_language": {
+                    "type": "string"
+                },
+                "publication_year": {
+                    "type": "integer"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.TagRef"
+                    }
+                },
+                "total_count": {
+                    "type": "integer"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.SeriesVolumeResponse": {
+            "type": "object",
+            "properties": {
+                "cover_url": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "external_id": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "position": {
+                    "type": "number"
+                },
+                "release_date": {
+                    "description": "YYYY-MM-DD",
+                    "type": "string"
+                },
+                "series_id": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.ShelfRef": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.ShelfResponse": {
+            "type": "object",
+            "properties": {
+                "book_count": {
+                    "type": "integer"
+                },
+                "color": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "display_order": {
+                    "type": "integer"
+                },
+                "icon": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "library_id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.TagRef"
+                    }
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.SyncApplyOp": {
+            "type": "object",
+            "properties": {
+                "deleted": {
+                    "type": "boolean"
+                },
+                "entity_id": {
+                    "type": "string"
+                },
+                "entity_type": {
+                    "type": "string"
+                },
+                "field": {
+                    "type": "string"
+                },
+                "op_id": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "value": {}
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.SyncApplyRequest": {
+            "type": "object",
+            "properties": {
+                "client_id": {
+                    "type": "string"
+                },
+                "ops": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.SyncApplyOp"
+                    }
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.SyncApplyResponse": {
+            "type": "object",
+            "properties": {
+                "results": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.SyncApplyResult"
+                    }
+                },
+                "server_time": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.SyncApplyResult": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string"
+                },
+                "op_id": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.SyncChangesResponse": {
+            "type": "object",
+            "properties": {
+                "has_more": {
+                    "type": "boolean"
+                },
+                "ops": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.SyncOp"
+                    }
+                },
+                "server_time": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.SyncOp": {
+            "type": "object",
+            "properties": {
+                "deleted": {
+                    "type": "boolean"
+                },
+                "entity_id": {
+                    "type": "string"
+                },
+                "entity_type": {
+                    "type": "string"
+                },
+                "field": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "value": {}
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.TagRef": {
+            "type": "object",
+            "properties": {
+                "color": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "library_id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.TagResponse": {
+            "type": "object",
+            "properties": {
+                "color": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "library_id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.UserResponse": {
+            "type": "object",
+            "properties": {
+                "display_name": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "is_instance_admin": {
+                    "type": "boolean"
+                },
+                "username": {
+                    "type": "string"
+                }
+            }
+        },
         "github_com_fireball1725_librarium-api_internal_models.AIMetadataProposal": {
             "type": "object",
             "properties": {
@@ -12366,6 +13834,30 @@ const docTemplate = `{
                 }
             }
         },
+        "github_com_fireball1725_librarium-api_internal_providers.ConfigField": {
+            "type": "object",
+            "properties": {
+                "help_text": {
+                    "type": "string"
+                },
+                "key": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "placeholder": {
+                    "type": "string"
+                },
+                "required": {
+                    "type": "boolean"
+                },
+                "type": {
+                    "description": "\"password\" | \"text\" | \"url\"",
+                    "type": "string"
+                }
+            }
+        },
         "github_com_fireball1725_librarium-api_internal_providers.CoverOption": {
             "type": "object",
             "properties": {
@@ -12521,6 +14013,126 @@ const docTemplate = `{
                 }
             }
         },
+        "github_com_fireball1725_librarium-api_internal_repository.AuthorIndexEntry": {
+            "type": "object",
+            "properties": {
+                "book_count": {
+                    "type": "integer"
+                },
+                "has_photo": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "letter": {
+                    "description": "Letter the index files this author under, taken from sort_name so\n\"Ursula K. Le Guin\" appears under L rather than U. '#' for anything\nthat does not start with a letter.",
+                    "type": "string"
+                },
+                "libraries": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_repository.AuthorLibraryRef"
+                    }
+                },
+                "name": {
+                    "type": "string"
+                },
+                "read_count": {
+                    "type": "integer"
+                },
+                "sort_name": {
+                    "type": "string"
+                },
+                "spines": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_repository.AuthorSpine"
+                    }
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_repository.AuthorLibraryRef": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_repository.AuthorSpine": {
+            "type": "object",
+            "properties": {
+                "book_id": {
+                    "type": "string"
+                },
+                "has_cover": {
+                    "type": "boolean"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_repository.BookFacets": {
+            "type": "object",
+            "properties": {
+                "genre": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_repository.FacetValue"
+                    }
+                },
+                "library": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_repository.FacetValue"
+                    }
+                },
+                "media_type": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_repository.FacetValue"
+                    }
+                },
+                "ownership": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_repository.FacetValue"
+                    }
+                },
+                "rating": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_repository.FacetValue"
+                    }
+                },
+                "read_status": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_repository.FacetValue"
+                    }
+                },
+                "shelf": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_repository.FacetValue"
+                    }
+                },
+                "tag": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_repository.FacetValue"
+                    }
+                }
+            }
+        },
         "github_com_fireball1725_librarium-api_internal_repository.BookFingerprint": {
             "type": "object",
             "properties": {
@@ -12530,6 +14142,46 @@ const docTemplate = `{
                 },
                 "total": {
                     "type": "integer"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_repository.FacetValue": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_repository.LibraryAccess": {
+            "type": "object",
+            "properties": {
+                "book_count": {
+                    "type": "integer"
+                },
+                "library_id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "permissions": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "role": {
+                    "type": "string"
+                },
+                "slug": {
+                    "type": "string"
                 }
             }
         },
@@ -12699,6 +14351,12 @@ const docTemplate = `{
                     "type": "object",
                     "additionalProperties": {
                         "type": "string"
+                    }
+                },
+                "config_fields": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_providers.ConfigField"
                     }
                 },
                 "description": {
@@ -13157,687 +14815,6 @@ const docTemplate = `{
                     }
                 },
                 "token_suffix": {
-                    "type": "string"
-                }
-            }
-        },
-        "responses.BookResponse": {
-            "type": "object",
-            "properties": {
-                "active_loan_count": {
-                    "description": "ActiveLoanCount is the number of active (not yet returned) loans for\nthis book — scoped to the library when the read is library-scoped,\nglobal otherwise. Always populated.",
-                    "type": "integer"
-                },
-                "active_loans": {
-                    "description": "ActiveLoans is the full list of active loans for this book. Only\npopulated by single-book reads (GetBook); list endpoints omit it to\nkeep payloads lean — use active_loan_count there for the badge.",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/responses.LoanResponse"
-                    }
-                },
-                "added_by": {
-                    "type": "string"
-                },
-                "contributors": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/responses.ContributorRef"
-                    }
-                },
-                "cover_url": {
-                    "type": "string"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "genres": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/responses.GenreRef"
-                    }
-                },
-                "id": {
-                    "type": "string"
-                },
-                "language": {
-                    "type": "string"
-                },
-                "library_id": {
-                    "type": "string"
-                },
-                "media_type": {
-                    "type": "string"
-                },
-                "media_type_id": {
-                    "type": "string"
-                },
-                "publish_year": {
-                    "type": "integer"
-                },
-                "publisher": {
-                    "type": "string"
-                },
-                "series": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/responses.SeriesRef"
-                    }
-                },
-                "shelves": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/responses.ShelfRef"
-                    }
-                },
-                "subtitle": {
-                    "type": "string"
-                },
-                "tags": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/responses.TagRef"
-                    }
-                },
-                "title": {
-                    "type": "string"
-                },
-                "updated_at": {
-                    "type": "string"
-                },
-                "user_progress_pct": {
-                    "description": "UserProgressPct is the caller's reading progress 0-100 (0 = none).",
-                    "type": "number"
-                },
-                "user_rating": {
-                    "description": "UserRating is the caller's rating (1-10 half-star integer; 0 = none).",
-                    "type": "integer"
-                }
-            }
-        },
-        "responses.ContributorItem": {
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                }
-            }
-        },
-        "responses.ContributorRef": {
-            "type": "object",
-            "properties": {
-                "contributor_id": {
-                    "type": "string"
-                },
-                "display_order": {
-                    "type": "integer"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "role": {
-                    "type": "string"
-                }
-            }
-        },
-        "responses.EditionResponse": {
-            "type": "object",
-            "properties": {
-                "acquired_at": {
-                    "description": "YYYY-MM-DD",
-                    "type": "string"
-                },
-                "book_id": {
-                    "type": "string"
-                },
-                "copy_count": {
-                    "type": "integer"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "duration_seconds": {
-                    "type": "integer"
-                },
-                "edition_name": {
-                    "type": "string"
-                },
-                "format": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "is_primary": {
-                    "type": "boolean"
-                },
-                "isbn_10": {
-                    "type": "string"
-                },
-                "isbn_13": {
-                    "type": "string"
-                },
-                "language": {
-                    "type": "string"
-                },
-                "narrator": {
-                    "type": "string"
-                },
-                "page_count": {
-                    "type": "integer"
-                },
-                "publish_date": {
-                    "description": "YYYY-MM-DD",
-                    "type": "string"
-                },
-                "publisher": {
-                    "type": "string"
-                },
-                "updated_at": {
-                    "type": "string"
-                }
-            }
-        },
-        "responses.GenreRef": {
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                }
-            }
-        },
-        "responses.GenreResponse": {
-            "type": "object",
-            "properties": {
-                "created_at": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                }
-            }
-        },
-        "responses.InteractionResponse": {
-            "type": "object",
-            "properties": {
-                "book_edition_id": {
-                    "type": "string"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "date_finished": {
-                    "description": "YYYY-MM-DD",
-                    "type": "string"
-                },
-                "date_started": {
-                    "description": "YYYY-MM-DD",
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "is_favorite": {
-                    "type": "boolean"
-                },
-                "notes": {
-                    "type": "string"
-                },
-                "rating": {
-                    "type": "integer"
-                },
-                "read_status": {
-                    "type": "string"
-                },
-                "reread_count": {
-                    "type": "integer"
-                },
-                "review": {
-                    "type": "string"
-                },
-                "updated_at": {
-                    "type": "string"
-                },
-                "user_id": {
-                    "type": "string"
-                }
-            }
-        },
-        "responses.LibraryResponse": {
-            "type": "object",
-            "properties": {
-                "book_count": {
-                    "description": "BookCount is the total number of books in the library. ReadingCount\nand ReadCount are caller-scoped — the calling user's reading + read\nbooks in this library. Always populated on list endpoints; on single-\nlibrary endpoints they fall back to 0 unless the path was scoped.",
-                    "type": "integer"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "is_public": {
-                    "type": "boolean"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "owner_id": {
-                    "type": "string"
-                },
-                "read_count": {
-                    "type": "integer"
-                },
-                "reading_count": {
-                    "type": "integer"
-                },
-                "slug": {
-                    "type": "string"
-                },
-                "updated_at": {
-                    "type": "string"
-                }
-            }
-        },
-        "responses.LoanResponse": {
-            "type": "object",
-            "properties": {
-                "book_id": {
-                    "type": "string"
-                },
-                "book_title": {
-                    "type": "string"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "due_date": {
-                    "description": "YYYY-MM-DD",
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "library_id": {
-                    "type": "string"
-                },
-                "loaned_at": {
-                    "description": "YYYY-MM-DD",
-                    "type": "string"
-                },
-                "loaned_to": {
-                    "type": "string"
-                },
-                "notes": {
-                    "type": "string"
-                },
-                "returned_at": {
-                    "description": "YYYY-MM-DD",
-                    "type": "string"
-                },
-                "tags": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/responses.TagRef"
-                    }
-                },
-                "updated_at": {
-                    "type": "string"
-                }
-            }
-        },
-        "responses.MediaTypeResponse": {
-            "type": "object",
-            "properties": {
-                "book_count": {
-                    "type": "integer"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "display_name": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                }
-            }
-        },
-        "responses.MemberResponse": {
-            "type": "object",
-            "properties": {
-                "display_name": {
-                    "type": "string"
-                },
-                "email": {
-                    "type": "string"
-                },
-                "invited_by": {
-                    "type": "string"
-                },
-                "joined_at": {
-                    "type": "string"
-                },
-                "role": {
-                    "type": "string"
-                },
-                "role_id": {
-                    "type": "string"
-                },
-                "tags": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/responses.TagRef"
-                    }
-                },
-                "user_id": {
-                    "type": "string"
-                },
-                "username": {
-                    "type": "string"
-                }
-            }
-        },
-        "responses.PagedBooksResponse": {
-            "type": "object",
-            "properties": {
-                "items": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/responses.BookResponse"
-                    }
-                },
-                "page": {
-                    "type": "integer"
-                },
-                "per_page": {
-                    "type": "integer"
-                },
-                "suggestions": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "total": {
-                    "type": "integer"
-                }
-            }
-        },
-        "responses.SeriesEntryResponse": {
-            "type": "object",
-            "properties": {
-                "book_id": {
-                    "type": "string"
-                },
-                "contributors": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/responses.ContributorRef"
-                    }
-                },
-                "media_type": {
-                    "type": "string"
-                },
-                "position": {
-                    "type": "number"
-                },
-                "subtitle": {
-                    "type": "string"
-                },
-                "title": {
-                    "type": "string"
-                }
-            }
-        },
-        "responses.SeriesRef": {
-            "type": "object",
-            "properties": {
-                "position": {
-                    "type": "number"
-                },
-                "series_id": {
-                    "type": "string"
-                },
-                "series_name": {
-                    "type": "string"
-                }
-            }
-        },
-        "responses.SeriesResponse": {
-            "type": "object",
-            "properties": {
-                "book_count": {
-                    "type": "integer"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "demographic": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "external_id": {
-                    "type": "string"
-                },
-                "external_source": {
-                    "type": "string"
-                },
-                "genres": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "id": {
-                    "type": "string"
-                },
-                "is_complete": {
-                    "type": "boolean"
-                },
-                "last_release_date": {
-                    "description": "YYYY-MM-DD",
-                    "type": "string"
-                },
-                "library_id": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "next_release_date": {
-                    "description": "YYYY-MM-DD",
-                    "type": "string"
-                },
-                "original_language": {
-                    "type": "string"
-                },
-                "publication_year": {
-                    "type": "integer"
-                },
-                "status": {
-                    "type": "string"
-                },
-                "tags": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/responses.TagRef"
-                    }
-                },
-                "total_count": {
-                    "type": "integer"
-                },
-                "updated_at": {
-                    "type": "string"
-                },
-                "url": {
-                    "type": "string"
-                }
-            }
-        },
-        "responses.SeriesVolumeResponse": {
-            "type": "object",
-            "properties": {
-                "cover_url": {
-                    "type": "string"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "external_id": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "position": {
-                    "type": "number"
-                },
-                "release_date": {
-                    "description": "YYYY-MM-DD",
-                    "type": "string"
-                },
-                "series_id": {
-                    "type": "string"
-                },
-                "title": {
-                    "type": "string"
-                },
-                "updated_at": {
-                    "type": "string"
-                }
-            }
-        },
-        "responses.ShelfRef": {
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                }
-            }
-        },
-        "responses.ShelfResponse": {
-            "type": "object",
-            "properties": {
-                "book_count": {
-                    "type": "integer"
-                },
-                "color": {
-                    "type": "string"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "display_order": {
-                    "type": "integer"
-                },
-                "icon": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "library_id": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "tags": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/responses.TagRef"
-                    }
-                },
-                "updated_at": {
-                    "type": "string"
-                }
-            }
-        },
-        "responses.TagRef": {
-            "type": "object",
-            "properties": {
-                "color": {
-                    "type": "string"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "library_id": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                }
-            }
-        },
-        "responses.TagResponse": {
-            "type": "object",
-            "properties": {
-                "color": {
-                    "type": "string"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "library_id": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                }
-            }
-        },
-        "responses.UserResponse": {
-            "type": "object",
-            "properties": {
-                "display_name": {
-                    "type": "string"
-                },
-                "email": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "is_instance_admin": {
-                    "type": "boolean"
-                },
-                "username": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -2134,7 +2134,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/responses.UserResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.UserResponse"
                         }
                     },
                     "401": {
@@ -2190,7 +2190,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/responses.UserResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.UserResponse"
                         }
                     },
                     "400": {
@@ -2676,6 +2676,53 @@
                 }
             }
         },
+        "/components": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Every Go module linked into this API binary, with its version and SPDX licence identifier. Clients render this on their licences page so the notices cover the server as well as the client. A component whose licence is unknown is returned with an empty licence rather than omitted.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "health"
+                ],
+                "summary": "List server components",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "components": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "licence": {
+                                                "type": "string"
+                                            },
+                                            "name": {
+                                                "type": "string"
+                                            },
+                                            "version": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                },
+                                "version": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/contributors": {
             "get": {
                 "security": [
@@ -2706,7 +2753,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/responses.ContributorItem"
+                                "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.ContributorItem"
                             }
                         }
                     },
@@ -2760,7 +2807,7 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/responses.ContributorItem"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.ContributorItem"
                         }
                     },
                     "400": {
@@ -3425,7 +3472,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/responses.GenreResponse"
+                                "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.GenreResponse"
                             }
                         }
                     },
@@ -3479,7 +3526,7 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/responses.GenreResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.GenreResponse"
                         }
                     },
                     "400": {
@@ -3563,7 +3610,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/responses.GenreResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.GenreResponse"
                         }
                     },
                     "400": {
@@ -3924,7 +3971,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/responses.LibraryResponse"
+                                "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.LibraryResponse"
                             }
                         }
                     },
@@ -3987,7 +4034,7 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/responses.LibraryResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.LibraryResponse"
                         }
                     },
                     "400": {
@@ -4054,7 +4101,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/responses.LibraryResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.LibraryResponse"
                         }
                     },
                     "400": {
@@ -4142,7 +4189,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/responses.LibraryResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.LibraryResponse"
                         }
                     },
                     "400": {
@@ -4275,7 +4322,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/responses.BookResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.BookResponse"
                         }
                     },
                     "400": {
@@ -4316,112 +4363,7 @@
         },
         "/libraries/{library_id}/books": {
             "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Returns a paginated, filtered, sorted list of books in the library.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "books"
-                ],
-                "summary": "List books in a library",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Library UUID",
-                        "name": "library_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Search query or query-language expression",
-                        "name": "q",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Page number",
-                        "name": "page",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Items per page",
-                        "name": "per_page",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Sort field",
-                        "name": "sort",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Sort direction (asc/desc)",
-                        "name": "sort_dir",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Filter by first letter",
-                        "name": "letter",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Filter by tag name",
-                        "name": "tag",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Filter by media type",
-                        "name": "type_filter",
-                        "in": "query"
-                    },
-                    {
-                        "type": "boolean",
-                        "description": "Treat q as regex",
-                        "name": "regex",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/responses.PagedBooksResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "object",
-                            "properties": {
-                                "error": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "type": "object",
-                            "properties": {
-                                "error": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                }
+                "responses": {}
             },
             "post": {
                 "security": [
@@ -4497,7 +4439,7 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/responses.BookResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.BookResponse"
                         }
                     },
                     "400": {
@@ -4704,6 +4646,74 @@
                 }
             }
         },
+        "/libraries/{library_id}/books/facets": {
+            "get": {
+                "description": "Counts books per facet value across the whole filtered set, not\nthe returned page, so a client can render a filter rail without\na request per value. Takes the same query parameters as the list\nendpoint and applies exactly the same filter.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "books"
+                ],
+                "summary": "Facet counts for a book search",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Library ID",
+                        "name": "library_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search query",
+                        "name": "q",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Structured filter JSON",
+                        "name": "filter",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_repository.BookFacets"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/libraries/{library_id}/books/fingerprint": {
             "get": {
                 "security": [
@@ -4854,7 +4864,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/responses.BookResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.BookResponse"
                         }
                     },
                     "400": {
@@ -4970,7 +4980,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/responses.BookResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.BookResponse"
                         }
                     },
                     "400": {
@@ -5424,7 +5434,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/responses.EditionResponse"
+                                "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.EditionResponse"
                             }
                         }
                     },
@@ -5542,7 +5552,7 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/responses.EditionResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.EditionResponse"
                         }
                     },
                     "400": {
@@ -5668,7 +5678,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/responses.EditionResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.EditionResponse"
                         }
                     },
                     "400": {
@@ -6149,7 +6159,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/responses.InteractionResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.InteractionResponse"
                         }
                     },
                     "400": {
@@ -6252,7 +6262,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/responses.InteractionResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.InteractionResponse"
                         }
                     },
                     "400": {
@@ -6467,7 +6477,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/responses.ShelfResponse"
+                                "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.ShelfResponse"
                             }
                         }
                     },
@@ -6996,7 +7006,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/responses.LoanResponse"
+                                "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.LoanResponse"
                             }
                         }
                     },
@@ -7080,7 +7090,7 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/responses.LoanResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.LoanResponse"
                         }
                     },
                     "400": {
@@ -7235,7 +7245,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/responses.LoanResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.LoanResponse"
                         }
                     },
                     "400": {
@@ -7316,7 +7326,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/responses.MemberResponse"
+                                "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.MemberResponse"
                             }
                         }
                     },
@@ -7779,7 +7789,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/responses.SeriesResponse"
+                                "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.SeriesResponse"
                             }
                         }
                     },
@@ -7890,7 +7900,7 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/responses.SeriesResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.SeriesResponse"
                         }
                     },
                     "400": {
@@ -8107,7 +8117,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/responses.SeriesResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.SeriesResponse"
                         }
                     },
                     "400": {
@@ -8235,7 +8245,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/responses.SeriesResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.SeriesResponse"
                         }
                     },
                     "400": {
@@ -8782,7 +8792,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/responses.SeriesEntryResponse"
+                                "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.SeriesEntryResponse"
                             }
                         }
                     },
@@ -9402,7 +9412,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/responses.SeriesVolumeResponse"
+                                "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.SeriesVolumeResponse"
                             }
                         }
                     },
@@ -9468,7 +9478,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/responses.SeriesVolumeResponse"
+                                "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.SeriesVolumeResponse"
                             }
                         }
                     },
@@ -9550,7 +9560,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/responses.ShelfResponse"
+                                "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.ShelfResponse"
                             }
                         }
                     },
@@ -9640,7 +9650,7 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/responses.ShelfResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.ShelfResponse"
                         }
                     },
                     "400": {
@@ -9738,7 +9748,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/responses.ShelfResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.ShelfResponse"
                         }
                     },
                     "400": {
@@ -9880,7 +9890,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/responses.BookResponse"
+                                "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.BookResponse"
                             }
                         }
                     },
@@ -10144,7 +10154,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/responses.TagResponse"
+                                "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.TagResponse"
                             }
                         }
                     },
@@ -10219,7 +10229,7 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/responses.TagResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.TagResponse"
                         }
                     },
                     "400": {
@@ -10302,7 +10312,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/responses.TagResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.TagResponse"
                         }
                     },
                     "400": {
@@ -10875,6 +10885,480 @@
                 }
             }
         },
+        "/me/authors/index": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "The cross-library Authors surface, with per-author book and\nread counts, cover thumbnails, and the letter each name files\nunder. Unpaged, for the same reason as the series index.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "me"
+                ],
+                "summary": "Authors across every library the caller can read",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Contributor roles, comma separated. Defaults to author.",
+                        "name": "role",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Library UUIDs, comma separated. Narrows the scope; cannot widen it.",
+                        "name": "lib",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "items": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_repository.AuthorIndexEntry"
+                                    }
+                                },
+                                "total": {
+                                    "type": "integer"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/me/books": {
+            "get": {
+                "description": "The default browse surface. Takes the same filters as the\nper-library list endpoint; library becomes one filter among\nseveral rather than part of the path.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "books"
+                ],
+                "summary": "Books across every library the caller can read",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Search query",
+                        "name": "q",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Results per page",
+                        "name": "per_page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Structured filter JSON",
+                        "name": "filter",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Library ids, comma separated",
+                        "name": "lib",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Read statuses, comma separated",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Media type names, comma separated",
+                        "name": "type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Genre names, comma separated",
+                        "name": "genre",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Tag names, comma separated",
+                        "name": "tag",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Ratings 0-5, comma separated",
+                        "name": "rating",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "items": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object"
+                                    }
+                                },
+                                "page": {
+                                    "type": "integer"
+                                },
+                                "per_page": {
+                                    "type": "integer"
+                                },
+                                "total": {
+                                    "type": "integer"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/me/books/facets": {
+            "get": {
+                "description": "Counts per facet value over the whole filtered set, so the\nfilter rail can be rendered in one request rather than one per\nvalue. Same filters as /me/books.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "books"
+                ],
+                "summary": "Facet counts across every library the caller can read",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Search query",
+                        "name": "q",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Structured filter JSON",
+                        "name": "filter",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_repository.BookFacets"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/me/books/grouped": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Same filters as /me/books, but each series becomes one entry so\na run and a standalone book are peers. Paging is over entries;\nbook_total reports how many books those entries stand for,\nbecause the facet rail still counts books.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "books"
+                ],
+                "summary": "Books across every readable library, series collapsed",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Search query",
+                        "name": "q",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Library UUIDs, comma separated",
+                        "name": "lib",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Ownership states, comma separated",
+                        "name": "own",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Read statuses, comma separated",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page, 1-based",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Entries per page",
+                        "name": "per_page",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "book_total": {
+                                    "type": "integer"
+                                },
+                                "items": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object"
+                                    }
+                                },
+                                "page": {
+                                    "type": "integer"
+                                },
+                                "per_page": {
+                                    "type": "integer"
+                                },
+                                "total": {
+                                    "type": "integer"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/me/counts": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Book, series and author counts across every library the caller\ncan read. One endpoint rather than three, because the sidebar\nneeds all of them on every page and none of them individually.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "me"
+                ],
+                "summary": "Totals for the navigation",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "authors": {
+                                    "type": "integer"
+                                },
+                                "books": {
+                                    "type": "integer"
+                                },
+                                "series": {
+                                    "type": "integer"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/me/libraries": {
+            "get": {
+                "description": "Returns every library the authenticated user can see and the\npermission names they hold in each, already capped by the\ntoken's scope. A client fetches this once and gates each row by\nthe library the row came from, rather than checking per book.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "libraries"
+                ],
+                "summary": "Libraries the caller can reach, with effective permissions",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_repository.LibraryAccess"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/me/loans": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "A loan is a book, a person and some dates; the library is where\nthe book happens to live. \"Who has my stuff\" is not a question\nanyone asks one library at a time, so this is the whole set,\neach row carrying the library it belongs to.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "me"
+                ],
+                "summary": "Loans across every library the caller can read",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Library UUIDs, comma separated. Narrows the scope; cannot widen it.",
+                        "name": "lib",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Match against borrower or book title",
+                        "name": "q",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Include loans already returned",
+                        "name": "include_returned",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Only loans past their due date",
+                        "name": "overdue",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "items": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.LoanResponse"
+                                    }
+                                },
+                                "total": {
+                                    "type": "integer"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/me/series": {
             "get": {
                 "security": [
@@ -10905,6 +11389,108 @@
                             "type": "array",
                             "items": {
                                 "$ref": "#/definitions/internal_api_handlers.MeSeriesResult"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/me/series/index": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "The cross-library Series surface. Unpaged: the A-Z bar has to\nknow which letters have series behind them, which means\ncounting the whole set anyway.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "me"
+                ],
+                "summary": "Series across every library the caller can read",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Name substring",
+                        "name": "q",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "items": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.SeriesResponse"
+                                    }
+                                },
+                                "total": {
+                                    "type": "integer"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/me/shelves": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "The rail lists shelves beside libraries and views, so it needs\nthem across the whole readable scope rather than one library at\na time. Each carries its library, colour and icon.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "me"
+                ],
+                "summary": "Shelves across every library the caller can read",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "items": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.ShelfResponse"
+                                    }
+                                },
+                                "total": {
+                                    "type": "integer"
+                                }
                             }
                         }
                     },
@@ -11493,7 +12079,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/responses.MediaTypeResponse"
+                                "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.MediaTypeResponse"
                             }
                         }
                     },
@@ -11553,7 +12139,7 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/responses.MediaTypeResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.MediaTypeResponse"
                         }
                     },
                     "400": {
@@ -11651,7 +12237,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/responses.MediaTypeResponse"
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.MediaTypeResponse"
                         }
                     },
                     "400": {
@@ -11891,6 +12477,129 @@
                 }
             }
         },
+        "/sync/apply": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Applies client ops with per-field last-writer-wins. Every op comes back with its own status, so a partial success is normal and the client clears only the ops it sees applied. Update-only in v1: create new rows through the per-resource endpoints.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "sync"
+                ],
+                "summary": "Push a batch of client changes",
+                "parameters": [
+                    {
+                        "description": "Ops to apply, at most 1000",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.SyncApplyRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.SyncApplyResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/sync/changes": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the caller's data changed since `since`, oldest first. Advance `since` to the newest updated_at you applied. When has_more is true the response hit `limit` and you should call again straight away.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "sync"
+                ],
+                "summary": "Pull changes since a timestamp",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "RFC3339 timestamp; returns changes strictly newer than this",
+                        "name": "since",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Ops per response, 1 to 1000 (default 500)",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.SyncChangesResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/users": {
             "get": {
                 "security": [
@@ -11955,6 +12664,765 @@
         }
     },
     "definitions": {
+        "github_com_fireball1725_librarium-api_internal_api_responses.BookResponse": {
+            "type": "object",
+            "properties": {
+                "active_loan_count": {
+                    "description": "ActiveLoanCount is the number of active (not yet returned) loans for\nthis book — scoped to the library when the read is library-scoped,\nglobal otherwise. Always populated.",
+                    "type": "integer"
+                },
+                "active_loans": {
+                    "description": "ActiveLoans is the full list of active loans for this book. Only\npopulated by single-book reads (GetBook); list endpoints omit it to\nkeep payloads lean — use active_loan_count there for the badge.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.LoanResponse"
+                    }
+                },
+                "added_by": {
+                    "type": "string"
+                },
+                "contributors": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.ContributorRef"
+                    }
+                },
+                "cover_url": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "genres": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.GenreRef"
+                    }
+                },
+                "id": {
+                    "type": "string"
+                },
+                "language": {
+                    "type": "string"
+                },
+                "library_id": {
+                    "type": "string"
+                },
+                "media_type": {
+                    "type": "string"
+                },
+                "media_type_id": {
+                    "type": "string"
+                },
+                "publish_year": {
+                    "type": "integer"
+                },
+                "publisher": {
+                    "type": "string"
+                },
+                "series": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.SeriesRef"
+                    }
+                },
+                "shelves": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.ShelfRef"
+                    }
+                },
+                "subtitle": {
+                    "type": "string"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.TagRef"
+                    }
+                },
+                "title": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "user_progress_pct": {
+                    "description": "UserProgressPct is the caller's reading progress 0-100 (0 = none).",
+                    "type": "number"
+                },
+                "user_rating": {
+                    "description": "UserRating is the caller's rating (1-10 half-star integer; 0 = none).",
+                    "type": "integer"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.ContributorItem": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.ContributorRef": {
+            "type": "object",
+            "properties": {
+                "contributor_id": {
+                    "type": "string"
+                },
+                "display_order": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "role": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.EditionResponse": {
+            "type": "object",
+            "properties": {
+                "acquired_at": {
+                    "description": "YYYY-MM-DD",
+                    "type": "string"
+                },
+                "book_id": {
+                    "type": "string"
+                },
+                "copy_count": {
+                    "type": "integer"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "duration_seconds": {
+                    "type": "integer"
+                },
+                "edition_name": {
+                    "type": "string"
+                },
+                "format": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "is_primary": {
+                    "type": "boolean"
+                },
+                "isbn_10": {
+                    "type": "string"
+                },
+                "isbn_13": {
+                    "type": "string"
+                },
+                "language": {
+                    "type": "string"
+                },
+                "narrator": {
+                    "type": "string"
+                },
+                "page_count": {
+                    "type": "integer"
+                },
+                "publish_date": {
+                    "description": "YYYY-MM-DD",
+                    "type": "string"
+                },
+                "publisher": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.GenreRef": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.GenreResponse": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.InteractionResponse": {
+            "type": "object",
+            "properties": {
+                "book_edition_id": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "date_finished": {
+                    "description": "YYYY-MM-DD",
+                    "type": "string"
+                },
+                "date_started": {
+                    "description": "YYYY-MM-DD",
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "is_favorite": {
+                    "type": "boolean"
+                },
+                "notes": {
+                    "type": "string"
+                },
+                "rating": {
+                    "type": "integer"
+                },
+                "read_status": {
+                    "type": "string"
+                },
+                "reread_count": {
+                    "type": "integer"
+                },
+                "review": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "user_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.LibraryResponse": {
+            "type": "object",
+            "properties": {
+                "book_count": {
+                    "description": "BookCount is the total number of books in the library. ReadingCount\nand ReadCount are caller-scoped — the calling user's reading + read\nbooks in this library. Always populated on list endpoints; on single-\nlibrary endpoints they fall back to 0 unless the path was scoped.",
+                    "type": "integer"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "is_public": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "owner_id": {
+                    "type": "string"
+                },
+                "read_count": {
+                    "type": "integer"
+                },
+                "reading_count": {
+                    "type": "integer"
+                },
+                "slug": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.LoanResponse": {
+            "type": "object",
+            "properties": {
+                "book_id": {
+                    "type": "string"
+                },
+                "book_title": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "due_date": {
+                    "description": "YYYY-MM-DD",
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "library_id": {
+                    "type": "string"
+                },
+                "loaned_at": {
+                    "description": "YYYY-MM-DD",
+                    "type": "string"
+                },
+                "loaned_to": {
+                    "type": "string"
+                },
+                "notes": {
+                    "type": "string"
+                },
+                "returned_at": {
+                    "description": "YYYY-MM-DD",
+                    "type": "string"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.TagRef"
+                    }
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.MediaTypeResponse": {
+            "type": "object",
+            "properties": {
+                "book_count": {
+                    "type": "integer"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.MemberResponse": {
+            "type": "object",
+            "properties": {
+                "display_name": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "invited_by": {
+                    "type": "string"
+                },
+                "joined_at": {
+                    "type": "string"
+                },
+                "role": {
+                    "type": "string"
+                },
+                "role_id": {
+                    "type": "string"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.TagRef"
+                    }
+                },
+                "user_id": {
+                    "type": "string"
+                },
+                "username": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.SeriesEntryResponse": {
+            "type": "object",
+            "properties": {
+                "book_id": {
+                    "type": "string"
+                },
+                "contributors": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.ContributorRef"
+                    }
+                },
+                "media_type": {
+                    "type": "string"
+                },
+                "position": {
+                    "type": "number"
+                },
+                "subtitle": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.SeriesRef": {
+            "type": "object",
+            "properties": {
+                "position": {
+                    "type": "number"
+                },
+                "series_id": {
+                    "type": "string"
+                },
+                "series_name": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.SeriesResponse": {
+            "type": "object",
+            "properties": {
+                "book_count": {
+                    "type": "integer"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "demographic": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "external_id": {
+                    "type": "string"
+                },
+                "external_source": {
+                    "type": "string"
+                },
+                "genres": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "id": {
+                    "type": "string"
+                },
+                "is_complete": {
+                    "type": "boolean"
+                },
+                "last_release_date": {
+                    "description": "YYYY-MM-DD",
+                    "type": "string"
+                },
+                "library_id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "next_release_date": {
+                    "description": "YYYY-MM-DD",
+                    "type": "string"
+                },
+                "original_language": {
+                    "type": "string"
+                },
+                "publication_year": {
+                    "type": "integer"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.TagRef"
+                    }
+                },
+                "total_count": {
+                    "type": "integer"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.SeriesVolumeResponse": {
+            "type": "object",
+            "properties": {
+                "cover_url": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "external_id": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "position": {
+                    "type": "number"
+                },
+                "release_date": {
+                    "description": "YYYY-MM-DD",
+                    "type": "string"
+                },
+                "series_id": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.ShelfRef": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.ShelfResponse": {
+            "type": "object",
+            "properties": {
+                "book_count": {
+                    "type": "integer"
+                },
+                "color": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "display_order": {
+                    "type": "integer"
+                },
+                "icon": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "library_id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.TagRef"
+                    }
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.SyncApplyOp": {
+            "type": "object",
+            "properties": {
+                "deleted": {
+                    "type": "boolean"
+                },
+                "entity_id": {
+                    "type": "string"
+                },
+                "entity_type": {
+                    "type": "string"
+                },
+                "field": {
+                    "type": "string"
+                },
+                "op_id": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "value": {}
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.SyncApplyRequest": {
+            "type": "object",
+            "properties": {
+                "client_id": {
+                    "type": "string"
+                },
+                "ops": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.SyncApplyOp"
+                    }
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.SyncApplyResponse": {
+            "type": "object",
+            "properties": {
+                "results": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.SyncApplyResult"
+                    }
+                },
+                "server_time": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.SyncApplyResult": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string"
+                },
+                "op_id": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.SyncChangesResponse": {
+            "type": "object",
+            "properties": {
+                "has_more": {
+                    "type": "boolean"
+                },
+                "ops": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.SyncOp"
+                    }
+                },
+                "server_time": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.SyncOp": {
+            "type": "object",
+            "properties": {
+                "deleted": {
+                    "type": "boolean"
+                },
+                "entity_id": {
+                    "type": "string"
+                },
+                "entity_type": {
+                    "type": "string"
+                },
+                "field": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "value": {}
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.TagRef": {
+            "type": "object",
+            "properties": {
+                "color": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "library_id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.TagResponse": {
+            "type": "object",
+            "properties": {
+                "color": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "library_id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_api_responses.UserResponse": {
+            "type": "object",
+            "properties": {
+                "display_name": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "is_instance_admin": {
+                    "type": "boolean"
+                },
+                "username": {
+                    "type": "string"
+                }
+            }
+        },
         "github_com_fireball1725_librarium-api_internal_models.AIMetadataProposal": {
             "type": "object",
             "properties": {
@@ -12360,6 +13828,30 @@
                 }
             }
         },
+        "github_com_fireball1725_librarium-api_internal_providers.ConfigField": {
+            "type": "object",
+            "properties": {
+                "help_text": {
+                    "type": "string"
+                },
+                "key": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "placeholder": {
+                    "type": "string"
+                },
+                "required": {
+                    "type": "boolean"
+                },
+                "type": {
+                    "description": "\"password\" | \"text\" | \"url\"",
+                    "type": "string"
+                }
+            }
+        },
         "github_com_fireball1725_librarium-api_internal_providers.CoverOption": {
             "type": "object",
             "properties": {
@@ -12515,6 +14007,126 @@
                 }
             }
         },
+        "github_com_fireball1725_librarium-api_internal_repository.AuthorIndexEntry": {
+            "type": "object",
+            "properties": {
+                "book_count": {
+                    "type": "integer"
+                },
+                "has_photo": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "letter": {
+                    "description": "Letter the index files this author under, taken from sort_name so\n\"Ursula K. Le Guin\" appears under L rather than U. '#' for anything\nthat does not start with a letter.",
+                    "type": "string"
+                },
+                "libraries": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_repository.AuthorLibraryRef"
+                    }
+                },
+                "name": {
+                    "type": "string"
+                },
+                "read_count": {
+                    "type": "integer"
+                },
+                "sort_name": {
+                    "type": "string"
+                },
+                "spines": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_repository.AuthorSpine"
+                    }
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_repository.AuthorLibraryRef": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_repository.AuthorSpine": {
+            "type": "object",
+            "properties": {
+                "book_id": {
+                    "type": "string"
+                },
+                "has_cover": {
+                    "type": "boolean"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_repository.BookFacets": {
+            "type": "object",
+            "properties": {
+                "genre": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_repository.FacetValue"
+                    }
+                },
+                "library": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_repository.FacetValue"
+                    }
+                },
+                "media_type": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_repository.FacetValue"
+                    }
+                },
+                "ownership": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_repository.FacetValue"
+                    }
+                },
+                "rating": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_repository.FacetValue"
+                    }
+                },
+                "read_status": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_repository.FacetValue"
+                    }
+                },
+                "shelf": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_repository.FacetValue"
+                    }
+                },
+                "tag": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_repository.FacetValue"
+                    }
+                }
+            }
+        },
         "github_com_fireball1725_librarium-api_internal_repository.BookFingerprint": {
             "type": "object",
             "properties": {
@@ -12524,6 +14136,46 @@
                 },
                 "total": {
                     "type": "integer"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_repository.FacetValue": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_fireball1725_librarium-api_internal_repository.LibraryAccess": {
+            "type": "object",
+            "properties": {
+                "book_count": {
+                    "type": "integer"
+                },
+                "library_id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "permissions": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "role": {
+                    "type": "string"
+                },
+                "slug": {
+                    "type": "string"
                 }
             }
         },
@@ -12693,6 +14345,12 @@
                     "type": "object",
                     "additionalProperties": {
                         "type": "string"
+                    }
+                },
+                "config_fields": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_providers.ConfigField"
                     }
                 },
                 "description": {
@@ -13151,687 +14809,6 @@
                     }
                 },
                 "token_suffix": {
-                    "type": "string"
-                }
-            }
-        },
-        "responses.BookResponse": {
-            "type": "object",
-            "properties": {
-                "active_loan_count": {
-                    "description": "ActiveLoanCount is the number of active (not yet returned) loans for\nthis book — scoped to the library when the read is library-scoped,\nglobal otherwise. Always populated.",
-                    "type": "integer"
-                },
-                "active_loans": {
-                    "description": "ActiveLoans is the full list of active loans for this book. Only\npopulated by single-book reads (GetBook); list endpoints omit it to\nkeep payloads lean — use active_loan_count there for the badge.",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/responses.LoanResponse"
-                    }
-                },
-                "added_by": {
-                    "type": "string"
-                },
-                "contributors": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/responses.ContributorRef"
-                    }
-                },
-                "cover_url": {
-                    "type": "string"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "genres": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/responses.GenreRef"
-                    }
-                },
-                "id": {
-                    "type": "string"
-                },
-                "language": {
-                    "type": "string"
-                },
-                "library_id": {
-                    "type": "string"
-                },
-                "media_type": {
-                    "type": "string"
-                },
-                "media_type_id": {
-                    "type": "string"
-                },
-                "publish_year": {
-                    "type": "integer"
-                },
-                "publisher": {
-                    "type": "string"
-                },
-                "series": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/responses.SeriesRef"
-                    }
-                },
-                "shelves": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/responses.ShelfRef"
-                    }
-                },
-                "subtitle": {
-                    "type": "string"
-                },
-                "tags": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/responses.TagRef"
-                    }
-                },
-                "title": {
-                    "type": "string"
-                },
-                "updated_at": {
-                    "type": "string"
-                },
-                "user_progress_pct": {
-                    "description": "UserProgressPct is the caller's reading progress 0-100 (0 = none).",
-                    "type": "number"
-                },
-                "user_rating": {
-                    "description": "UserRating is the caller's rating (1-10 half-star integer; 0 = none).",
-                    "type": "integer"
-                }
-            }
-        },
-        "responses.ContributorItem": {
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                }
-            }
-        },
-        "responses.ContributorRef": {
-            "type": "object",
-            "properties": {
-                "contributor_id": {
-                    "type": "string"
-                },
-                "display_order": {
-                    "type": "integer"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "role": {
-                    "type": "string"
-                }
-            }
-        },
-        "responses.EditionResponse": {
-            "type": "object",
-            "properties": {
-                "acquired_at": {
-                    "description": "YYYY-MM-DD",
-                    "type": "string"
-                },
-                "book_id": {
-                    "type": "string"
-                },
-                "copy_count": {
-                    "type": "integer"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "duration_seconds": {
-                    "type": "integer"
-                },
-                "edition_name": {
-                    "type": "string"
-                },
-                "format": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "is_primary": {
-                    "type": "boolean"
-                },
-                "isbn_10": {
-                    "type": "string"
-                },
-                "isbn_13": {
-                    "type": "string"
-                },
-                "language": {
-                    "type": "string"
-                },
-                "narrator": {
-                    "type": "string"
-                },
-                "page_count": {
-                    "type": "integer"
-                },
-                "publish_date": {
-                    "description": "YYYY-MM-DD",
-                    "type": "string"
-                },
-                "publisher": {
-                    "type": "string"
-                },
-                "updated_at": {
-                    "type": "string"
-                }
-            }
-        },
-        "responses.GenreRef": {
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                }
-            }
-        },
-        "responses.GenreResponse": {
-            "type": "object",
-            "properties": {
-                "created_at": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                }
-            }
-        },
-        "responses.InteractionResponse": {
-            "type": "object",
-            "properties": {
-                "book_edition_id": {
-                    "type": "string"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "date_finished": {
-                    "description": "YYYY-MM-DD",
-                    "type": "string"
-                },
-                "date_started": {
-                    "description": "YYYY-MM-DD",
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "is_favorite": {
-                    "type": "boolean"
-                },
-                "notes": {
-                    "type": "string"
-                },
-                "rating": {
-                    "type": "integer"
-                },
-                "read_status": {
-                    "type": "string"
-                },
-                "reread_count": {
-                    "type": "integer"
-                },
-                "review": {
-                    "type": "string"
-                },
-                "updated_at": {
-                    "type": "string"
-                },
-                "user_id": {
-                    "type": "string"
-                }
-            }
-        },
-        "responses.LibraryResponse": {
-            "type": "object",
-            "properties": {
-                "book_count": {
-                    "description": "BookCount is the total number of books in the library. ReadingCount\nand ReadCount are caller-scoped — the calling user's reading + read\nbooks in this library. Always populated on list endpoints; on single-\nlibrary endpoints they fall back to 0 unless the path was scoped.",
-                    "type": "integer"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "is_public": {
-                    "type": "boolean"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "owner_id": {
-                    "type": "string"
-                },
-                "read_count": {
-                    "type": "integer"
-                },
-                "reading_count": {
-                    "type": "integer"
-                },
-                "slug": {
-                    "type": "string"
-                },
-                "updated_at": {
-                    "type": "string"
-                }
-            }
-        },
-        "responses.LoanResponse": {
-            "type": "object",
-            "properties": {
-                "book_id": {
-                    "type": "string"
-                },
-                "book_title": {
-                    "type": "string"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "due_date": {
-                    "description": "YYYY-MM-DD",
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "library_id": {
-                    "type": "string"
-                },
-                "loaned_at": {
-                    "description": "YYYY-MM-DD",
-                    "type": "string"
-                },
-                "loaned_to": {
-                    "type": "string"
-                },
-                "notes": {
-                    "type": "string"
-                },
-                "returned_at": {
-                    "description": "YYYY-MM-DD",
-                    "type": "string"
-                },
-                "tags": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/responses.TagRef"
-                    }
-                },
-                "updated_at": {
-                    "type": "string"
-                }
-            }
-        },
-        "responses.MediaTypeResponse": {
-            "type": "object",
-            "properties": {
-                "book_count": {
-                    "type": "integer"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "display_name": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                }
-            }
-        },
-        "responses.MemberResponse": {
-            "type": "object",
-            "properties": {
-                "display_name": {
-                    "type": "string"
-                },
-                "email": {
-                    "type": "string"
-                },
-                "invited_by": {
-                    "type": "string"
-                },
-                "joined_at": {
-                    "type": "string"
-                },
-                "role": {
-                    "type": "string"
-                },
-                "role_id": {
-                    "type": "string"
-                },
-                "tags": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/responses.TagRef"
-                    }
-                },
-                "user_id": {
-                    "type": "string"
-                },
-                "username": {
-                    "type": "string"
-                }
-            }
-        },
-        "responses.PagedBooksResponse": {
-            "type": "object",
-            "properties": {
-                "items": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/responses.BookResponse"
-                    }
-                },
-                "page": {
-                    "type": "integer"
-                },
-                "per_page": {
-                    "type": "integer"
-                },
-                "suggestions": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "total": {
-                    "type": "integer"
-                }
-            }
-        },
-        "responses.SeriesEntryResponse": {
-            "type": "object",
-            "properties": {
-                "book_id": {
-                    "type": "string"
-                },
-                "contributors": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/responses.ContributorRef"
-                    }
-                },
-                "media_type": {
-                    "type": "string"
-                },
-                "position": {
-                    "type": "number"
-                },
-                "subtitle": {
-                    "type": "string"
-                },
-                "title": {
-                    "type": "string"
-                }
-            }
-        },
-        "responses.SeriesRef": {
-            "type": "object",
-            "properties": {
-                "position": {
-                    "type": "number"
-                },
-                "series_id": {
-                    "type": "string"
-                },
-                "series_name": {
-                    "type": "string"
-                }
-            }
-        },
-        "responses.SeriesResponse": {
-            "type": "object",
-            "properties": {
-                "book_count": {
-                    "type": "integer"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "demographic": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "external_id": {
-                    "type": "string"
-                },
-                "external_source": {
-                    "type": "string"
-                },
-                "genres": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "id": {
-                    "type": "string"
-                },
-                "is_complete": {
-                    "type": "boolean"
-                },
-                "last_release_date": {
-                    "description": "YYYY-MM-DD",
-                    "type": "string"
-                },
-                "library_id": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "next_release_date": {
-                    "description": "YYYY-MM-DD",
-                    "type": "string"
-                },
-                "original_language": {
-                    "type": "string"
-                },
-                "publication_year": {
-                    "type": "integer"
-                },
-                "status": {
-                    "type": "string"
-                },
-                "tags": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/responses.TagRef"
-                    }
-                },
-                "total_count": {
-                    "type": "integer"
-                },
-                "updated_at": {
-                    "type": "string"
-                },
-                "url": {
-                    "type": "string"
-                }
-            }
-        },
-        "responses.SeriesVolumeResponse": {
-            "type": "object",
-            "properties": {
-                "cover_url": {
-                    "type": "string"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "external_id": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "position": {
-                    "type": "number"
-                },
-                "release_date": {
-                    "description": "YYYY-MM-DD",
-                    "type": "string"
-                },
-                "series_id": {
-                    "type": "string"
-                },
-                "title": {
-                    "type": "string"
-                },
-                "updated_at": {
-                    "type": "string"
-                }
-            }
-        },
-        "responses.ShelfRef": {
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                }
-            }
-        },
-        "responses.ShelfResponse": {
-            "type": "object",
-            "properties": {
-                "book_count": {
-                    "type": "integer"
-                },
-                "color": {
-                    "type": "string"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "display_order": {
-                    "type": "integer"
-                },
-                "icon": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "library_id": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "tags": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/responses.TagRef"
-                    }
-                },
-                "updated_at": {
-                    "type": "string"
-                }
-            }
-        },
-        "responses.TagRef": {
-            "type": "object",
-            "properties": {
-                "color": {
-                    "type": "string"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "library_id": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                }
-            }
-        },
-        "responses.TagResponse": {
-            "type": "object",
-            "properties": {
-                "color": {
-                    "type": "string"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "library_id": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                }
-            }
-        },
-        "responses.UserResponse": {
-            "type": "object",
-            "properties": {
-                "display_name": {
-                    "type": "string"
-                },
-                "email": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "is_instance_admin": {
-                    "type": "boolean"
-                },
-                "username": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,5 +1,519 @@
 basePath: /api/v1
 definitions:
+  github_com_fireball1725_librarium-api_internal_api_responses.BookResponse:
+    properties:
+      active_loan_count:
+        description: |-
+          ActiveLoanCount is the number of active (not yet returned) loans for
+          this book — scoped to the library when the read is library-scoped,
+          global otherwise. Always populated.
+        type: integer
+      active_loans:
+        description: |-
+          ActiveLoans is the full list of active loans for this book. Only
+          populated by single-book reads (GetBook); list endpoints omit it to
+          keep payloads lean — use active_loan_count there for the badge.
+        items:
+          $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.LoanResponse'
+        type: array
+      added_by:
+        type: string
+      contributors:
+        items:
+          $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.ContributorRef'
+        type: array
+      cover_url:
+        type: string
+      created_at:
+        type: string
+      description:
+        type: string
+      genres:
+        items:
+          $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.GenreRef'
+        type: array
+      id:
+        type: string
+      language:
+        type: string
+      library_id:
+        type: string
+      media_type:
+        type: string
+      media_type_id:
+        type: string
+      publish_year:
+        type: integer
+      publisher:
+        type: string
+      series:
+        items:
+          $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.SeriesRef'
+        type: array
+      shelves:
+        items:
+          $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.ShelfRef'
+        type: array
+      subtitle:
+        type: string
+      tags:
+        items:
+          $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.TagRef'
+        type: array
+      title:
+        type: string
+      updated_at:
+        type: string
+      user_progress_pct:
+        description: UserProgressPct is the caller's reading progress 0-100 (0 = none).
+        type: number
+      user_rating:
+        description: UserRating is the caller's rating (1-10 half-star integer; 0
+          = none).
+        type: integer
+    type: object
+  github_com_fireball1725_librarium-api_internal_api_responses.ContributorItem:
+    properties:
+      id:
+        type: string
+      name:
+        type: string
+    type: object
+  github_com_fireball1725_librarium-api_internal_api_responses.ContributorRef:
+    properties:
+      contributor_id:
+        type: string
+      display_order:
+        type: integer
+      name:
+        type: string
+      role:
+        type: string
+    type: object
+  github_com_fireball1725_librarium-api_internal_api_responses.EditionResponse:
+    properties:
+      acquired_at:
+        description: YYYY-MM-DD
+        type: string
+      book_id:
+        type: string
+      copy_count:
+        type: integer
+      created_at:
+        type: string
+      description:
+        type: string
+      duration_seconds:
+        type: integer
+      edition_name:
+        type: string
+      format:
+        type: string
+      id:
+        type: string
+      is_primary:
+        type: boolean
+      isbn_10:
+        type: string
+      isbn_13:
+        type: string
+      language:
+        type: string
+      narrator:
+        type: string
+      page_count:
+        type: integer
+      publish_date:
+        description: YYYY-MM-DD
+        type: string
+      publisher:
+        type: string
+      updated_at:
+        type: string
+    type: object
+  github_com_fireball1725_librarium-api_internal_api_responses.GenreRef:
+    properties:
+      id:
+        type: string
+      name:
+        type: string
+    type: object
+  github_com_fireball1725_librarium-api_internal_api_responses.GenreResponse:
+    properties:
+      created_at:
+        type: string
+      id:
+        type: string
+      name:
+        type: string
+    type: object
+  github_com_fireball1725_librarium-api_internal_api_responses.InteractionResponse:
+    properties:
+      book_edition_id:
+        type: string
+      created_at:
+        type: string
+      date_finished:
+        description: YYYY-MM-DD
+        type: string
+      date_started:
+        description: YYYY-MM-DD
+        type: string
+      id:
+        type: string
+      is_favorite:
+        type: boolean
+      notes:
+        type: string
+      rating:
+        type: integer
+      read_status:
+        type: string
+      reread_count:
+        type: integer
+      review:
+        type: string
+      updated_at:
+        type: string
+      user_id:
+        type: string
+    type: object
+  github_com_fireball1725_librarium-api_internal_api_responses.LibraryResponse:
+    properties:
+      book_count:
+        description: |-
+          BookCount is the total number of books in the library. ReadingCount
+          and ReadCount are caller-scoped — the calling user's reading + read
+          books in this library. Always populated on list endpoints; on single-
+          library endpoints they fall back to 0 unless the path was scoped.
+        type: integer
+      created_at:
+        type: string
+      description:
+        type: string
+      id:
+        type: string
+      is_public:
+        type: boolean
+      name:
+        type: string
+      owner_id:
+        type: string
+      read_count:
+        type: integer
+      reading_count:
+        type: integer
+      slug:
+        type: string
+      updated_at:
+        type: string
+    type: object
+  github_com_fireball1725_librarium-api_internal_api_responses.LoanResponse:
+    properties:
+      book_id:
+        type: string
+      book_title:
+        type: string
+      created_at:
+        type: string
+      due_date:
+        description: YYYY-MM-DD
+        type: string
+      id:
+        type: string
+      library_id:
+        type: string
+      loaned_at:
+        description: YYYY-MM-DD
+        type: string
+      loaned_to:
+        type: string
+      notes:
+        type: string
+      returned_at:
+        description: YYYY-MM-DD
+        type: string
+      tags:
+        items:
+          $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.TagRef'
+        type: array
+      updated_at:
+        type: string
+    type: object
+  github_com_fireball1725_librarium-api_internal_api_responses.MediaTypeResponse:
+    properties:
+      book_count:
+        type: integer
+      description:
+        type: string
+      display_name:
+        type: string
+      id:
+        type: string
+      name:
+        type: string
+    type: object
+  github_com_fireball1725_librarium-api_internal_api_responses.MemberResponse:
+    properties:
+      display_name:
+        type: string
+      email:
+        type: string
+      invited_by:
+        type: string
+      joined_at:
+        type: string
+      role:
+        type: string
+      role_id:
+        type: string
+      tags:
+        items:
+          $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.TagRef'
+        type: array
+      user_id:
+        type: string
+      username:
+        type: string
+    type: object
+  github_com_fireball1725_librarium-api_internal_api_responses.SeriesEntryResponse:
+    properties:
+      book_id:
+        type: string
+      contributors:
+        items:
+          $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.ContributorRef'
+        type: array
+      media_type:
+        type: string
+      position:
+        type: number
+      subtitle:
+        type: string
+      title:
+        type: string
+    type: object
+  github_com_fireball1725_librarium-api_internal_api_responses.SeriesRef:
+    properties:
+      position:
+        type: number
+      series_id:
+        type: string
+      series_name:
+        type: string
+    type: object
+  github_com_fireball1725_librarium-api_internal_api_responses.SeriesResponse:
+    properties:
+      book_count:
+        type: integer
+      created_at:
+        type: string
+      demographic:
+        type: string
+      description:
+        type: string
+      external_id:
+        type: string
+      external_source:
+        type: string
+      genres:
+        items:
+          type: string
+        type: array
+      id:
+        type: string
+      is_complete:
+        type: boolean
+      last_release_date:
+        description: YYYY-MM-DD
+        type: string
+      library_id:
+        type: string
+      name:
+        type: string
+      next_release_date:
+        description: YYYY-MM-DD
+        type: string
+      original_language:
+        type: string
+      publication_year:
+        type: integer
+      status:
+        type: string
+      tags:
+        items:
+          $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.TagRef'
+        type: array
+      total_count:
+        type: integer
+      updated_at:
+        type: string
+      url:
+        type: string
+    type: object
+  github_com_fireball1725_librarium-api_internal_api_responses.SeriesVolumeResponse:
+    properties:
+      cover_url:
+        type: string
+      created_at:
+        type: string
+      external_id:
+        type: string
+      id:
+        type: string
+      position:
+        type: number
+      release_date:
+        description: YYYY-MM-DD
+        type: string
+      series_id:
+        type: string
+      title:
+        type: string
+      updated_at:
+        type: string
+    type: object
+  github_com_fireball1725_librarium-api_internal_api_responses.ShelfRef:
+    properties:
+      id:
+        type: string
+      name:
+        type: string
+    type: object
+  github_com_fireball1725_librarium-api_internal_api_responses.ShelfResponse:
+    properties:
+      book_count:
+        type: integer
+      color:
+        type: string
+      created_at:
+        type: string
+      description:
+        type: string
+      display_order:
+        type: integer
+      icon:
+        type: string
+      id:
+        type: string
+      library_id:
+        type: string
+      name:
+        type: string
+      tags:
+        items:
+          $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.TagRef'
+        type: array
+      updated_at:
+        type: string
+    type: object
+  github_com_fireball1725_librarium-api_internal_api_responses.SyncApplyOp:
+    properties:
+      deleted:
+        type: boolean
+      entity_id:
+        type: string
+      entity_type:
+        type: string
+      field:
+        type: string
+      op_id:
+        type: string
+      updated_at:
+        type: string
+      value: {}
+    type: object
+  github_com_fireball1725_librarium-api_internal_api_responses.SyncApplyRequest:
+    properties:
+      client_id:
+        type: string
+      ops:
+        items:
+          $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.SyncApplyOp'
+        type: array
+    type: object
+  github_com_fireball1725_librarium-api_internal_api_responses.SyncApplyResponse:
+    properties:
+      results:
+        items:
+          $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.SyncApplyResult'
+        type: array
+      server_time:
+        type: string
+    type: object
+  github_com_fireball1725_librarium-api_internal_api_responses.SyncApplyResult:
+    properties:
+      error:
+        type: string
+      op_id:
+        type: string
+      status:
+        type: string
+    type: object
+  github_com_fireball1725_librarium-api_internal_api_responses.SyncChangesResponse:
+    properties:
+      has_more:
+        type: boolean
+      ops:
+        items:
+          $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.SyncOp'
+        type: array
+      server_time:
+        type: string
+    type: object
+  github_com_fireball1725_librarium-api_internal_api_responses.SyncOp:
+    properties:
+      deleted:
+        type: boolean
+      entity_id:
+        type: string
+      entity_type:
+        type: string
+      field:
+        type: string
+      updated_at:
+        type: string
+      value: {}
+    type: object
+  github_com_fireball1725_librarium-api_internal_api_responses.TagRef:
+    properties:
+      color:
+        type: string
+      created_at:
+        type: string
+      id:
+        type: string
+      library_id:
+        type: string
+      name:
+        type: string
+    type: object
+  github_com_fireball1725_librarium-api_internal_api_responses.TagResponse:
+    properties:
+      color:
+        type: string
+      created_at:
+        type: string
+      id:
+        type: string
+      library_id:
+        type: string
+      name:
+        type: string
+    type: object
+  github_com_fireball1725_librarium-api_internal_api_responses.UserResponse:
+    properties:
+      display_name:
+        type: string
+      email:
+        type: string
+      id:
+        type: string
+      is_instance_admin:
+        type: boolean
+      username:
+        type: string
+    type: object
   github_com_fireball1725_librarium-api_internal_models.AIMetadataProposal:
     properties:
       applied_at:
@@ -283,6 +797,22 @@ definitions:
       title:
         type: string
     type: object
+  github_com_fireball1725_librarium-api_internal_providers.ConfigField:
+    properties:
+      help_text:
+        type: string
+      key:
+        type: string
+      label:
+        type: string
+      placeholder:
+        type: string
+      required:
+        type: boolean
+      type:
+        description: '"password" | "text" | "url"'
+        type: string
+    type: object
   github_com_fireball1725_librarium-api_internal_providers.CoverOption:
     properties:
       cover_url:
@@ -387,6 +917,88 @@ definitions:
       url:
         type: string
     type: object
+  github_com_fireball1725_librarium-api_internal_repository.AuthorIndexEntry:
+    properties:
+      book_count:
+        type: integer
+      has_photo:
+        type: boolean
+      id:
+        type: string
+      letter:
+        description: |-
+          Letter the index files this author under, taken from sort_name so
+          "Ursula K. Le Guin" appears under L rather than U. '#' for anything
+          that does not start with a letter.
+        type: string
+      libraries:
+        items:
+          $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_repository.AuthorLibraryRef'
+        type: array
+      name:
+        type: string
+      read_count:
+        type: integer
+      sort_name:
+        type: string
+      spines:
+        items:
+          $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_repository.AuthorSpine'
+        type: array
+    type: object
+  github_com_fireball1725_librarium-api_internal_repository.AuthorLibraryRef:
+    properties:
+      id:
+        type: string
+      name:
+        type: string
+    type: object
+  github_com_fireball1725_librarium-api_internal_repository.AuthorSpine:
+    properties:
+      book_id:
+        type: string
+      has_cover:
+        type: boolean
+      title:
+        type: string
+      updated_at:
+        type: string
+    type: object
+  github_com_fireball1725_librarium-api_internal_repository.BookFacets:
+    properties:
+      genre:
+        items:
+          $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_repository.FacetValue'
+        type: array
+      library:
+        items:
+          $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_repository.FacetValue'
+        type: array
+      media_type:
+        items:
+          $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_repository.FacetValue'
+        type: array
+      ownership:
+        items:
+          $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_repository.FacetValue'
+        type: array
+      rating:
+        items:
+          $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_repository.FacetValue'
+        type: array
+      read_status:
+        items:
+          $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_repository.FacetValue'
+        type: array
+      shelf:
+        items:
+          $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_repository.FacetValue'
+        type: array
+      tag:
+        items:
+          $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_repository.FacetValue'
+        type: array
+    type: object
   github_com_fireball1725_librarium-api_internal_repository.BookFingerprint:
     properties:
       max_updated_at:
@@ -394,6 +1006,32 @@ definitions:
         type: string
       total:
         type: integer
+    type: object
+  github_com_fireball1725_librarium-api_internal_repository.FacetValue:
+    properties:
+      count:
+        type: integer
+      label:
+        type: string
+      value:
+        type: string
+    type: object
+  github_com_fireball1725_librarium-api_internal_repository.LibraryAccess:
+    properties:
+      book_count:
+        type: integer
+      library_id:
+        type: string
+      name:
+        type: string
+      permissions:
+        items:
+          type: string
+        type: array
+      role:
+        type: string
+      slug:
+        type: string
     type: object
   github_com_fireball1725_librarium-api_internal_service.AIPermissions:
     properties:
@@ -515,6 +1153,10 @@ definitions:
         additionalProperties:
           type: string
         type: object
+      config_fields:
+        items:
+          $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_providers.ConfigField'
+        type: array
       description:
         type: string
       display_name:
@@ -834,469 +1476,6 @@ definitions:
           type: string
         type: array
       token_suffix:
-        type: string
-    type: object
-  responses.BookResponse:
-    properties:
-      active_loan_count:
-        description: |-
-          ActiveLoanCount is the number of active (not yet returned) loans for
-          this book — scoped to the library when the read is library-scoped,
-          global otherwise. Always populated.
-        type: integer
-      active_loans:
-        description: |-
-          ActiveLoans is the full list of active loans for this book. Only
-          populated by single-book reads (GetBook); list endpoints omit it to
-          keep payloads lean — use active_loan_count there for the badge.
-        items:
-          $ref: '#/definitions/responses.LoanResponse'
-        type: array
-      added_by:
-        type: string
-      contributors:
-        items:
-          $ref: '#/definitions/responses.ContributorRef'
-        type: array
-      cover_url:
-        type: string
-      created_at:
-        type: string
-      description:
-        type: string
-      genres:
-        items:
-          $ref: '#/definitions/responses.GenreRef'
-        type: array
-      id:
-        type: string
-      language:
-        type: string
-      library_id:
-        type: string
-      media_type:
-        type: string
-      media_type_id:
-        type: string
-      publish_year:
-        type: integer
-      publisher:
-        type: string
-      series:
-        items:
-          $ref: '#/definitions/responses.SeriesRef'
-        type: array
-      shelves:
-        items:
-          $ref: '#/definitions/responses.ShelfRef'
-        type: array
-      subtitle:
-        type: string
-      tags:
-        items:
-          $ref: '#/definitions/responses.TagRef'
-        type: array
-      title:
-        type: string
-      updated_at:
-        type: string
-      user_progress_pct:
-        description: UserProgressPct is the caller's reading progress 0-100 (0 = none).
-        type: number
-      user_rating:
-        description: UserRating is the caller's rating (1-10 half-star integer; 0
-          = none).
-        type: integer
-    type: object
-  responses.ContributorItem:
-    properties:
-      id:
-        type: string
-      name:
-        type: string
-    type: object
-  responses.ContributorRef:
-    properties:
-      contributor_id:
-        type: string
-      display_order:
-        type: integer
-      name:
-        type: string
-      role:
-        type: string
-    type: object
-  responses.EditionResponse:
-    properties:
-      acquired_at:
-        description: YYYY-MM-DD
-        type: string
-      book_id:
-        type: string
-      copy_count:
-        type: integer
-      created_at:
-        type: string
-      description:
-        type: string
-      duration_seconds:
-        type: integer
-      edition_name:
-        type: string
-      format:
-        type: string
-      id:
-        type: string
-      is_primary:
-        type: boolean
-      isbn_10:
-        type: string
-      isbn_13:
-        type: string
-      language:
-        type: string
-      narrator:
-        type: string
-      page_count:
-        type: integer
-      publish_date:
-        description: YYYY-MM-DD
-        type: string
-      publisher:
-        type: string
-      updated_at:
-        type: string
-    type: object
-  responses.GenreRef:
-    properties:
-      id:
-        type: string
-      name:
-        type: string
-    type: object
-  responses.GenreResponse:
-    properties:
-      created_at:
-        type: string
-      id:
-        type: string
-      name:
-        type: string
-    type: object
-  responses.InteractionResponse:
-    properties:
-      book_edition_id:
-        type: string
-      created_at:
-        type: string
-      date_finished:
-        description: YYYY-MM-DD
-        type: string
-      date_started:
-        description: YYYY-MM-DD
-        type: string
-      id:
-        type: string
-      is_favorite:
-        type: boolean
-      notes:
-        type: string
-      rating:
-        type: integer
-      read_status:
-        type: string
-      reread_count:
-        type: integer
-      review:
-        type: string
-      updated_at:
-        type: string
-      user_id:
-        type: string
-    type: object
-  responses.LibraryResponse:
-    properties:
-      book_count:
-        description: |-
-          BookCount is the total number of books in the library. ReadingCount
-          and ReadCount are caller-scoped — the calling user's reading + read
-          books in this library. Always populated on list endpoints; on single-
-          library endpoints they fall back to 0 unless the path was scoped.
-        type: integer
-      created_at:
-        type: string
-      description:
-        type: string
-      id:
-        type: string
-      is_public:
-        type: boolean
-      name:
-        type: string
-      owner_id:
-        type: string
-      read_count:
-        type: integer
-      reading_count:
-        type: integer
-      slug:
-        type: string
-      updated_at:
-        type: string
-    type: object
-  responses.LoanResponse:
-    properties:
-      book_id:
-        type: string
-      book_title:
-        type: string
-      created_at:
-        type: string
-      due_date:
-        description: YYYY-MM-DD
-        type: string
-      id:
-        type: string
-      library_id:
-        type: string
-      loaned_at:
-        description: YYYY-MM-DD
-        type: string
-      loaned_to:
-        type: string
-      notes:
-        type: string
-      returned_at:
-        description: YYYY-MM-DD
-        type: string
-      tags:
-        items:
-          $ref: '#/definitions/responses.TagRef'
-        type: array
-      updated_at:
-        type: string
-    type: object
-  responses.MediaTypeResponse:
-    properties:
-      book_count:
-        type: integer
-      description:
-        type: string
-      display_name:
-        type: string
-      id:
-        type: string
-      name:
-        type: string
-    type: object
-  responses.MemberResponse:
-    properties:
-      display_name:
-        type: string
-      email:
-        type: string
-      invited_by:
-        type: string
-      joined_at:
-        type: string
-      role:
-        type: string
-      role_id:
-        type: string
-      tags:
-        items:
-          $ref: '#/definitions/responses.TagRef'
-        type: array
-      user_id:
-        type: string
-      username:
-        type: string
-    type: object
-  responses.PagedBooksResponse:
-    properties:
-      items:
-        items:
-          $ref: '#/definitions/responses.BookResponse'
-        type: array
-      page:
-        type: integer
-      per_page:
-        type: integer
-      suggestions:
-        items:
-          type: string
-        type: array
-      total:
-        type: integer
-    type: object
-  responses.SeriesEntryResponse:
-    properties:
-      book_id:
-        type: string
-      contributors:
-        items:
-          $ref: '#/definitions/responses.ContributorRef'
-        type: array
-      media_type:
-        type: string
-      position:
-        type: number
-      subtitle:
-        type: string
-      title:
-        type: string
-    type: object
-  responses.SeriesRef:
-    properties:
-      position:
-        type: number
-      series_id:
-        type: string
-      series_name:
-        type: string
-    type: object
-  responses.SeriesResponse:
-    properties:
-      book_count:
-        type: integer
-      created_at:
-        type: string
-      demographic:
-        type: string
-      description:
-        type: string
-      external_id:
-        type: string
-      external_source:
-        type: string
-      genres:
-        items:
-          type: string
-        type: array
-      id:
-        type: string
-      is_complete:
-        type: boolean
-      last_release_date:
-        description: YYYY-MM-DD
-        type: string
-      library_id:
-        type: string
-      name:
-        type: string
-      next_release_date:
-        description: YYYY-MM-DD
-        type: string
-      original_language:
-        type: string
-      publication_year:
-        type: integer
-      status:
-        type: string
-      tags:
-        items:
-          $ref: '#/definitions/responses.TagRef'
-        type: array
-      total_count:
-        type: integer
-      updated_at:
-        type: string
-      url:
-        type: string
-    type: object
-  responses.SeriesVolumeResponse:
-    properties:
-      cover_url:
-        type: string
-      created_at:
-        type: string
-      external_id:
-        type: string
-      id:
-        type: string
-      position:
-        type: number
-      release_date:
-        description: YYYY-MM-DD
-        type: string
-      series_id:
-        type: string
-      title:
-        type: string
-      updated_at:
-        type: string
-    type: object
-  responses.ShelfRef:
-    properties:
-      id:
-        type: string
-      name:
-        type: string
-    type: object
-  responses.ShelfResponse:
-    properties:
-      book_count:
-        type: integer
-      color:
-        type: string
-      created_at:
-        type: string
-      description:
-        type: string
-      display_order:
-        type: integer
-      icon:
-        type: string
-      id:
-        type: string
-      library_id:
-        type: string
-      name:
-        type: string
-      tags:
-        items:
-          $ref: '#/definitions/responses.TagRef'
-        type: array
-      updated_at:
-        type: string
-    type: object
-  responses.TagRef:
-    properties:
-      color:
-        type: string
-      created_at:
-        type: string
-      id:
-        type: string
-      library_id:
-        type: string
-      name:
-        type: string
-    type: object
-  responses.TagResponse:
-    properties:
-      color:
-        type: string
-      created_at:
-        type: string
-      id:
-        type: string
-      library_id:
-        type: string
-      name:
-        type: string
-    type: object
-  responses.UserResponse:
-    properties:
-      display_name:
-        type: string
-      email:
-        type: string
-      id:
-        type: string
-      is_instance_admin:
-        type: boolean
-      username:
         type: string
     type: object
 host: localhost:8080
@@ -2681,7 +2860,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/responses.UserResponse'
+            $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.UserResponse'
         "401":
           description: Unauthorized
           schema:
@@ -2716,7 +2895,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/responses.UserResponse'
+            $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.UserResponse'
         "400":
           description: Bad Request
           schema:
@@ -3030,6 +3209,38 @@ paths:
       summary: Re-enrich metadata for a single book
       tags:
       - books
+  /components:
+    get:
+      description: Every Go module linked into this API binary, with its version and
+        SPDX licence identifier. Clients render this on their licences page so the
+        notices cover the server as well as the client. A component whose licence
+        is unknown is returned with an empty licence rather than omitted.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            properties:
+              components:
+                items:
+                  properties:
+                    licence:
+                      type: string
+                    name:
+                      type: string
+                    version:
+                      type: string
+                  type: object
+                type: array
+              version:
+                type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: List server components
+      tags:
+      - health
   /contributors:
     get:
       description: Full-text search for contributors (authors, illustrators, etc.).
@@ -3047,7 +3258,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/responses.ContributorItem'
+              $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.ContributorItem'
             type: array
         "401":
           description: Unauthorized
@@ -3081,7 +3292,7 @@ paths:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/responses.ContributorItem'
+            $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.ContributorItem'
         "400":
           description: Bad Request
           schema:
@@ -3502,7 +3713,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/responses.GenreResponse'
+              $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.GenreResponse'
             type: array
         "401":
           description: Unauthorized
@@ -3536,7 +3747,7 @@ paths:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/responses.GenreResponse'
+            $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.GenreResponse'
         "400":
           description: Bad Request
           schema:
@@ -3633,7 +3844,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/responses.GenreResponse'
+            $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.GenreResponse'
         "400":
           description: Bad Request
           schema:
@@ -3815,7 +4026,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/responses.LibraryResponse'
+              $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.LibraryResponse'
             type: array
         "401":
           description: Unauthorized
@@ -3855,7 +4066,7 @@ paths:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/responses.LibraryResponse'
+            $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.LibraryResponse'
         "400":
           description: Bad Request
           schema:
@@ -3934,7 +4145,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/responses.LibraryResponse'
+            $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.LibraryResponse'
         "400":
           description: Bad Request
           schema:
@@ -3990,7 +4201,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/responses.LibraryResponse'
+            $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.LibraryResponse'
         "400":
           description: Bad Request
           schema:
@@ -4037,7 +4248,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/responses.BookResponse'
+            $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.BookResponse'
         "400":
           description: Bad Request
           schema:
@@ -4066,75 +4277,7 @@ paths:
       - books
   /libraries/{library_id}/books:
     get:
-      description: Returns a paginated, filtered, sorted list of books in the library.
-      parameters:
-      - description: Library UUID
-        in: path
-        name: library_id
-        required: true
-        type: string
-      - description: Search query or query-language expression
-        in: query
-        name: q
-        type: string
-      - description: Page number
-        in: query
-        name: page
-        type: integer
-      - description: Items per page
-        in: query
-        name: per_page
-        type: integer
-      - description: Sort field
-        in: query
-        name: sort
-        type: string
-      - description: Sort direction (asc/desc)
-        in: query
-        name: sort_dir
-        type: string
-      - description: Filter by first letter
-        in: query
-        name: letter
-        type: string
-      - description: Filter by tag name
-        in: query
-        name: tag
-        type: string
-      - description: Filter by media type
-        in: query
-        name: type_filter
-        type: string
-      - description: Treat q as regex
-        in: query
-        name: regex
-        type: boolean
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/responses.PagedBooksResponse'
-        "400":
-          description: Bad Request
-          schema:
-            properties:
-              error:
-                type: string
-            type: object
-        "401":
-          description: Unauthorized
-          schema:
-            properties:
-              error:
-                type: string
-            type: object
-      security:
-      - BearerAuth: []
-      summary: List books in a library
-      tags:
-      - books
+      responses: {}
     post:
       consumes:
       - application/json
@@ -4180,7 +4323,7 @@ paths:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/responses.BookResponse'
+            $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.BookResponse'
         "400":
           description: Bad Request
           schema:
@@ -4267,7 +4410,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/responses.BookResponse'
+            $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.BookResponse'
         "400":
           description: Bad Request
           schema:
@@ -4387,7 +4530,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/responses.BookResponse'
+            $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.BookResponse'
         "400":
           description: Bad Request
           schema:
@@ -4594,7 +4737,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/responses.EditionResponse'
+              $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.EditionResponse'
             type: array
         "400":
           description: Bad Request
@@ -4671,7 +4814,7 @@ paths:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/responses.EditionResponse'
+            $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.EditionResponse'
         "400":
           description: Bad Request
           schema:
@@ -4800,7 +4943,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/responses.EditionResponse'
+            $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.EditionResponse'
         "400":
           description: Bad Request
           schema:
@@ -5114,7 +5257,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/responses.InteractionResponse'
+            $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.InteractionResponse'
         "400":
           description: Bad Request
           schema:
@@ -5182,7 +5325,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/responses.InteractionResponse'
+            $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.InteractionResponse'
         "400":
           description: Bad Request
           schema:
@@ -5272,7 +5415,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/responses.ShelfResponse'
+              $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.ShelfResponse'
             type: array
         "400":
           description: Bad Request
@@ -5408,6 +5551,54 @@ paths:
       tags:
       - books
       - enrichment
+  /libraries/{library_id}/books/facets:
+    get:
+      description: |-
+        Counts books per facet value across the whole filtered set, not
+        the returned page, so a client can render a filter rail without
+        a request per value. Takes the same query parameters as the list
+        endpoint and applies exactly the same filter.
+      parameters:
+      - description: Library ID
+        in: path
+        name: library_id
+        required: true
+        type: string
+      - description: Search query
+        in: query
+        name: q
+        type: string
+      - description: Structured filter JSON
+        in: query
+        name: filter
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            properties:
+              data:
+                $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_repository.BookFacets'
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+      summary: Facet counts for a book search
+      tags:
+      - books
   /libraries/{library_id}/books/fingerprint:
     get:
       description: |-
@@ -5804,7 +5995,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/responses.LoanResponse'
+              $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.LoanResponse'
             type: array
         "400":
           description: Bad Request
@@ -5858,7 +6049,7 @@ paths:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/responses.LoanResponse'
+            $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.LoanResponse'
         "400":
           description: Bad Request
           schema:
@@ -5957,7 +6148,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/responses.LoanResponse'
+            $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.LoanResponse'
         "400":
           description: Bad Request
           schema:
@@ -6008,7 +6199,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/responses.MemberResponse'
+              $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.MemberResponse'
             type: array
         "400":
           description: Bad Request
@@ -6307,7 +6498,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/responses.SeriesResponse'
+              $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.SeriesResponse'
             type: array
         "400":
           description: Bad Request
@@ -6379,7 +6570,7 @@ paths:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/responses.SeriesResponse'
+            $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.SeriesResponse'
         "400":
           description: Bad Request
           schema:
@@ -6461,7 +6652,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/responses.SeriesResponse'
+            $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.SeriesResponse'
         "400":
           description: Bad Request
           schema:
@@ -6544,7 +6735,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/responses.SeriesResponse'
+            $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.SeriesResponse'
         "400":
           description: Bad Request
           schema:
@@ -6854,7 +7045,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/responses.SeriesEntryResponse'
+              $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.SeriesEntryResponse'
             type: array
         "400":
           description: Bad Request
@@ -7265,7 +7456,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/responses.SeriesVolumeResponse'
+              $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.SeriesVolumeResponse'
             type: array
         "400":
           description: Bad Request
@@ -7308,7 +7499,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/responses.SeriesVolumeResponse'
+              $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.SeriesVolumeResponse'
             type: array
         "400":
           description: Bad Request
@@ -7461,7 +7652,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/responses.ShelfResponse'
+              $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.ShelfResponse'
             type: array
         "400":
           description: Bad Request
@@ -7519,7 +7710,7 @@ paths:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/responses.ShelfResponse'
+            $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.ShelfResponse'
         "400":
           description: Bad Request
           schema:
@@ -7624,7 +7815,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/responses.ShelfResponse'
+            $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.ShelfResponse'
         "400":
           description: Bad Request
           schema:
@@ -7672,7 +7863,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/responses.BookResponse'
+              $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.BookResponse'
             type: array
         "400":
           description: Bad Request
@@ -7841,7 +8032,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/responses.TagResponse'
+              $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.TagResponse'
             type: array
         "400":
           description: Bad Request
@@ -7889,7 +8080,7 @@ paths:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/responses.TagResponse'
+            $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.TagResponse'
         "400":
           description: Bad Request
           schema:
@@ -7984,7 +8175,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/responses.TagResponse'
+            $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.TagResponse'
         "400":
           description: Bad Request
           schema:
@@ -8310,6 +8501,334 @@ paths:
       tags:
       - me
       - api-tokens
+  /me/authors/index:
+    get:
+      description: |-
+        The cross-library Authors surface, with per-author book and
+        read counts, cover thumbnails, and the letter each name files
+        under. Unpaged, for the same reason as the series index.
+      parameters:
+      - description: Contributor roles, comma separated. Defaults to author.
+        in: query
+        name: role
+        type: string
+      - description: Library UUIDs, comma separated. Narrows the scope; cannot widen
+          it.
+        in: query
+        name: lib
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            properties:
+              items:
+                items:
+                  $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_repository.AuthorIndexEntry'
+                type: array
+              total:
+                type: integer
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Authors across every library the caller can read
+      tags:
+      - me
+  /me/books:
+    get:
+      description: |-
+        The default browse surface. Takes the same filters as the
+        per-library list endpoint; library becomes one filter among
+        several rather than part of the path.
+      parameters:
+      - description: Search query
+        in: query
+        name: q
+        type: string
+      - description: Page number
+        in: query
+        name: page
+        type: integer
+      - description: Results per page
+        in: query
+        name: per_page
+        type: integer
+      - description: Structured filter JSON
+        in: query
+        name: filter
+        type: string
+      - description: Library ids, comma separated
+        in: query
+        name: lib
+        type: string
+      - description: Read statuses, comma separated
+        in: query
+        name: status
+        type: string
+      - description: Media type names, comma separated
+        in: query
+        name: type
+        type: string
+      - description: Genre names, comma separated
+        in: query
+        name: genre
+        type: string
+      - description: Tag names, comma separated
+        in: query
+        name: tag
+        type: string
+      - description: Ratings 0-5, comma separated
+        in: query
+        name: rating
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            properties:
+              items:
+                items:
+                  type: object
+                type: array
+              page:
+                type: integer
+              per_page:
+                type: integer
+              total:
+                type: integer
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+      summary: Books across every library the caller can read
+      tags:
+      - books
+  /me/books/facets:
+    get:
+      description: |-
+        Counts per facet value over the whole filtered set, so the
+        filter rail can be rendered in one request rather than one per
+        value. Same filters as /me/books.
+      parameters:
+      - description: Search query
+        in: query
+        name: q
+        type: string
+      - description: Structured filter JSON
+        in: query
+        name: filter
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            properties:
+              data:
+                $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_repository.BookFacets'
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+      summary: Facet counts across every library the caller can read
+      tags:
+      - books
+  /me/books/grouped:
+    get:
+      description: |-
+        Same filters as /me/books, but each series becomes one entry so
+        a run and a standalone book are peers. Paging is over entries;
+        book_total reports how many books those entries stand for,
+        because the facet rail still counts books.
+      parameters:
+      - description: Search query
+        in: query
+        name: q
+        type: string
+      - description: Library UUIDs, comma separated
+        in: query
+        name: lib
+        type: string
+      - description: Ownership states, comma separated
+        in: query
+        name: own
+        type: string
+      - description: Read statuses, comma separated
+        in: query
+        name: status
+        type: string
+      - description: Page, 1-based
+        in: query
+        name: page
+        type: integer
+      - description: Entries per page
+        in: query
+        name: per_page
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            properties:
+              book_total:
+                type: integer
+              items:
+                items:
+                  type: object
+                type: array
+              page:
+                type: integer
+              per_page:
+                type: integer
+              total:
+                type: integer
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Books across every readable library, series collapsed
+      tags:
+      - books
+  /me/counts:
+    get:
+      description: |-
+        Book, series and author counts across every library the caller
+        can read. One endpoint rather than three, because the sidebar
+        needs all of them on every page and none of them individually.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            properties:
+              authors:
+                type: integer
+              books:
+                type: integer
+              series:
+                type: integer
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Totals for the navigation
+      tags:
+      - me
+  /me/libraries:
+    get:
+      description: |-
+        Returns every library the authenticated user can see and the
+        permission names they hold in each, already capped by the
+        token's scope. A client fetches this once and gates each row by
+        the library the row came from, rather than checking per book.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            properties:
+              data:
+                items:
+                  $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_repository.LibraryAccess'
+                type: array
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+      summary: Libraries the caller can reach, with effective permissions
+      tags:
+      - libraries
+  /me/loans:
+    get:
+      description: |-
+        A loan is a book, a person and some dates; the library is where
+        the book happens to live. "Who has my stuff" is not a question
+        anyone asks one library at a time, so this is the whole set,
+        each row carrying the library it belongs to.
+      parameters:
+      - description: Library UUIDs, comma separated. Narrows the scope; cannot widen
+          it.
+        in: query
+        name: lib
+        type: string
+      - description: Match against borrower or book title
+        in: query
+        name: q
+        type: string
+      - description: Include loans already returned
+        in: query
+        name: include_returned
+        type: boolean
+      - description: Only loans past their due date
+        in: query
+        name: overdue
+        type: boolean
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            properties:
+              items:
+                items:
+                  $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.LoanResponse'
+                type: array
+              total:
+                type: integer
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Loans across every library the caller can read
+      tags:
+      - me
   /me/series:
     get:
       description: Returns series from every library the caller can access, filtered
@@ -8338,6 +8857,75 @@ paths:
       security:
       - BearerAuth: []
       summary: Search series across my libraries
+      tags:
+      - me
+  /me/series/index:
+    get:
+      description: |-
+        The cross-library Series surface. Unpaged: the A-Z bar has to
+        know which letters have series behind them, which means
+        counting the whole set anyway.
+      parameters:
+      - description: Name substring
+        in: query
+        name: q
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            properties:
+              items:
+                items:
+                  $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.SeriesResponse'
+                type: array
+              total:
+                type: integer
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Series across every library the caller can read
+      tags:
+      - me
+  /me/shelves:
+    get:
+      description: |-
+        The rail lists shelves beside libraries and views, so it needs
+        them across the whole readable scope rather than one library at
+        a time. Each carries its library, colour and icon.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            properties:
+              items:
+                items:
+                  $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.ShelfResponse'
+                type: array
+              total:
+                type: integer
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Shelves across every library the caller can read
       tags:
       - me
   /me/suggestions:
@@ -8714,7 +9302,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/responses.MediaTypeResponse'
+              $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.MediaTypeResponse'
             type: array
         "401":
           description: Unauthorized
@@ -8752,7 +9340,7 @@ paths:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/responses.MediaTypeResponse'
+            $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.MediaTypeResponse'
         "400":
           description: Bad Request
           schema:
@@ -8867,7 +9455,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/responses.MediaTypeResponse'
+            $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.MediaTypeResponse'
         "400":
           description: Bad Request
           schema:
@@ -8973,6 +9561,88 @@ paths:
       summary: Setup status
       tags:
       - setup
+  /sync/apply:
+    post:
+      consumes:
+      - application/json
+      description: 'Applies client ops with per-field last-writer-wins. Every op comes
+        back with its own status, so a partial success is normal and the client clears
+        only the ops it sees applied. Update-only in v1: create new rows through the
+        per-resource endpoints.'
+      parameters:
+      - description: Ops to apply, at most 1000
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.SyncApplyRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.SyncApplyResponse'
+        "400":
+          description: Bad Request
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Push a batch of client changes
+      tags:
+      - sync
+  /sync/changes:
+    get:
+      description: Returns the caller's data changed since `since`, oldest first.
+        Advance `since` to the newest updated_at you applied. When has_more is true
+        the response hit `limit` and you should call again straight away.
+      parameters:
+      - description: RFC3339 timestamp; returns changes strictly newer than this
+        in: query
+        name: since
+        required: true
+        type: string
+      - description: Ops per response, 1 to 1000 (default 500)
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_api_responses.SyncChangesResponse'
+        "400":
+          description: Bad Request
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Pull changes since a timestamp
+      tags:
+      - sync
   /users:
     get:
       description: Full-text search across users; returns minimal profile data. Query

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/swaggo/swag v1.16.6
 	golang.org/x/crypto v0.53.0
+	golang.org/x/text v0.40.0
 )
 
 require (
@@ -67,7 +68,6 @@ require (
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
-	golang.org/x/text v0.40.0 // indirect
 	golang.org/x/tools v0.47.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/internal/api/handlers/annotations_test.go
+++ b/internal/api/handlers/annotations_test.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725 (Adaléa)
+
+package handlers
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// modulePrefix is what swag calls this module's packages internally: the import
+// path with every separator flattened to an underscore.
+const modulePrefix = "github_com_fireball1725_librarium-api_"
+
+// annotationLine matches the swag directives that name a type. @Description is
+// excluded on purpose — it is prose, and "e.g. Foo.Bar" in a sentence is not a
+// type reference.
+var annotationLine = regexp.MustCompile(`^\s*//\s*@(Success|Failure|Param)\b`)
+
+// typeRef finds `alias.Type` pairs. The alias may carry the hyphen and
+// underscores of a mangled module path, which is why it is not just \w+.
+var typeRef = regexp.MustCompile(`\b([a-z][a-zA-Z0-9_\-]*)\.([A-Z][A-Za-z0-9_]*)\b`)
+
+// importLine pulls the path out of an import, with or without an explicit name.
+var importLine = regexp.MustCompile(`^\s*(?:([\w.]+)\s+)?"([^"]+)"\s*$`)
+
+// TestAnnotationTypesResolve catches the mistake that broke `make docs`.
+//
+// swag resolves a short package alias in a comment against the imports of the
+// file that comment sits in. A handler file has no reason to import a package
+// it only names in an annotation, so `responses.BookResponse` failed to resolve
+// in the nine files that wrote it — and because one bad annotation aborts the
+// whole `swag init` run, every route stopped regenerating. The committed spec
+// sat thirteen routes behind before anyone noticed, and a TODO in sync.go blamed
+// a swag parser bug that did not exist.
+//
+// This fails in `go test`, where it is seen, rather than in a docs target that
+// is easy to skip. Either import the package or use the mangled full path:
+//
+//	@Success 200 {object} github_com_fireball1725_librarium-api_internal_api_responses.BookResponse
+func TestAnnotationTypesResolve(t *testing.T) {
+	files, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("globbing handlers: %v", err)
+	}
+	if len(files) < 5 {
+		t.Fatalf("found %d files in the handlers package; the glob is wrong, and a "+
+			"glob that finds nothing would make this test pass by checking nothing", len(files))
+	}
+
+	checked := 0
+	for _, f := range files {
+		if strings.HasSuffix(f, "_test.go") {
+			continue
+		}
+		src, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("reading %s: %v", f, err)
+		}
+		known := importedNames(string(src))
+		known["handlers"] = true // the package this file is in
+
+		for i, line := range strings.Split(string(src), "\n") {
+			if !annotationLine.MatchString(line) {
+				continue
+			}
+			for _, m := range typeRef.FindAllStringSubmatch(line, -1) {
+				alias, typ := m[1], m[2]
+				checked++
+				if known[alias] || strings.HasPrefix(alias, modulePrefix) {
+					continue
+				}
+				t.Errorf("%s:%d: annotation names %s.%s, but %s is neither the "+
+					"current package nor imported by this file, so swag cannot resolve it.\n"+
+					"    Use %s<path>.%s, or import the package.",
+					f, i+1, alias, typ, alias, modulePrefix, typ)
+			}
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no annotation type references found; the regexes no longer match the " +
+			"comment style, so this test is passing without checking anything")
+	}
+	t.Logf("checked %d annotation type references across %d files", checked, len(files))
+}
+
+// importedNames returns the local names a file's imports bind, keyed for lookup.
+func importedNames(src string) map[string]bool {
+	out := map[string]bool{}
+	inBlock := false
+	for _, line := range strings.Split(src, "\n") {
+		trimmed := strings.TrimSpace(line)
+		switch {
+		case trimmed == "import (":
+			inBlock = true
+			continue
+		case inBlock && trimmed == ")":
+			inBlock = false
+			continue
+		case strings.HasPrefix(trimmed, "import "):
+			line = strings.TrimPrefix(trimmed, "import ")
+		case !inBlock:
+			continue
+		}
+		m := importLine.FindStringSubmatch(strings.TrimSpace(line))
+		if m == nil {
+			continue
+		}
+		if m[1] != "" {
+			out[m[1]] = true // explicit alias
+			continue
+		}
+		parts := strings.Split(m[2], "/")
+		out[parts[len(parts)-1]] = true
+	}
+	return out
+}

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -245,7 +245,7 @@ func (h *AuthHandler) Logout(w http.ResponseWriter, r *http.Request) {
 // @Produce     json
 // @Security    BearerAuth
 // @Param       body  body      object{display_name=string,email=string}  true  "Update profile request"
-// @Success     200   {object}  responses.UserResponse
+// @Success     200   {object}  github_com_fireball1725_librarium-api_internal_api_responses.UserResponse
 // @Failure     400   {object}  object{error=string}
 // @Failure     401   {object}  object{error=string}
 // @Failure     409   {object}  object{error=string}
@@ -342,7 +342,7 @@ func (h *AuthHandler) UpdatePassword(w http.ResponseWriter, r *http.Request) {
 // @Tags        auth
 // @Produce     json
 // @Security    BearerAuth
-// @Success     200  {object}  responses.UserResponse
+// @Success     200  {object}  github_com_fireball1725_librarium-api_internal_api_responses.UserResponse
 // @Failure     401  {object}  object{error=string}
 // @Router      /auth/me [get]
 func (h *AuthHandler) Me(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handlers/books.go
+++ b/internal/api/handlers/books.go
@@ -32,10 +32,11 @@ type BookHandler struct {
 	riverClient       *river.Client[pgx.Tx]           // may be nil; used for enrichment batch jobs
 	enrichmentBatches *repository.EnrichmentBatchRepo // may be nil; required for bulk enrich/cover
 	editionFiles      *service.EditionFileService
+	libraries         *repository.LibraryRepo // resolves the caller's readable libraries for the cross-library routes
 }
 
-func NewBookHandler(svc *service.BookService, books *repository.BookRepo, loans *repository.LoanRepo, riverClient *river.Client[pgx.Tx], enrichmentBatches *repository.EnrichmentBatchRepo, editionFiles *service.EditionFileService) *BookHandler {
-	return &BookHandler{svc: svc, books: books, loans: loans, riverClient: riverClient, enrichmentBatches: enrichmentBatches, editionFiles: editionFiles}
+func NewBookHandler(svc *service.BookService, books *repository.BookRepo, loans *repository.LoanRepo, riverClient *river.Client[pgx.Tx], enrichmentBatches *repository.EnrichmentBatchRepo, editionFiles *service.EditionFileService, libraries *repository.LibraryRepo) *BookHandler {
+	return &BookHandler{svc: svc, books: books, loans: loans, riverClient: riverClient, enrichmentBatches: enrichmentBatches, editionFiles: editionFiles, libraries: libraries}
 }
 
 // ─── Media types ──────────────────────────────────────────────────────────────
@@ -1059,7 +1060,7 @@ func (h *BookHandler) Facets(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	facets, err := h.books.Facets(r.Context(), libraryID, opts)
+	facets, err := h.books.Facets(r.Context(), []uuid.UUID{libraryID}, opts)
 	if err != nil {
 		respond.ServerError(w, r, err)
 		return

--- a/internal/api/handlers/books.go
+++ b/internal/api/handlers/books.go
@@ -199,19 +199,20 @@ func (h *BookHandler) GetBookFingerprint(w http.ResponseWriter, r *http.Request)
 // @Success     200  {object}  responses.PagedBooksResponse
 // @Failure     400  {object}  object{error=string}
 // @Failure     401  {object}  object{error=string}
-// @Router      /libraries/{library_id}/books [get]
-func (h *BookHandler) ListBooks(w http.ResponseWriter, r *http.Request) {
-	libraryID, err := uuid.Parse(r.PathValue("library_id"))
-	if err != nil {
-		respond.Error(w, http.StatusBadRequest, "invalid library id")
-		return
-	}
+// parseListBooksOpts turns a request's query string into the repository's
+// filter options. Shared by ListBooks and Facets: the counts have to be built
+// from exactly the same filter as the results, and the only way to guarantee
+// that is to parse it once.
+//
+// Returns the raw search text alongside the opts because ListBooks records it
+// for search suggestions and Facets does not.
+var errQueryTooLong = errors.New("query too long")
 
+func parseListBooksOpts(r *http.Request) (repository.ListBooksOpts, string, error) {
 	q := r.URL.Query().Get("q")
 	rawSearchQuery := q
 	if len(q) > 500 {
-		respond.Error(w, http.StatusBadRequest, "query too long")
-		return
+		return repository.ListBooksOpts{}, "", errQueryTooLong
 	}
 	page, _ := strconv.Atoi(r.URL.Query().Get("page"))
 	perPage, _ := strconv.Atoi(r.URL.Query().Get("per_page"))
@@ -275,7 +276,7 @@ func (h *BookHandler) ListBooks(w http.ResponseWriter, r *http.Request) {
 		callerID = claims.UserID
 	}
 
-	books, total, err := h.svc.ListBooks(r.Context(), libraryID, repository.ListBooksOpts{
+	return repository.ListBooksOpts{
 		Query:      q,
 		Page:       page,
 		PerPage:    perPage,
@@ -287,7 +288,23 @@ func (h *BookHandler) ListBooks(w http.ResponseWriter, r *http.Request) {
 		IsRegex:    isRegex,
 		Groups:     filterGroups,
 		CallerID:   callerID,
-	})
+	}, rawSearchQuery, nil
+}
+
+// @Router      /libraries/{library_id}/books [get]
+func (h *BookHandler) ListBooks(w http.ResponseWriter, r *http.Request) {
+	libraryID, err := uuid.Parse(r.PathValue("library_id"))
+	if err != nil {
+		respond.Error(w, http.StatusBadRequest, "invalid library id")
+		return
+	}
+
+	opts, rawSearchQuery, err := parseListBooksOpts(r)
+	if err != nil {
+		respond.Error(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	books, total, err := h.svc.ListBooks(r.Context(), libraryID, opts)
 	if err != nil {
 		respond.ServerError(w, r, err)
 		return
@@ -300,8 +317,8 @@ func (h *BookHandler) ListBooks(w http.ResponseWriter, r *http.Request) {
 	resp := map[string]any{
 		"items":    items,
 		"total":    total,
-		"page":     max(page, 1),
-		"per_page": perPage,
+		"page":     max(opts.Page, 1),
+		"per_page": opts.PerPage,
 	}
 	// "Did you mean…" — when the literal query found nothing, run a
 	// pg_trgm similarity match and include up to 5 suggestions. Skipped
@@ -1011,4 +1028,41 @@ func (h *BookHandler) createBatchItems(ctx context.Context, batchID uuid.UUID, b
 		}
 	}
 	return h.enrichmentBatches.CreateItems(ctx, items)
+}
+
+// Facets godoc
+//
+// @Summary     Facet counts for a book search
+// @Description Counts books per facet value across the whole filtered set, not
+// @Description the returned page, so a client can render a filter rail without
+// @Description a request per value. Takes the same query parameters as the list
+// @Description endpoint and applies exactly the same filter.
+// @Tags        books
+// @Produce     json
+// @Param       library_id  path  string  true  "Library ID"
+// @Param       q           query string  false "Search query"
+// @Param       filter      query string  false "Structured filter JSON"
+// @Success     200  {object}  object{data=repository.BookFacets}
+// @Failure     400  {object}  object{error=string}
+// @Failure     401  {object}  object{error=string}
+// @Router      /libraries/{library_id}/books/facets [get]
+func (h *BookHandler) Facets(w http.ResponseWriter, r *http.Request) {
+	libraryID, err := uuid.Parse(r.PathValue("library_id"))
+	if err != nil {
+		respond.Error(w, http.StatusBadRequest, "invalid library id")
+		return
+	}
+
+	opts, _, err := parseListBooksOpts(r)
+	if err != nil {
+		respond.Error(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	facets, err := h.books.Facets(r.Context(), libraryID, opts)
+	if err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
+	respond.JSON(w, http.StatusOK, map[string]any{"data": facets})
 }

--- a/internal/api/handlers/books.go
+++ b/internal/api/handlers/books.go
@@ -68,7 +68,7 @@ func (h *BookHandler) ListMediaTypes(w http.ResponseWriter, r *http.Request) {
 // @Produce     json
 // @Security    BearerAuth
 // @Param       q    query     string  true  "Search query (min 2 chars)"
-// @Success     200  {array}   responses.ContributorItem
+// @Success     200  {array}   github_com_fireball1725_librarium-api_internal_api_responses.ContributorItem
 // @Failure     401  {object}  object{error=string}
 // @Router      /contributors [get]
 func (h *BookHandler) SearchContributors(w http.ResponseWriter, r *http.Request) {
@@ -98,7 +98,7 @@ func (h *BookHandler) SearchContributors(w http.ResponseWriter, r *http.Request)
 // @Produce     json
 // @Security    BearerAuth
 // @Param       body  body      object{name=string}  true  "Contributor name"
-// @Success     201   {object}  responses.ContributorItem
+// @Success     201   {object}  github_com_fireball1725_librarium-api_internal_api_responses.ContributorItem
 // @Failure     400   {object}  object{error=string}
 // @Failure     401   {object}  object{error=string}
 // @Router      /contributors [post]
@@ -197,7 +197,7 @@ func (h *BookHandler) GetBookFingerprint(w http.ResponseWriter, r *http.Request)
 // @Param       tag          query     string   false  "Filter by tag name"
 // @Param       type_filter  query     string   false  "Filter by media type"
 // @Param       regex        query     boolean  false  "Treat q as regex"
-// @Success     200  {object}  responses.PagedBooksResponse
+// @Success     200  {object}  github_com_fireball1725_librarium-api_internal_api_responses.PagedBooksResponse
 // @Failure     400  {object}  object{error=string}
 // @Failure     401  {object}  object{error=string}
 // parseListBooksOpts turns a request's query string into the repository's
@@ -279,6 +279,8 @@ func parseListBooksOpts(r *http.Request) (repository.ListBooksOpts, string, erro
 
 	return repository.ListBooksOpts{
 		Query:      q,
+		SeriesIDs:  seriesIDsFromQuery(r),
+		ShelfIDs:   parseFacetSelection(r).Shelves,
 		Page:       page,
 		PerPage:    perPage,
 		Sort:       sort,
@@ -342,7 +344,7 @@ func (h *BookHandler) ListBooks(w http.ResponseWriter, r *http.Request) {
 // @Security    BearerAuth
 // @Param       library_id  path      string  true  "Library UUID"
 // @Param       body        body      object{title=string,subtitle=string,media_type_id=string,description=string,contributors=[]object,tag_ids=[]string,genre_ids=[]string,edition=object}  true  "Book details"
-// @Success     201  {object}  responses.BookResponse
+// @Success     201  {object}  github_com_fireball1725_librarium-api_internal_api_responses.BookResponse
 // @Failure     400  {object}  object{error=string}
 // @Failure     401  {object}  object{error=string}
 // @Router      /libraries/{library_id}/books [post]
@@ -377,7 +379,7 @@ func (h *BookHandler) CreateBook(w http.ResponseWriter, r *http.Request) {
 // @Security    BearerAuth
 // @Param       library_id  path      string  true  "Library UUID"
 // @Param       book_id     path      string  true  "Book UUID"
-// @Success     200  {object}  responses.BookResponse
+// @Success     200  {object}  github_com_fireball1725_librarium-api_internal_api_responses.BookResponse
 // @Failure     400  {object}  object{error=string}
 // @Failure     401  {object}  object{error=string}
 // @Failure     404  {object}  object{error=string}
@@ -388,10 +390,21 @@ func (h *BookHandler) GetBook(w http.ResponseWriter, r *http.Request) {
 		respond.Error(w, http.StatusBadRequest, "invalid book id")
 		return
 	}
-	libraryID, err := uuid.Parse(r.PathValue("library_id"))
-	if err != nil {
-		respond.Error(w, http.StatusBadRequest, "invalid library id")
-		return
+	// This handler serves two routes: the library-scoped one, and the bare
+	// /books/{book_id} the work-level detail page uses for a book that may sit
+	// in no library at all. On that route library_id is not a path value, so
+	// demanding one made the whole endpoint a 400 — and the Series index links
+	// every volume tick at it, so each of those was a dead link to a raw
+	// "invalid library id". Nil is the repository's own "no particular
+	// library", which it already handles; an id that is present but malformed
+	// is still the caller's mistake and still fails.
+	var libraryID uuid.UUID
+	if raw := r.PathValue("library_id"); raw != "" {
+		libraryID, err = uuid.Parse(raw)
+		if err != nil {
+			respond.Error(w, http.StatusBadRequest, "invalid library id")
+			return
+		}
 	}
 	// Caller-scope the user_read_status / user_rating / user_progress_pct
 	// + per-library active_loan_count columns so the per-book GET emits
@@ -431,7 +444,7 @@ func (h *BookHandler) GetBook(w http.ResponseWriter, r *http.Request) {
 // @Param       library_id  path      string  true  "Library UUID"
 // @Param       book_id     path      string  true  "Book UUID"
 // @Param       body        body      object{title=string,subtitle=string,media_type_id=string,description=string,contributors=[]object,tag_ids=[]string,genre_ids=[]string}  true  "Updated book"
-// @Success     200  {object}  responses.BookResponse
+// @Success     200  {object}  github_com_fireball1725_librarium-api_internal_api_responses.BookResponse
 // @Failure     400  {object}  object{error=string}
 // @Failure     401  {object}  object{error=string}
 // @Failure     404  {object}  object{error=string}
@@ -470,7 +483,7 @@ func (h *BookHandler) UpdateBook(w http.ResponseWriter, r *http.Request) {
 // @Security    BearerAuth
 // @Param       library_id  path      string  true  "Library UUID"
 // @Param       isbn        path      string  true  "ISBN-10 or ISBN-13"
-// @Success     200  {object}  responses.BookResponse
+// @Success     200  {object}  github_com_fireball1725_librarium-api_internal_api_responses.BookResponse
 // @Failure     400  {object}  object{error=string}
 // @Failure     401  {object}  object{error=string}
 // @Failure     404  {object}  object{error=string}
@@ -1061,7 +1074,7 @@ func (h *BookHandler) Facets(w http.ResponseWriter, r *http.Request) {
 	}
 
 	facets, err := h.books.Facets(r.Context(), []uuid.UUID{libraryID},
-		parseFacetSelection(r), r.URL.Query().Get("q"), callerID)
+		parseFacetSelection(r), r.URL.Query().Get("q"), seriesIDsFromQuery(r), callerID)
 	if err != nil {
 		respond.ServerError(w, r, err)
 		return

--- a/internal/api/handlers/books.go
+++ b/internal/api/handlers/books.go
@@ -1054,13 +1054,14 @@ func (h *BookHandler) Facets(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	opts, _, err := parseListBooksOpts(r)
-	if err != nil {
-		respond.Error(w, http.StatusBadRequest, err.Error())
-		return
+	claims := middleware.ClaimsFromContext(r.Context())
+	var callerID uuid.UUID
+	if claims != nil {
+		callerID = claims.UserID
 	}
 
-	facets, err := h.books.Facets(r.Context(), []uuid.UUID{libraryID}, opts)
+	facets, err := h.books.Facets(r.Context(), []uuid.UUID{libraryID},
+		parseFacetSelection(r), r.URL.Query().Get("q"), callerID)
 	if err != nil {
 		respond.ServerError(w, r, err)
 		return

--- a/internal/api/handlers/books_across.go
+++ b/internal/api/handlers/books_across.go
@@ -64,6 +64,52 @@ func (h *BookHandler) readableLibraryIDs(r *http.Request) ([]uuid.UUID, error) {
 	return readableLibraryIDs(r, h.libraries)
 }
 
+// narrowToReadable intersects a requested set of libraries with the readable
+// set, so a library filter can only ever shrink the scope.
+//
+// Intersection rather than substitution is the whole point: the requested ids
+// arrive from the client, and any code path that let them replace the readable
+// set would turn a query parameter into a way to read someone else's library.
+// An empty request means "no filter" and leaves the scope alone.
+func narrowToReadable(requested, readable []uuid.UUID) []uuid.UUID {
+	if len(requested) == 0 {
+		return readable
+	}
+	allowed := make(map[uuid.UUID]bool, len(readable))
+	for _, id := range readable {
+		allowed[id] = true
+	}
+	picked := make([]uuid.UUID, 0, len(requested))
+	for _, id := range requested {
+		if allowed[id] {
+			picked = append(picked, id)
+		}
+	}
+	return picked
+}
+
+// libraryIDsFromQuery reads a comma-separated `lib` parameter. Unparseable ids
+// are dropped rather than rejected: the parameter is a filter, and a stale
+// bookmark holding a deleted library should show nothing, not an error page.
+func libraryIDsFromQuery(r *http.Request) []uuid.UUID {
+	raw := r.URL.Query().Get("lib")
+	if raw == "" {
+		return nil
+	}
+	var ids []uuid.UUID
+	for _, part := range strings.Split(raw, ",") {
+		if id, err := uuid.Parse(strings.TrimSpace(part)); err == nil {
+			ids = append(ids, id)
+		}
+	}
+	// Every id was junk. That is a filter matching nothing, not an absent
+	// filter, so it must not fall back to the whole readable set.
+	if len(ids) == 0 {
+		return []uuid.UUID{uuid.Nil}
+	}
+	return ids
+}
+
 // ListMyBooks godoc
 //
 // @Summary     Books across every library the caller can read
@@ -107,19 +153,7 @@ func (h *BookHandler) ListMyBooks(w http.ResponseWriter, r *http.Request) {
 	// The library facet narrows the scope rather than adding a WHERE clause,
 	// and it narrows by intersection so a library id the caller cannot read
 	// cannot widen the result no matter what the client sends.
-	if len(sel.Libraries) > 0 {
-		readable := make(map[uuid.UUID]bool, len(libraryIDs))
-		for _, id := range libraryIDs {
-			readable[id] = true
-		}
-		picked := make([]uuid.UUID, 0, len(sel.Libraries))
-		for _, id := range sel.Libraries {
-			if readable[id] {
-				picked = append(picked, id)
-			}
-		}
-		libraryIDs = picked
-	}
+	libraryIDs = narrowToReadable(sel.Libraries, libraryIDs)
 	if len(libraryIDs) == 0 {
 		// Not an error. A new user, or one whose only membership was revoked,
 		// has an empty shelf and the client renders its own empty state.
@@ -173,7 +207,8 @@ func (h *BookHandler) MyBookFacets(w http.ResponseWriter, r *http.Request) {
 		callerID = claims.UserID
 	}
 
-	facets, err := h.books.Facets(r.Context(), libraryIDs, parseFacetSelection(r), r.URL.Query().Get("q"), callerID)
+	facets, err := h.books.Facets(r.Context(), libraryIDs, parseFacetSelection(r),
+		r.URL.Query().Get("q"), seriesIDsFromQuery(r), callerID)
 	if err != nil {
 		respond.ServerError(w, r, err)
 		return
@@ -211,6 +246,13 @@ func parseFacetSelection(r *http.Request) repository.FacetSelection {
 		Genres:     split("genre"),
 		Tags:       split("tag"),
 	}
+	// Shelves come through by id for the same reason libraries do: the name is
+	// only unique within one library.
+	for _, s := range split("shelf") {
+		if id, err := uuid.Parse(s); err == nil {
+			sel.Shelves = append(sel.Shelves, id)
+		}
+	}
 	for _, s := range split("lib") {
 		if id, err := uuid.Parse(s); err == nil {
 			sel.Libraries = append(sel.Libraries, id)
@@ -222,4 +264,113 @@ func parseFacetSelection(r *http.Request) repository.FacetSelection {
 		}
 	}
 	return sel
+}
+
+// ListMyBooksGrouped godoc
+//
+// @Summary     Books across every readable library, series collapsed
+// @Description Same filters as /me/books, but each series becomes one entry so
+// @Description a run and a standalone book are peers. Paging is over entries;
+// @Description book_total reports how many books those entries stand for,
+// @Description because the facet rail still counts books.
+// @Tags        books
+// @Produce     json
+// @Security    BearerAuth
+// @Param       q         query string false "Search query"
+// @Param       lib       query string false "Library UUIDs, comma separated"
+// @Param       own       query string false "Ownership states, comma separated"
+// @Param       status    query string false "Read statuses, comma separated"
+// @Param       page      query int    false "Page, 1-based"
+// @Param       per_page  query int    false "Entries per page"
+// @Success     200  {object}  object{items=[]object,total=int,book_total=int,page=int,per_page=int}
+// @Failure     401  {object}  object{error=string}
+// @Router      /me/books/grouped [get]
+func (h *BookHandler) ListMyBooksGrouped(w http.ResponseWriter, r *http.Request) {
+	opts, _, err := parseListBooksOpts(r)
+	if err != nil {
+		respond.Error(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	opts.Selection = parseFacetSelection(r)
+
+	libraryIDs, err := h.readableLibraryIDs(r)
+	if err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
+	libraryIDs = narrowToReadable(opts.Selection.Libraries, libraryIDs)
+	if len(libraryIDs) == 0 {
+		respond.JSON(w, http.StatusOK, map[string]any{
+			"items": []any{}, "total": 0, "book_total": 0,
+			"page": 1, "per_page": opts.PerPage,
+		})
+		return
+	}
+
+	entries, total, bookTotal, err := h.books.ListGroupedBySeries(r.Context(), libraryIDs, opts)
+	if err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
+
+	items := make([]map[string]any, 0, len(entries))
+	for _, e := range entries {
+		if e.Series != nil {
+			items = append(items, seriesGroupBody(e.Series))
+			continue
+		}
+		if e.Book != nil {
+			// The same body the ungrouped list sends, so a standalone entry and
+			// a row on /me/books are the same shape and the client renders one.
+			items = append(items, map[string]any{"kind": "book", "book": bookBody(e.Book)})
+		}
+	}
+
+	respond.JSON(w, http.StatusOK, map[string]any{
+		"items":      items,
+		"total":      total,
+		"book_total": bookTotal,
+		"page":       max(opts.Page, 1),
+		"per_page":   opts.PerPage,
+	})
+}
+
+func seriesGroupBody(g *repository.SeriesGroup) map[string]any {
+	var coverURL any
+	if g.CoverBookID != nil {
+		coverURL = "/api/v1/books/" + g.CoverBookID.String() + "/cover"
+	}
+	return map[string]any{
+		"kind":        "series",
+		"series_id":   g.ID,
+		"series_name": g.Name,
+		"matched":     g.Matched,
+		"owned":       g.Owned,
+		"read":        g.Read,
+		"total_count": g.TotalCount,
+		"cover_url":   coverURL,
+	}
+}
+
+// seriesIDsFromQuery reads a comma-separated `series` parameter.
+//
+// Several ids rather than one because selecting a page of collapsed groups asks
+// for every book in every series on that page, and one request beats one per
+// row. Unparseable ids are dropped for the same reason they are in
+// libraryIDsFromQuery: a stale link should show nothing, not an error page.
+func seriesIDsFromQuery(r *http.Request) []uuid.UUID {
+	raw := r.URL.Query().Get("series")
+	if raw == "" {
+		return nil
+	}
+	var ids []uuid.UUID
+	for _, part := range strings.Split(raw, ",") {
+		if id, err := uuid.Parse(strings.TrimSpace(part)); err == nil {
+			ids = append(ids, id)
+		}
+	}
+	if len(ids) == 0 {
+		return []uuid.UUID{uuid.Nil}
+	}
+	return ids
 }

--- a/internal/api/handlers/books_across.go
+++ b/internal/api/handlers/books_across.go
@@ -29,7 +29,11 @@ import (
 // readableLibraryIDs returns the libraries the caller may read books in.
 // Instance admins get every library, matching RequireLibraryPermission, which
 // lets them past the per-library membership check.
-func (h *BookHandler) readableLibraryIDs(r *http.Request) ([]uuid.UUID, error) {
+//
+// A free function rather than a method because every cross-library surface
+// needs the same answer, and the one thing that must not drift between them is
+// what the caller is allowed to see.
+func readableLibraryIDs(r *http.Request, libraries *repository.LibraryRepo) ([]uuid.UUID, error) {
 	claims := middleware.ClaimsFromContext(r.Context())
 	if claims == nil {
 		return nil, nil
@@ -40,7 +44,7 @@ func (h *BookHandler) readableLibraryIDs(r *http.Request) ([]uuid.UUID, error) {
 		return []uuid.UUID{}, nil
 	}
 
-	access, err := h.libraries.ListAccessForUser(r.Context(), claims.UserID, claims.IsInstanceAdmin)
+	access, err := libraries.ListAccessForUser(r.Context(), claims.UserID, claims.IsInstanceAdmin)
 	if err != nil {
 		return nil, err
 	}
@@ -54,6 +58,10 @@ func (h *BookHandler) readableLibraryIDs(r *http.Request) ([]uuid.UUID, error) {
 		}
 	}
 	return ids, nil
+}
+
+func (h *BookHandler) readableLibraryIDs(r *http.Request) ([]uuid.UUID, error) {
+	return readableLibraryIDs(r, h.libraries)
 }
 
 // ListMyBooks godoc

--- a/internal/api/handlers/books_across.go
+++ b/internal/api/handlers/books_across.go
@@ -205,6 +205,7 @@ func parseFacetSelection(r *http.Request) repository.FacetSelection {
 	}
 
 	sel := repository.FacetSelection{
+		Ownership:  split("own"),
 		ReadStatus: split("status"),
 		MediaTypes: split("type"),
 		Genres:     split("genre"),

--- a/internal/api/handlers/books_across.go
+++ b/internal/api/handlers/books_across.go
@@ -68,6 +68,12 @@ func (h *BookHandler) readableLibraryIDs(r *http.Request) ([]uuid.UUID, error) {
 // @Param       page      query int    false "Page number"
 // @Param       per_page  query int    false "Results per page"
 // @Param       filter    query string false "Structured filter JSON"
+// @Param       lib       query string false "Library ids, comma separated"
+// @Param       status    query string false "Read statuses, comma separated"
+// @Param       type      query string false "Media type names, comma separated"
+// @Param       genre     query string false "Genre names, comma separated"
+// @Param       tag       query string false "Tag names, comma separated"
+// @Param       rating    query string false "Ratings 0-5, comma separated"
 // @Success     200  {object}  object{items=[]object,total=int,page=int,per_page=int}
 // @Failure     401  {object}  object{error=string}
 // @Router      /me/books [get]
@@ -78,10 +84,33 @@ func (h *BookHandler) ListMyBooks(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// The list takes the same facet parameters as the counts beside it. One wire
+	// format, one selection struct: a rail that says "Reading 29" and a list
+	// that ignores the tick is the failure this prevents.
+	sel := parseFacetSelection(r)
+	opts.Selection = sel
+
 	libraryIDs, err := h.readableLibraryIDs(r)
 	if err != nil {
 		respond.ServerError(w, r, err)
 		return
+	}
+
+	// The library facet narrows the scope rather than adding a WHERE clause,
+	// and it narrows by intersection so a library id the caller cannot read
+	// cannot widen the result no matter what the client sends.
+	if len(sel.Libraries) > 0 {
+		readable := make(map[uuid.UUID]bool, len(libraryIDs))
+		for _, id := range libraryIDs {
+			readable[id] = true
+		}
+		picked := make([]uuid.UUID, 0, len(sel.Libraries))
+		for _, id := range sel.Libraries {
+			if readable[id] {
+				picked = append(picked, id)
+			}
+		}
+		libraryIDs = picked
 	}
 	if len(libraryIDs) == 0 {
 		// Not an error. A new user, or one whose only membership was revoked,

--- a/internal/api/handlers/books_across.go
+++ b/internal/api/handlers/books_across.go
@@ -5,9 +5,12 @@ package handlers
 
 import (
 	"net/http"
+	"strconv"
+	"strings"
 
 	"github.com/fireball1725/librarium-api/internal/api/middleware"
 	"github.com/fireball1725/librarium-api/internal/api/respond"
+	"github.com/fireball1725/librarium-api/internal/repository"
 	"github.com/google/uuid"
 )
 
@@ -121,41 +124,64 @@ func (h *BookHandler) ListMyBooks(w http.ResponseWriter, r *http.Request) {
 // @Failure     401  {object}  object{error=string}
 // @Router      /me/books/facets [get]
 func (h *BookHandler) MyBookFacets(w http.ResponseWriter, r *http.Request) {
-	opts, _, err := parseListBooksOpts(r)
-	if err != nil {
-		respond.Error(w, http.StatusBadRequest, err.Error())
-		return
-	}
-
 	libraryIDs, err := h.readableLibraryIDs(r)
 	if err != nil {
 		respond.ServerError(w, r, err)
 		return
 	}
 
-	facets, err := h.books.Facets(r.Context(), libraryIDs, opts)
+	claims := middleware.ClaimsFromContext(r.Context())
+	var callerID uuid.UUID
+	if claims != nil {
+		callerID = claims.UserID
+	}
+
+	facets, err := h.books.Facets(r.Context(), libraryIDs, parseFacetSelection(r), r.URL.Query().Get("q"), callerID)
 	if err != nil {
 		respond.ServerError(w, r, err)
 		return
 	}
+	respond.JSON(w, http.StatusOK, map[string]any{"data": facets})
+}
 
-	// The library facet is only meaningful across libraries, so it is built
-	// here rather than in the shared facet query: per-library routes would
-	// always return a single value with the same count as the total.
-	libFacet, err := h.books.LibraryFacet(r.Context(), libraryIDs, opts)
-	if err != nil {
-		respond.ServerError(w, r, err)
-		return
+// parseFacetSelection reads the same short parameters the client keeps in its
+// URL (lib, status, type, genre, tag, rating), each a comma-separated list.
+//
+// Deliberately not the structured `filter` JSON the list endpoint takes: the
+// facet query needs each dimension separately so it can exclude a dimension's
+// own selection when counting it, and flattened filter groups cannot be taken
+// apart again.
+func parseFacetSelection(r *http.Request) repository.FacetSelection {
+	q := r.URL.Query()
+	split := func(key string) []string {
+		raw := strings.TrimSpace(q.Get(key))
+		if raw == "" {
+			return nil
+		}
+		out := make([]string, 0, 4)
+		for _, part := range strings.Split(raw, ",") {
+			if p := strings.TrimSpace(part); p != "" {
+				out = append(out, p)
+			}
+		}
+		return out
 	}
 
-	respond.JSON(w, http.StatusOK, map[string]any{
-		"data": map[string]any{
-			"read_status": facets.ReadStatus,
-			"media_type":  facets.MediaType,
-			"genre":       facets.Genre,
-			"tag":         facets.Tag,
-			"rating":      facets.Rating,
-			"library":     libFacet,
-		},
-	})
+	sel := repository.FacetSelection{
+		ReadStatus: split("status"),
+		MediaTypes: split("type"),
+		Genres:     split("genre"),
+		Tags:       split("tag"),
+	}
+	for _, s := range split("lib") {
+		if id, err := uuid.Parse(s); err == nil {
+			sel.Libraries = append(sel.Libraries, id)
+		}
+	}
+	for _, s := range split("rating") {
+		if n, err := strconv.Atoi(s); err == nil && n >= 0 && n <= 5 {
+			sel.Ratings = append(sel.Ratings, int32(n))
+		}
+	}
+	return sel
 }

--- a/internal/api/handlers/books_across.go
+++ b/internal/api/handlers/books_across.go
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725 (Adaléa)
+
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/fireball1725/librarium-api/internal/api/middleware"
+	"github.com/fireball1725/librarium-api/internal/api/respond"
+	"github.com/google/uuid"
+)
+
+// Cross-library book browsing.
+//
+// Every other books route is scoped to one library because the client used to
+// navigate into a library first. The redesign makes a library a filter rather
+// than a folder, so the default surface is "my books" across every library the
+// caller belongs to, with library available as one facet among several.
+//
+// Scope is always the caller's own memberships. There is no way to ask for a
+// library you cannot read: the set is derived server-side from the membership
+// table rather than taken from the request, so a crafted library_id cannot
+// widen it.
+
+// readableLibraryIDs returns the libraries the caller may read books in.
+// Instance admins get every library, matching RequireLibraryPermission, which
+// lets them past the per-library membership check.
+func (h *BookHandler) readableLibraryIDs(r *http.Request) ([]uuid.UUID, error) {
+	claims := middleware.ClaimsFromContext(r.Context())
+	if claims == nil {
+		return nil, nil
+	}
+	// A scope-capped token that cannot read books reads nothing, whatever the
+	// user's role says.
+	if !claims.ScopeAllows("books:read") {
+		return []uuid.UUID{}, nil
+	}
+
+	access, err := h.libraries.ListAccessForUser(r.Context(), claims.UserID, claims.IsInstanceAdmin)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]uuid.UUID, 0, len(access))
+	for _, a := range access {
+		for _, p := range a.Permissions {
+			if p == "books:read" {
+				ids = append(ids, a.LibraryID)
+				break
+			}
+		}
+	}
+	return ids, nil
+}
+
+// ListMyBooks godoc
+//
+// @Summary     Books across every library the caller can read
+// @Description The default browse surface. Takes the same filters as the
+// @Description per-library list endpoint; library becomes one filter among
+// @Description several rather than part of the path.
+// @Tags        books
+// @Produce     json
+// @Param       q         query string false "Search query"
+// @Param       page      query int    false "Page number"
+// @Param       per_page  query int    false "Results per page"
+// @Param       filter    query string false "Structured filter JSON"
+// @Success     200  {object}  object{items=[]object,total=int,page=int,per_page=int}
+// @Failure     401  {object}  object{error=string}
+// @Router      /me/books [get]
+func (h *BookHandler) ListMyBooks(w http.ResponseWriter, r *http.Request) {
+	opts, _, err := parseListBooksOpts(r)
+	if err != nil {
+		respond.Error(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	libraryIDs, err := h.readableLibraryIDs(r)
+	if err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
+	if len(libraryIDs) == 0 {
+		// Not an error. A new user, or one whose only membership was revoked,
+		// has an empty shelf and the client renders its own empty state.
+		respond.JSON(w, http.StatusOK, map[string]any{
+			"items": []any{}, "total": 0, "page": 1, "per_page": opts.PerPage,
+		})
+		return
+	}
+
+	books, total, err := h.books.ListAcross(r.Context(), libraryIDs, opts)
+	if err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
+
+	items := make([]map[string]any, 0, len(books))
+	for _, b := range books {
+		items = append(items, bookBody(b))
+	}
+	respond.JSON(w, http.StatusOK, map[string]any{
+		"items":    items,
+		"total":    total,
+		"page":     max(opts.Page, 1),
+		"per_page": opts.PerPage,
+	})
+}
+
+// MyBookFacets godoc
+//
+// @Summary     Facet counts across every library the caller can read
+// @Description Counts per facet value over the whole filtered set, so the
+// @Description filter rail can be rendered in one request rather than one per
+// @Description value. Same filters as /me/books.
+// @Tags        books
+// @Produce     json
+// @Param       q       query string false "Search query"
+// @Param       filter  query string false "Structured filter JSON"
+// @Success     200  {object}  object{data=repository.BookFacets}
+// @Failure     401  {object}  object{error=string}
+// @Router      /me/books/facets [get]
+func (h *BookHandler) MyBookFacets(w http.ResponseWriter, r *http.Request) {
+	opts, _, err := parseListBooksOpts(r)
+	if err != nil {
+		respond.Error(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	libraryIDs, err := h.readableLibraryIDs(r)
+	if err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
+
+	facets, err := h.books.Facets(r.Context(), libraryIDs, opts)
+	if err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
+
+	// The library facet is only meaningful across libraries, so it is built
+	// here rather than in the shared facet query: per-library routes would
+	// always return a single value with the same count as the total.
+	libFacet, err := h.books.LibraryFacet(r.Context(), libraryIDs, opts)
+	if err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
+
+	respond.JSON(w, http.StatusOK, map[string]any{
+		"data": map[string]any{
+			"read_status": facets.ReadStatus,
+			"media_type":  facets.MediaType,
+			"genre":       facets.Genre,
+			"tag":         facets.Tag,
+			"rating":      facets.Rating,
+			"library":     libFacet,
+		},
+	})
+}

--- a/internal/api/handlers/editions.go
+++ b/internal/api/handlers/editions.go
@@ -28,7 +28,7 @@ import (
 // @Security    BearerAuth
 // @Param       library_id  path      string  true  "Library UUID"
 // @Param       book_id     path      string  true  "Book UUID"
-// @Success     200  {array}   responses.EditionResponse
+// @Success     200  {array}   github_com_fireball1725_librarium-api_internal_api_responses.EditionResponse
 // @Failure     400  {object}  object{error=string}
 // @Failure     401  {object}  object{error=string}
 // @Router      /libraries/{library_id}/books/{book_id}/editions [get]
@@ -81,7 +81,7 @@ func (h *BookHandler) ListEditions(w http.ResponseWriter, r *http.Request) {
 // @Param       library_id  path      string  true  "Library UUID"
 // @Param       book_id     path      string  true  "Book UUID"
 // @Param       body        body      object{format=string,language=string,edition_name=string,narrator=string,publisher=string,publish_date=string,isbn_10=string,isbn_13=string,description=string,duration_seconds=integer,page_count=integer,copy_count=integer,is_primary=boolean,acquired_at=string}  true  "Edition details"
-// @Success     201  {object}  responses.EditionResponse
+// @Success     201  {object}  github_com_fireball1725_librarium-api_internal_api_responses.EditionResponse
 // @Failure     400  {object}  object{error=string}
 // @Failure     401  {object}  object{error=string}
 // @Router      /libraries/{library_id}/books/{book_id}/editions [post]
@@ -116,7 +116,7 @@ func (h *BookHandler) CreateEdition(w http.ResponseWriter, r *http.Request) {
 // @Param       book_id      path      string  true  "Book UUID"
 // @Param       edition_id   path      string  true  "Edition UUID"
 // @Param       body         body      object{format=string,language=string,edition_name=string,narrator=string,publisher=string,publish_date=string,isbn_10=string,isbn_13=string,description=string,duration_seconds=integer,page_count=integer,copy_count=integer,is_primary=boolean,acquired_at=string}  true  "Edition details"
-// @Success     200  {object}  responses.EditionResponse
+// @Success     200  {object}  github_com_fireball1725_librarium-api_internal_api_responses.EditionResponse
 // @Failure     400  {object}  object{error=string}
 // @Failure     401  {object}  object{error=string}
 // @Failure     404  {object}  object{error=string}
@@ -186,7 +186,7 @@ func (h *BookHandler) DeleteEdition(w http.ResponseWriter, r *http.Request) {
 // @Param       library_id   path      string  true  "Library UUID"
 // @Param       book_id      path      string  true  "Book UUID"
 // @Param       edition_id   path      string  true  "Edition UUID"
-// @Success     200  {object}  responses.InteractionResponse
+// @Success     200  {object}  github_com_fireball1725_librarium-api_internal_api_responses.InteractionResponse
 // @Failure     400  {object}  object{error=string}
 // @Failure     401  {object}  object{error=string}
 // @Router      /libraries/{library_id}/books/{book_id}/editions/{edition_id}/my-interaction [get]
@@ -221,7 +221,7 @@ func (h *BookHandler) GetMyInteraction(w http.ResponseWriter, r *http.Request) {
 // @Param       book_id      path      string  true  "Book UUID"
 // @Param       edition_id   path      string  true  "Edition UUID"
 // @Param       body         body      object{read_status=string,rating=integer,notes=string,review=string,date_started=string,date_finished=string,is_favorite=boolean}  true  "Interaction data"
-// @Success     200  {object}  responses.InteractionResponse
+// @Success     200  {object}  github_com_fireball1725_librarium-api_internal_api_responses.InteractionResponse
 // @Failure     400  {object}  object{error=string}
 // @Failure     401  {object}  object{error=string}
 // @Router      /libraries/{library_id}/books/{book_id}/editions/{edition_id}/my-interaction [put]

--- a/internal/api/handlers/genres.go
+++ b/internal/api/handlers/genres.go
@@ -28,7 +28,7 @@ func NewGenreHandler(genres *repository.GenreRepo) *GenreHandler {
 // @Tags        genres
 // @Produce     json
 // @Security    BearerAuth
-// @Success     200  {array}   responses.GenreResponse
+// @Success     200  {array}   github_com_fireball1725_librarium-api_internal_api_responses.GenreResponse
 // @Failure     401  {object}  object{error=string}
 // @Router      /genres [get]
 func (h *GenreHandler) ListGenres(w http.ResponseWriter, r *http.Request) {
@@ -49,7 +49,7 @@ func (h *GenreHandler) ListGenres(w http.ResponseWriter, r *http.Request) {
 // @Produce     json
 // @Security    BearerAuth
 // @Param       body  body      object{name=string}  true  "Genre name"
-// @Success     201   {object}  responses.GenreResponse
+// @Success     201   {object}  github_com_fireball1725_librarium-api_internal_api_responses.GenreResponse
 // @Failure     400   {object}  object{error=string}
 // @Failure     401   {object}  object{error=string}
 // @Failure     403   {object}  object{error=string}
@@ -84,7 +84,7 @@ func (h *GenreHandler) CreateGenre(w http.ResponseWriter, r *http.Request) {
 // @Security    BearerAuth
 // @Param       genre_id  path      string  true  "Genre UUID"
 // @Param       body      body      object{name=string}  true  "Updated name"
-// @Success     200   {object}  responses.GenreResponse
+// @Success     200   {object}  github_com_fireball1725_librarium-api_internal_api_responses.GenreResponse
 // @Failure     400   {object}  object{error=string}
 // @Failure     401   {object}  object{error=string}
 // @Failure     403   {object}  object{error=string}

--- a/internal/api/handlers/libraries.go
+++ b/internal/api/handlers/libraries.go
@@ -33,7 +33,7 @@ func NewLibraryHandler(svc *service.LibraryService) *LibraryHandler {
 // @Tags        libraries
 // @Produce     json
 // @Security    BearerAuth
-// @Success     200  {array}   responses.LibraryResponse
+// @Success     200  {array}   github_com_fireball1725_librarium-api_internal_api_responses.LibraryResponse
 // @Failure     401  {object}  object{error=string}
 // @Router      /libraries [get]
 func (h *LibraryHandler) ListLibraries(w http.ResponseWriter, r *http.Request) {
@@ -59,7 +59,7 @@ func (h *LibraryHandler) ListLibraries(w http.ResponseWriter, r *http.Request) {
 // @Produce     json
 // @Security    BearerAuth
 // @Param       body  body      object{name=string,description=string,slug=string,is_public=boolean}  true  "Library details"
-// @Success     201   {object}  responses.LibraryResponse
+// @Success     201   {object}  github_com_fireball1725_librarium-api_internal_api_responses.LibraryResponse
 // @Failure     400   {object}  object{error=string}
 // @Failure     401   {object}  object{error=string}
 // @Failure     409   {object}  object{error=string}
@@ -107,7 +107,7 @@ func (h *LibraryHandler) CreateLibrary(w http.ResponseWriter, r *http.Request) {
 // @Produce     json
 // @Security    BearerAuth
 // @Param       library_id  path      string  true  "Library UUID"
-// @Success     200  {object}  responses.LibraryResponse
+// @Success     200  {object}  github_com_fireball1725_librarium-api_internal_api_responses.LibraryResponse
 // @Failure     400  {object}  object{error=string}
 // @Failure     401  {object}  object{error=string}
 // @Failure     404  {object}  object{error=string}
@@ -140,7 +140,7 @@ func (h *LibraryHandler) GetLibrary(w http.ResponseWriter, r *http.Request) {
 // @Security    BearerAuth
 // @Param       library_id  path      string  true  "Library UUID"
 // @Param       body        body      object{name=string,description=string,is_public=boolean}  true  "Updated fields"
-// @Success     200  {object}  responses.LibraryResponse
+// @Success     200  {object}  github_com_fireball1725_librarium-api_internal_api_responses.LibraryResponse
 // @Failure     400  {object}  object{error=string}
 // @Failure     401  {object}  object{error=string}
 // @Failure     404  {object}  object{error=string}
@@ -222,7 +222,7 @@ func (h *LibraryHandler) DeleteLibrary(w http.ResponseWriter, r *http.Request) {
 // @Param       library_id  path      string  true   "Library UUID"
 // @Param       search      query     string  false  "Filter by username/display name"
 // @Param       tag         query     string  false  "Filter by tag name"
-// @Success     200  {array}   responses.MemberResponse
+// @Success     200  {array}   github_com_fireball1725_librarium-api_internal_api_responses.MemberResponse
 // @Failure     400  {object}  object{error=string}
 // @Failure     401  {object}  object{error=string}
 // @Router      /libraries/{library_id}/members [get]

--- a/internal/api/handlers/libraries.go
+++ b/internal/api/handlers/libraries.go
@@ -444,3 +444,30 @@ func memberBody(m *models.LibraryMember) map[string]any {
 	}
 	return body
 }
+
+// ListMyAccess godoc
+//
+// @Summary     Libraries the caller can reach, with effective permissions
+// @Description Returns every library the authenticated user can see and the
+// @Description permission names they hold in each, already capped by the
+// @Description token's scope. A client fetches this once and gates each row by
+// @Description the library the row came from, rather than checking per book.
+// @Tags        libraries
+// @Produce     json
+// @Success     200  {object}  object{data=[]repository.LibraryAccess}
+// @Failure     401  {object}  object{error=string}
+// @Router      /me/libraries [get]
+func (h *LibraryHandler) ListMyAccess(w http.ResponseWriter, r *http.Request) {
+	claims := middleware.ClaimsFromContext(r.Context())
+	if claims == nil {
+		respond.Error(w, http.StatusUnauthorized, "authentication required")
+		return
+	}
+
+	access, err := h.svc.ListMyAccess(r.Context(), claims.UserID, claims.IsInstanceAdmin, claims.ScopeAllows)
+	if err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
+	respond.JSON(w, http.StatusOK, map[string]any{"data": access})
+}

--- a/internal/api/handlers/library_scope_test.go
+++ b/internal/api/handlers/library_scope_test.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725
+
+package handlers
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// The library filter is the one query parameter that decides what rows a caller
+// is allowed to see, so these tests are about the boundary rather than the
+// convenience. Every case below is a way the parameter could be made to widen
+// the scope instead of narrowing it.
+
+func TestNarrowToReadable(t *testing.T) {
+	a, b, c := uuid.New(), uuid.New(), uuid.New()
+	readable := []uuid.UUID{a, b}
+
+	t.Run("no request leaves the scope alone", func(t *testing.T) {
+		got := narrowToReadable(nil, readable)
+		if len(got) != 2 {
+			t.Fatalf("want the readable set, got %v", got)
+		}
+	})
+
+	t.Run("narrows to the intersection", func(t *testing.T) {
+		got := narrowToReadable([]uuid.UUID{a}, readable)
+		if len(got) != 1 || got[0] != a {
+			t.Fatalf("want [a], got %v", got)
+		}
+	})
+
+	t.Run("cannot widen to a library the caller cannot read", func(t *testing.T) {
+		// The whole point. c is not readable, so asking for it must not
+		// return it, and must not fall back to everything either.
+		got := narrowToReadable([]uuid.UUID{c}, readable)
+		if len(got) != 0 {
+			t.Fatalf("want nothing, got %v", got)
+		}
+	})
+
+	t.Run("drops the unreadable half of a mixed request", func(t *testing.T) {
+		got := narrowToReadable([]uuid.UUID{a, c}, readable)
+		if len(got) != 1 || got[0] != a {
+			t.Fatalf("want [a], got %v", got)
+		}
+	})
+
+	t.Run("a caller who can read nothing reads nothing", func(t *testing.T) {
+		got := narrowToReadable([]uuid.UUID{a}, nil)
+		if len(got) != 0 {
+			t.Fatalf("want nothing, got %v", got)
+		}
+	})
+}
+
+func TestLibraryIDsFromQuery(t *testing.T) {
+	id := uuid.New()
+
+	t.Run("absent means no filter", func(t *testing.T) {
+		r := httptest.NewRequest("GET", "/x", nil)
+		if got := libraryIDsFromQuery(r); got != nil {
+			t.Fatalf("want nil so the scope is untouched, got %v", got)
+		}
+	})
+
+	t.Run("parses a comma separated list", func(t *testing.T) {
+		other := uuid.New()
+		r := httptest.NewRequest("GET", "/x?lib="+id.String()+","+other.String(), nil)
+		if got := libraryIDsFromQuery(r); len(got) != 2 {
+			t.Fatalf("want 2 ids, got %v", got)
+		}
+	})
+
+	t.Run("tolerates surrounding space", func(t *testing.T) {
+		r := httptest.NewRequest("GET", "/x?lib=%20"+id.String()+"%20", nil)
+		got := libraryIDsFromQuery(r)
+		if len(got) != 1 || got[0] != id {
+			t.Fatalf("want the id, got %v", got)
+		}
+	})
+
+	t.Run("junk is a filter matching nothing, not an absent filter", func(t *testing.T) {
+		// The dangerous failure: returning nil here would make `?lib=nonsense`
+		// mean "every library the caller can read" rather than "none".
+		r := httptest.NewRequest("GET", "/x?lib=not-a-uuid", nil)
+		got := libraryIDsFromQuery(r)
+		if len(got) == 0 {
+			t.Fatal("want a filter that matches nothing, got an absent filter")
+		}
+		if len(narrowToReadable(got, []uuid.UUID{id})) != 0 {
+			t.Fatal("junk must not resolve to any readable library")
+		}
+	})
+
+	t.Run("keeps the good half of a partly junk list", func(t *testing.T) {
+		r := httptest.NewRequest("GET", "/x?lib=nope,"+id.String(), nil)
+		got := libraryIDsFromQuery(r)
+		if len(got) != 1 || got[0] != id {
+			t.Fatalf("want just the parseable id, got %v", got)
+		}
+	})
+}

--- a/internal/api/handlers/licences.go
+++ b/internal/api/handlers/licences.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725 (Adaléa)
+
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/fireball1725/librarium-api/internal/api/respond"
+	"github.com/fireball1725/librarium-api/internal/licences"
+	"github.com/fireball1725/librarium-api/internal/version"
+)
+
+// ListComponents godoc
+//
+// @Summary     List server components
+// @Description Every Go module linked into this API binary, with its version and SPDX licence identifier. Clients render this on their licences page so the notices cover the server as well as the client. A component whose licence is unknown is returned with an empty licence rather than omitted.
+// @Tags        health
+// @Produce     json
+// @Security    BearerAuth
+// @Success     200  {object}  object{version=string,components=[]object{name=string,version=string,licence=string}}
+// @Router      /components [get]
+func ListComponents(w http.ResponseWriter, r *http.Request) {
+	components := licences.Components()
+	if components == nil {
+		// Not an error: a binary built outside module mode genuinely does not
+		// know its dependencies. Say so with an empty list rather than a 500,
+		// so the page renders what it does know.
+		components = []licences.Component{}
+	}
+	respond.JSON(w, http.StatusOK, map[string]any{
+		// The server's own version, so a client showing several instances can
+		// label whose component list it is holding.
+		"version":    version.BuildVersion,
+		"components": components,
+	})
+}

--- a/internal/api/handlers/loan_date_test.go
+++ b/internal/api/handlers/loan_date_test.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725
+
+package handlers
+
+import "testing"
+
+// Regression test for a bug found 2026-08-17: parseDate accepted only
+// YYYY-MM-DD and returned nil on anything else, so a client that read a loan
+// and wrote it back sent the RFC3339 timestamp the API had just given it, and
+// the due date was silently cleared. Marking a loan returned erased when it
+// had been due.
+func TestParseLoanDate(t *testing.T) {
+	t.Run("accepts the documented format", func(t *testing.T) {
+		got, err := parseLoanDate("2026-07-06")
+		if err != nil || got == nil {
+			t.Fatalf("want a date, got %v err %v", got, err)
+		}
+		if got.Format("2006-01-02") != "2026-07-06" {
+			t.Fatalf("wrong date: %s", got)
+		}
+	})
+
+	t.Run("accepts what the API itself emits", func(t *testing.T) {
+		// This is the exact shape a loan's due_date comes back as.
+		got, err := parseLoanDate("2026-07-06T00:00:00Z")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got == nil {
+			t.Fatal("round-tripping the API's own value must not clear the field")
+		}
+		if got.Format("2006-01-02") != "2026-07-06" {
+			t.Fatalf("wrong date: %s", got)
+		}
+	})
+
+	t.Run("empty means no date", func(t *testing.T) {
+		got, err := parseLoanDate("")
+		if err != nil || got != nil {
+			t.Fatalf("want nil with no error, got %v err %v", got, err)
+		}
+	})
+
+	t.Run("nonsense is an error, not a silent clear", func(t *testing.T) {
+		// The whole point. Swallowing this is what let a bad value look like
+		// an intentional "remove the due date".
+		if _, err := parseLoanDate("last thursday"); err == nil {
+			t.Fatal("want an error so the caller hears about it")
+		}
+	})
+}

--- a/internal/api/handlers/loans.go
+++ b/internal/api/handlers/loans.go
@@ -6,6 +6,7 @@ package handlers
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -36,7 +37,7 @@ func NewLoanHandler(svc *service.LoanService) *LoanHandler {
 // @Param       include_returned  query     boolean  false  "Include returned loans"
 // @Param       search            query     string   false  "Filter by borrower name"
 // @Param       book_id           query     string   false  "Filter to loans of a specific book"
-// @Success     200  {array}   responses.LoanResponse
+// @Success     200  {array}   github_com_fireball1725_librarium-api_internal_api_responses.LoanResponse
 // @Failure     400  {object}  object{error=string}
 // @Failure     401  {object}  object{error=string}
 // @Router      /libraries/{library_id}/loans [get]
@@ -78,7 +79,7 @@ func (h *LoanHandler) ListLoans(w http.ResponseWriter, r *http.Request) {
 // @Security    BearerAuth
 // @Param       library_id  path      string  true  "Library UUID"
 // @Param       body        body      object{book_id=string,loaned_to=string,loaned_at=string,due_date=string,notes=string}  true  "Loan details"
-// @Success     201  {object}  responses.LoanResponse
+// @Success     201  {object}  github_com_fireball1725_librarium-api_internal_api_responses.LoanResponse
 // @Failure     400  {object}  object{error=string}
 // @Failure     401  {object}  object{error=string}
 // @Router      /libraries/{library_id}/loans [post]
@@ -113,7 +114,7 @@ func (h *LoanHandler) CreateLoan(w http.ResponseWriter, r *http.Request) {
 // @Param       library_id  path      string  true  "Library UUID"
 // @Param       loan_id     path      string  true  "Loan UUID"
 // @Param       body        body      object{loaned_to=string,due_date=string,returned_at=string,notes=string}  true  "Updated loan"
-// @Success     200  {object}  responses.LoanResponse
+// @Success     200  {object}  github_com_fireball1725_librarium-api_internal_api_responses.LoanResponse
 // @Failure     400  {object}  object{error=string}
 // @Failure     401  {object}  object{error=string}
 // @Failure     404  {object}  object{error=string}
@@ -172,6 +173,33 @@ func (h *LoanHandler) DeleteLoan(w http.ResponseWriter, r *http.Request) {
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
+// parseLoanDate reads a date a client sent for a loan.
+//
+// Accepts YYYY-MM-DD, which is what the API documents, and RFC3339, which is
+// what the API itself emits: loan dates are DATE columns but marshal as full
+// timestamps, so a client that reads a loan and writes it back sends
+// "2026-07-06T00:00:00Z". Rejecting that is defensible; silently treating it as
+// "no date" is not, and that is what this used to do. Marking a loan returned
+// echoed its due_date back and quietly erased it.
+//
+// Empty or absent means no date. Anything else that will not parse is an error,
+// so a client sending nonsense hears about it instead of losing a field.
+func parseLoanDate(s string) (*time.Time, error) {
+	if s == "" {
+		return nil, nil
+	}
+	if t, err := time.Parse("2006-01-02", s); err == nil {
+		return &t, nil
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		// The date part only. These columns are DATE, so carrying a time here
+		// would depend on the sender's zone for a value that has no time.
+		d := time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
+		return &d, nil
+	}
+	return nil, fmt.Errorf("invalid date %q, expected YYYY-MM-DD", s)
+}
+
 func decodeLoanCreateRequest(r *http.Request) (*service.LoanRequest, error) {
 	var body struct {
 		BookID   string `json:"book_id"`
@@ -192,17 +220,15 @@ func decodeLoanCreateRequest(r *http.Request) (*service.LoanRequest, error) {
 	}
 
 	loanedAt := time.Now()
-	if body.LoanedAt != "" {
-		if t, err := time.Parse("2006-01-02", body.LoanedAt); err == nil {
-			loanedAt = t
-		}
+	if at, err := parseLoanDate(body.LoanedAt); err != nil {
+		return nil, err
+	} else if at != nil {
+		loanedAt = *at
 	}
 
-	var dueDate *time.Time
-	if body.DueDate != "" {
-		if t, err := time.Parse("2006-01-02", body.DueDate); err == nil {
-			dueDate = &t
-		}
+	dueDate, err := parseLoanDate(body.DueDate)
+	if err != nil {
+		return nil, err
 	}
 
 	return &service.LoanRequest{
@@ -228,21 +254,26 @@ func decodeLoanUpdateRequest(r *http.Request) (*service.LoanUpdateRequest, error
 		return nil, errors.New("loaned_to is required")
 	}
 
-	parseDate := func(s *string) *time.Time {
-		if s == nil || *s == "" {
-			return nil
+	optional := func(s *string) string {
+		if s == nil {
+			return ""
 		}
-		t, err := time.Parse("2006-01-02", *s)
-		if err != nil {
-			return nil
-		}
-		return &t
+		return *s
+	}
+
+	due, err := parseLoanDate(optional(body.DueDate))
+	if err != nil {
+		return nil, err
+	}
+	returned, err := parseLoanDate(optional(body.ReturnedAt))
+	if err != nil {
+		return nil, err
 	}
 
 	return &service.LoanUpdateRequest{
 		LoanedTo:   body.LoanedTo,
-		DueDate:    parseDate(body.DueDate),
-		ReturnedAt: parseDate(body.ReturnedAt),
+		DueDate:    due,
+		ReturnedAt: returned,
 		Notes:      body.Notes,
 	}, nil
 }

--- a/internal/api/handlers/me_browse.go
+++ b/internal/api/handlers/me_browse.go
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725 (Adaléa)
+
+package handlers
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/fireball1725/librarium-api/internal/api/middleware"
+	"github.com/fireball1725/librarium-api/internal/api/respond"
+	"github.com/fireball1725/librarium-api/internal/repository"
+	"github.com/google/uuid"
+)
+
+// The cross-library Series and Authors surfaces.
+//
+// Same shape as /me/books: scope is the caller's own memberships, derived
+// server-side, and the surface is the whole collection rather than one library
+// you navigated into.
+//
+// Deliberately not folded into the existing GET /me/series, which is the
+// typeahead behind the suggestions modal. That endpoint answers "name a series
+// matching these keystrokes" and is capped at twenty; this one answers "show me
+// everything I have" and carries counts and cover thumbnails per row. Serving
+// both from one route would make every keystroke pay for the index.
+
+// MeBrowseHandler serves the cross-library index surfaces.
+type MeBrowseHandler struct {
+	libraries    *repository.LibraryRepo
+	series       *repository.SeriesRepo
+	contributors *repository.ContributorRepo
+}
+
+func NewMeBrowseHandler(
+	libraries *repository.LibraryRepo,
+	series *repository.SeriesRepo,
+	contributors *repository.ContributorRepo,
+) *MeBrowseHandler {
+	return &MeBrowseHandler{libraries: libraries, series: series, contributors: contributors}
+}
+
+// seriesIndexVolumes caps the volume strip on a series row.
+//
+// The strip shows every volume it can, because the gaps are the point: a run
+// missing volumes 4 and 9 should look like a run missing volumes 4 and 9. The
+// cap only stops a pathological series from turning one row into a thousand-
+// element payload, and the client says "+N more" past it.
+const seriesIndexVolumes = 60
+
+func callerID(r *http.Request) uuid.UUID {
+	if claims := middleware.ClaimsFromContext(r.Context()); claims != nil {
+		return claims.UserID
+	}
+	return uuid.Nil
+}
+
+// SeriesIndex godoc
+//
+//	@Summary     Series across every library the caller can read
+//	@Description The cross-library Series surface. Unpaged: the A-Z bar has to
+//	@Description know which letters have series behind them, which means
+//	@Description counting the whole set anyway.
+//	@Tags        me
+//	@Produce     json
+//	@Security    BearerAuth
+//	@Param       q  query  string  false  "Name substring"
+//	@Success     200  {object}  object{items=[]models.Series,total=int}
+//	@Failure     401  {object}  object{error=string}
+//	@Router      /me/series/index [get]
+func (h *MeBrowseHandler) SeriesIndex(w http.ResponseWriter, r *http.Request) {
+	libraryIDs, err := readableLibraryIDs(r, h.libraries)
+	if err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
+
+	items, err := h.series.ListAcross(
+		r.Context(), libraryIDs, callerID(r),
+		strings.TrimSpace(r.URL.Query().Get("q")), seriesIndexVolumes,
+	)
+	if err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
+
+	// Through seriesBody, not the model directly: it is what turns has_cover
+	// plus updated_at into the cache-busted cover URL every other series route
+	// already returns. Serialising the struct raw would hand this one surface a
+	// different shape than the rest of the API.
+	bodies := make([]map[string]any, 0, len(items))
+	for _, s := range items {
+		bodies = append(bodies, seriesBody(s))
+	}
+	respond.JSON(w, http.StatusOK, map[string]any{"items": bodies, "total": len(bodies)})
+}
+
+// Counts godoc
+//
+//	@Summary     Totals for the navigation
+//	@Description Book, series and author counts across every library the caller
+//	@Description can read. One endpoint rather than three, because the sidebar
+//	@Description needs all of them on every page and none of them individually.
+//	@Tags        me
+//	@Produce     json
+//	@Security    BearerAuth
+//	@Success     200  {object}  object{books=int,series=int,authors=int}
+//	@Failure     401  {object}  object{error=string}
+//	@Router      /me/counts [get]
+func (h *MeBrowseHandler) Counts(w http.ResponseWriter, r *http.Request) {
+	libraryIDs, err := readableLibraryIDs(r, h.libraries)
+	if err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
+
+	counts, err := h.libraries.CountsForLibraries(r.Context(), libraryIDs)
+	if err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
+	respond.JSON(w, http.StatusOK, counts)
+}
+
+// authorBody mirrors previewBooksToBody: the thumbnail URL is assembled here so
+// no client has to know how a cover path is spelled.
+func authorBody(a *repository.AuthorIndexEntry) map[string]any {
+	spines := make([]map[string]any, 0, len(a.Spines))
+	for _, s := range a.Spines {
+		var coverURL any
+		if s.HasCover {
+			coverURL = "/api/v1/books/" + s.BookID.String() + "/cover?v=" + itoa(s.UpdatedAt.Unix())
+		}
+		spines = append(spines, map[string]any{
+			"book_id": s.BookID, "title": s.Title, "cover_url": coverURL,
+		})
+	}
+	var photoURL any
+	if a.HasPhoto {
+		photoURL = "/api/v1/contributors/" + a.ID.String() + "/photo"
+	}
+	return map[string]any{
+		"id":         a.ID,
+		"name":       a.Name,
+		"sort_name":  a.SortName,
+		"letter":     a.Letter,
+		"photo_url":  photoURL,
+		"book_count": a.BookCount,
+		"read_count": a.ReadCount,
+		"spines":     spines,
+		"libraries":  a.Libraries,
+	}
+}
+
+// AuthorsIndex godoc
+//
+//	@Summary     Authors across every library the caller can read
+//	@Description The cross-library Authors surface, with per-author book and
+//	@Description read counts, cover thumbnails, and the letter each name files
+//	@Description under. Unpaged, for the same reason as the series index.
+//	@Tags        me
+//	@Produce     json
+//	@Security    BearerAuth
+//	@Param       role  query  string  false  "Contributor roles, comma separated. Defaults to author."
+//	@Success     200  {object}  object{items=[]repository.AuthorIndexEntry,total=int}
+//	@Failure     401  {object}  object{error=string}
+//	@Router      /me/authors/index [get]
+func (h *MeBrowseHandler) AuthorsIndex(w http.ResponseWriter, r *http.Request) {
+	libraryIDs, err := readableLibraryIDs(r, h.libraries)
+	if err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
+
+	var roles []string
+	for _, part := range strings.Split(r.URL.Query().Get("role"), ",") {
+		if p := strings.TrimSpace(part); p != "" {
+			roles = append(roles, p)
+		}
+	}
+
+	items, err := h.contributors.ListAuthorIndex(r.Context(), libraryIDs, callerID(r), roles)
+	if err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
+
+	bodies := make([]map[string]any, 0, len(items))
+	for _, a := range items {
+		bodies = append(bodies, authorBody(a))
+	}
+	respond.JSON(w, http.StatusOK, map[string]any{"items": bodies, "total": len(bodies)})
+}

--- a/internal/api/handlers/me_browse.go
+++ b/internal/api/handlers/me_browse.go
@@ -30,14 +30,21 @@ type MeBrowseHandler struct {
 	libraries    *repository.LibraryRepo
 	series       *repository.SeriesRepo
 	contributors *repository.ContributorRepo
+	shelves      *repository.ShelfRepo
+	loans        *repository.LoanRepo
 }
 
 func NewMeBrowseHandler(
 	libraries *repository.LibraryRepo,
 	series *repository.SeriesRepo,
 	contributors *repository.ContributorRepo,
+	shelves *repository.ShelfRepo,
+	loans *repository.LoanRepo,
 ) *MeBrowseHandler {
-	return &MeBrowseHandler{libraries: libraries, series: series, contributors: contributors}
+	return &MeBrowseHandler{
+		libraries: libraries, series: series,
+		contributors: contributors, shelves: shelves, loans: loans,
+	}
 }
 
 // seriesIndexVolumes caps the volume strip on a series row.
@@ -65,7 +72,7 @@ func callerID(r *http.Request) uuid.UUID {
 //	@Produce     json
 //	@Security    BearerAuth
 //	@Param       q  query  string  false  "Name substring"
-//	@Success     200  {object}  object{items=[]models.Series,total=int}
+//	@Success     200  {object}  object{items=[]github_com_fireball1725_librarium-api_internal_api_responses.SeriesResponse,total=int}
 //	@Failure     401  {object}  object{error=string}
 //	@Router      /me/series/index [get]
 func (h *MeBrowseHandler) SeriesIndex(w http.ResponseWriter, r *http.Request) {
@@ -162,6 +169,7 @@ func authorBody(a *repository.AuthorIndexEntry) map[string]any {
 //	@Produce     json
 //	@Security    BearerAuth
 //	@Param       role  query  string  false  "Contributor roles, comma separated. Defaults to author."
+//	@Param       lib   query  string  false  "Library UUIDs, comma separated. Narrows the scope; cannot widen it."
 //	@Success     200  {object}  object{items=[]repository.AuthorIndexEntry,total=int}
 //	@Failure     401  {object}  object{error=string}
 //	@Router      /me/authors/index [get]
@@ -169,6 +177,15 @@ func (h *MeBrowseHandler) AuthorsIndex(w http.ResponseWriter, r *http.Request) {
 	libraryIDs, err := readableLibraryIDs(r, h.libraries)
 	if err != nil {
 		respond.ServerError(w, r, err)
+		return
+	}
+
+	// The per-library Contributors page redirects here carrying its library, so
+	// this parameter is what keeps that redirect honest. Without it the reader
+	// asks for one library's authors and silently gets every library's.
+	libraryIDs = narrowToReadable(libraryIDsFromQuery(r), libraryIDs)
+	if len(libraryIDs) == 0 {
+		respond.JSON(w, http.StatusOK, map[string]any{"items": []any{}, "total": 0})
 		return
 	}
 
@@ -190,4 +207,80 @@ func (h *MeBrowseHandler) AuthorsIndex(w http.ResponseWriter, r *http.Request) {
 		bodies = append(bodies, authorBody(a))
 	}
 	respond.JSON(w, http.StatusOK, map[string]any{"items": bodies, "total": len(bodies)})
+}
+
+// MyShelves godoc
+//
+//	@Summary     Shelves across every library the caller can read
+//	@Description The rail lists shelves beside libraries and views, so it needs
+//	@Description them across the whole readable scope rather than one library at
+//	@Description a time. Each carries its library, colour and icon.
+//	@Tags        me
+//	@Produce     json
+//	@Security    BearerAuth
+//	@Success     200  {object}  object{items=[]github_com_fireball1725_librarium-api_internal_api_responses.ShelfResponse,total=int}
+//	@Failure     401  {object}  object{error=string}
+//	@Router      /me/shelves [get]
+func (h *MeBrowseHandler) MyShelves(w http.ResponseWriter, r *http.Request) {
+	libraryIDs, err := readableLibraryIDs(r, h.libraries)
+	if err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
+	items, err := h.shelves.ListAcross(r.Context(), libraryIDs)
+	if err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
+	// Through shelfBody, not the model. models.Shelf carries no json tags, so
+	// serialising it directly emits PascalCase and every field the client reads
+	// comes back undefined.
+	bodies := make([]map[string]any, 0, len(items))
+	for _, sh := range items {
+		bodies = append(bodies, shelfBody(sh))
+	}
+	respond.JSON(w, http.StatusOK, map[string]any{"items": bodies, "total": len(bodies)})
+}
+
+// MyLoans godoc
+//
+//	@Summary     Loans across every library the caller can read
+//	@Description A loan is a book, a person and some dates; the library is where
+//	@Description the book happens to live. "Who has my stuff" is not a question
+//	@Description anyone asks one library at a time, so this is the whole set,
+//	@Description each row carrying the library it belongs to.
+//	@Tags        me
+//	@Produce     json
+//	@Security    BearerAuth
+//	@Param       lib               query  string  false  "Library UUIDs, comma separated. Narrows the scope; cannot widen it."
+//	@Param       q                 query  string  false  "Match against borrower or book title"
+//	@Param       include_returned  query  bool    false  "Include loans already returned"
+//	@Param       overdue           query  bool    false  "Only loans past their due date"
+//	@Success     200  {object}  object{items=[]github_com_fireball1725_librarium-api_internal_api_responses.LoanResponse,total=int}
+//	@Failure     401  {object}  object{error=string}
+//	@Router      /me/loans [get]
+func (h *MeBrowseHandler) MyLoans(w http.ResponseWriter, r *http.Request) {
+	libraryIDs, err := readableLibraryIDs(r, h.libraries)
+	if err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
+	libraryIDs = narrowToReadable(libraryIDsFromQuery(r), libraryIDs)
+	if len(libraryIDs) == 0 {
+		respond.JSON(w, http.StatusOK, map[string]any{"items": []any{}, "total": 0})
+		return
+	}
+
+	q := r.URL.Query()
+	items, err := h.loans.ListAcross(
+		r.Context(), libraryIDs,
+		q.Get("include_returned") == "true",
+		q.Get("overdue") == "true",
+		strings.TrimSpace(q.Get("q")),
+	)
+	if err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
+	respond.JSON(w, http.StatusOK, map[string]any{"items": items, "total": len(items)})
 }

--- a/internal/api/handlers/media_types.go
+++ b/internal/api/handlers/media_types.go
@@ -28,7 +28,7 @@ func NewMediaTypeHandler(mediaTypes *repository.MediaTypeRepo) *MediaTypeHandler
 // @Tags        media-types
 // @Produce     json
 // @Security    BearerAuth
-// @Success     200  {array}   responses.MediaTypeResponse
+// @Success     200  {array}   github_com_fireball1725_librarium-api_internal_api_responses.MediaTypeResponse
 // @Failure     401  {object}  object{error=string}
 // @Router      /media-types [get]
 func (h *MediaTypeHandler) ListMediaTypes(w http.ResponseWriter, r *http.Request) {
@@ -49,7 +49,7 @@ func (h *MediaTypeHandler) ListMediaTypes(w http.ResponseWriter, r *http.Request
 // @Produce     json
 // @Security    BearerAuth
 // @Param       body  body      object{name=string,display_name=string,description=string}  true  "Media type details"
-// @Success     201   {object}  responses.MediaTypeResponse
+// @Success     201   {object}  github_com_fireball1725_librarium-api_internal_api_responses.MediaTypeResponse
 // @Failure     400   {object}  object{error=string}
 // @Failure     401   {object}  object{error=string}
 // @Failure     403   {object}  object{error=string}
@@ -95,7 +95,7 @@ func (h *MediaTypeHandler) CreateMediaType(w http.ResponseWriter, r *http.Reques
 // @Security    BearerAuth
 // @Param       media_type_id  path      string  true  "Media type UUID"
 // @Param       body           body      object{display_name=string,description=string}  true  "Updated fields"
-// @Success     200   {object}  responses.MediaTypeResponse
+// @Success     200   {object}  github_com_fireball1725_librarium-api_internal_api_responses.MediaTypeResponse
 // @Failure     400   {object}  object{error=string}
 // @Failure     401   {object}  object{error=string}
 // @Failure     403   {object}  object{error=string}

--- a/internal/api/handlers/series.go
+++ b/internal/api/handlers/series.go
@@ -39,7 +39,7 @@ func NewSeriesHandler(svc *service.SeriesService, sync *service.ReleaseSyncServi
 // @Param       library_id  path      string  true   "Library UUID"
 // @Param       search      query     string  false  "Filter by series name"
 // @Param       tag         query     string  false  "Filter by tag"
-// @Success     200  {array}   responses.SeriesResponse
+// @Success     200  {array}   github_com_fireball1725_librarium-api_internal_api_responses.SeriesResponse
 // @Failure     400  {object}  object{error=string}
 // @Failure     401  {object}  object{error=string}
 // @Router      /libraries/{library_id}/series [get]
@@ -74,7 +74,7 @@ func (h *SeriesHandler) ListSeries(w http.ResponseWriter, r *http.Request) {
 // @Security    BearerAuth
 // @Param       library_id  path      string  true  "Library UUID"
 // @Param       body        body      object{name=string,description=string,total_count=integer,status=string,original_language=string,publication_year=integer,demographic=string,genres=[]string,url=string,external_id=string,external_source=string,tag_ids=[]string}  true  "Series details"
-// @Success     201  {object}  responses.SeriesResponse
+// @Success     201  {object}  github_com_fireball1725_librarium-api_internal_api_responses.SeriesResponse
 // @Failure     400  {object}  object{error=string}
 // @Failure     401  {object}  object{error=string}
 // @Router      /libraries/{library_id}/series [post]
@@ -107,7 +107,7 @@ func (h *SeriesHandler) CreateSeries(w http.ResponseWriter, r *http.Request) {
 // @Security    BearerAuth
 // @Param       library_id  path      string  true  "Library UUID"
 // @Param       series_id   path      string  true  "Series UUID"
-// @Success     200  {object}  responses.SeriesResponse
+// @Success     200  {object}  github_com_fireball1725_librarium-api_internal_api_responses.SeriesResponse
 // @Failure     400  {object}  object{error=string}
 // @Failure     401  {object}  object{error=string}
 // @Failure     404  {object}  object{error=string}
@@ -142,7 +142,7 @@ func (h *SeriesHandler) GetSeries(w http.ResponseWriter, r *http.Request) {
 // @Param       library_id  path      string  true  "Library UUID"
 // @Param       series_id   path      string  true  "Series UUID"
 // @Param       body        body      object{name=string,description=string,total_count=integer,status=string,original_language=string,publication_year=integer,demographic=string,genres=[]string,url=string,external_id=string,external_source=string,tag_ids=[]string}  true  "Updated series"
-// @Success     200  {object}  responses.SeriesResponse
+// @Success     200  {object}  github_com_fireball1725_librarium-api_internal_api_responses.SeriesResponse
 // @Failure     400  {object}  object{error=string}
 // @Failure     401  {object}  object{error=string}
 // @Failure     404  {object}  object{error=string}
@@ -208,7 +208,7 @@ func (h *SeriesHandler) DeleteSeries(w http.ResponseWriter, r *http.Request) {
 // @Security    BearerAuth
 // @Param       library_id  path      string  true  "Library UUID"
 // @Param       series_id   path      string  true  "Series UUID"
-// @Success     200  {array}   responses.SeriesEntryResponse
+// @Success     200  {array}   github_com_fireball1725_librarium-api_internal_api_responses.SeriesEntryResponse
 // @Failure     400  {object}  object{error=string}
 // @Failure     401  {object}  object{error=string}
 // @Router      /libraries/{library_id}/series/{series_id}/books [get]
@@ -512,7 +512,7 @@ func (h *SeriesHandler) RemoveSeriesBook(w http.ResponseWriter, r *http.Request)
 // @Security    BearerAuth
 // @Param       library_id  path      string  true  "Library UUID"
 // @Param       series_id   path      string  true  "Series UUID"
-// @Success     200  {array}   responses.SeriesVolumeResponse
+// @Success     200  {array}   github_com_fireball1725_librarium-api_internal_api_responses.SeriesVolumeResponse
 // @Failure     400  {object}  object{error=string}
 // @Failure     401  {object}  object{error=string}
 // @Router      /libraries/{library_id}/series/{series_id}/volumes [get]
@@ -558,7 +558,7 @@ func (h *SeriesHandler) ListSeriesVolumes(w http.ResponseWriter, r *http.Request
 // @Security    BearerAuth
 // @Param       library_id  path      string  true  "Library UUID"
 // @Param       series_id   path      string  true  "Series UUID"
-// @Success     200  {array}   responses.SeriesVolumeResponse
+// @Success     200  {array}   github_com_fireball1725_librarium-api_internal_api_responses.SeriesVolumeResponse
 // @Failure     400  {object}  object{error=string}
 // @Failure     401  {object}  object{error=string}
 // @Failure     503  {object}  object{error=string}

--- a/internal/api/handlers/shelves.go
+++ b/internal/api/handlers/shelves.go
@@ -36,7 +36,7 @@ func NewShelfHandler(svc *service.ShelfService) *ShelfHandler {
 // @Param       library_id  path      string  true   "Library UUID"
 // @Param       search      query     string  false  "Filter by shelf name"
 // @Param       tag         query     string  false  "Filter by tag name"
-// @Success     200  {array}   responses.ShelfResponse
+// @Success     200  {array}   github_com_fireball1725_librarium-api_internal_api_responses.ShelfResponse
 // @Failure     400  {object}  object{error=string}
 // @Failure     401  {object}  object{error=string}
 // @Router      /libraries/{library_id}/shelves [get]
@@ -70,7 +70,7 @@ func (h *ShelfHandler) ListShelves(w http.ResponseWriter, r *http.Request) {
 // @Security    BearerAuth
 // @Param       library_id  path      string  true  "Library UUID"
 // @Param       body        body      object{name=string,description=string,color=string,icon=string,display_order=integer,tag_ids=[]string}  true  "Shelf details"
-// @Success     201  {object}  responses.ShelfResponse
+// @Success     201  {object}  github_com_fireball1725_librarium-api_internal_api_responses.ShelfResponse
 // @Failure     400  {object}  object{error=string}
 // @Failure     401  {object}  object{error=string}
 // @Router      /libraries/{library_id}/shelves [post]
@@ -106,7 +106,7 @@ func (h *ShelfHandler) CreateShelf(w http.ResponseWriter, r *http.Request) {
 // @Param       library_id  path      string  true  "Library UUID"
 // @Param       shelf_id    path      string  true  "Shelf UUID"
 // @Param       body        body      object{name=string,description=string,color=string,icon=string,display_order=integer,tag_ids=[]string}  true  "Updated shelf"
-// @Success     200  {object}  responses.ShelfResponse
+// @Success     200  {object}  github_com_fireball1725_librarium-api_internal_api_responses.ShelfResponse
 // @Failure     400  {object}  object{error=string}
 // @Failure     401  {object}  object{error=string}
 // @Failure     404  {object}  object{error=string}
@@ -173,7 +173,7 @@ func (h *ShelfHandler) DeleteShelf(w http.ResponseWriter, r *http.Request) {
 // @Security    BearerAuth
 // @Param       library_id  path      string  true  "Library UUID"
 // @Param       book_id     path      string  true  "Book UUID"
-// @Success     200  {array}   responses.ShelfResponse
+// @Success     200  {array}   github_com_fireball1725_librarium-api_internal_api_responses.ShelfResponse
 // @Failure     400  {object}  object{error=string}
 // @Failure     401  {object}  object{error=string}
 // @Router      /libraries/{library_id}/books/{book_id}/shelves [get]
@@ -209,7 +209,7 @@ func (h *ShelfHandler) ListBookShelves(w http.ResponseWriter, r *http.Request) {
 // @Security    BearerAuth
 // @Param       library_id  path      string  true  "Library UUID"
 // @Param       shelf_id    path      string  true  "Shelf UUID"
-// @Success     200  {array}   responses.BookResponse
+// @Success     200  {array}   github_com_fireball1725_librarium-api_internal_api_responses.BookResponse
 // @Failure     400  {object}  object{error=string}
 // @Failure     401  {object}  object{error=string}
 // @Router      /libraries/{library_id}/shelves/{shelf_id}/books [get]
@@ -317,7 +317,7 @@ func (h *ShelfHandler) RemoveBookFromShelf(w http.ResponseWriter, r *http.Reques
 // @Produce     json
 // @Security    BearerAuth
 // @Param       library_id  path      string  true  "Library UUID"
-// @Success     200  {array}   responses.TagResponse
+// @Success     200  {array}   github_com_fireball1725_librarium-api_internal_api_responses.TagResponse
 // @Failure     400  {object}  object{error=string}
 // @Failure     401  {object}  object{error=string}
 // @Router      /libraries/{library_id}/tags [get]
@@ -349,7 +349,7 @@ func (h *ShelfHandler) ListTags(w http.ResponseWriter, r *http.Request) {
 // @Security    BearerAuth
 // @Param       library_id  path      string  true  "Library UUID"
 // @Param       body        body      object{name=string,color=string}  true  "Tag details"
-// @Success     201  {object}  responses.TagResponse
+// @Success     201  {object}  github_com_fireball1725_librarium-api_internal_api_responses.TagResponse
 // @Failure     400  {object}  object{error=string}
 // @Failure     401  {object}  object{error=string}
 // @Router      /libraries/{library_id}/tags [post]
@@ -388,7 +388,7 @@ func (h *ShelfHandler) CreateTag(w http.ResponseWriter, r *http.Request) {
 // @Param       library_id  path      string  true  "Library UUID"
 // @Param       tag_id      path      string  true  "Tag UUID"
 // @Param       body        body      object{name=string,color=string}  true  "Updated tag"
-// @Success     200  {object}  responses.TagResponse
+// @Success     200  {object}  github_com_fireball1725_librarium-api_internal_api_responses.TagResponse
 // @Failure     400  {object}  object{error=string}
 // @Failure     401  {object}  object{error=string}
 // @Failure     404  {object}  object{error=string}

--- a/internal/api/handlers/sync.go
+++ b/internal/api/handlers/sync.go
@@ -31,19 +31,31 @@ func NewSyncHandler(repo *repository.SyncRepo) *SyncHandler {
 
 // GetChanges returns the caller's data that has changed since the given timestamp.
 //
-// Query params: since (RFC3339, required), limit (1..1000, default 500).
-//
-// Response shape (responses.SyncChangesResponse): { ops, server_time, has_more }.
 // Clients advance `since` to max(updated_at) of returned ops; when has_more is
 // true, call again immediately to keep draining the queue.
 //
 // v1 scope is user_book_interactions only. Other synced tables (loans, shelves,
 // memberships, etc.) follow one at a time.
 //
-// TODO: add swag annotations. The current swag 1.16.4 hits a parser bug when
-// this handler references responses.SyncChangesResponse, which corrupts type
-// resolution for unrelated handlers (auth.go's UserResponse fails to resolve).
-// Tracked separately; the endpoint is documented inline above for now.
+// This carried a TODO saying swag hit a parser bug here that broke type
+// resolution in unrelated handlers, auth.go among them. It did not. auth.go
+// failed on its own because it names responses.UserResponse in a comment while
+// importing no such package, and one unresolvable annotation fails the whole
+// run — so every file looked broken and this one, being the file under edit at
+// the time, got the blame. sync.go is in fact the only handler that imports the
+// package for real.
+//
+// @Summary     Pull changes since a timestamp
+// @Description Returns the caller's data changed since `since`, oldest first. Advance `since` to the newest updated_at you applied. When has_more is true the response hit `limit` and you should call again straight away.
+// @Tags        sync
+// @Produce     json
+// @Security    BearerAuth
+// @Param       since  query     string   true   "RFC3339 timestamp; returns changes strictly newer than this"
+// @Param       limit  query     integer  false  "Ops per response, 1 to 1000 (default 500)"
+// @Success     200    {object}  github_com_fireball1725_librarium-api_internal_api_responses.SyncChangesResponse
+// @Failure     400    {object}  object{error=string}
+// @Failure     401    {object}  object{error=string}
+// @Router      /sync/changes [get]
 func (h *SyncHandler) GetChanges(w http.ResponseWriter, r *http.Request) {
 	claims := middleware.ClaimsFromContext(r.Context())
 	if claims == nil {
@@ -113,6 +125,18 @@ func (h *SyncHandler) GetChanges(w http.ResponseWriter, r *http.Request) {
 // v1 scope is user_book_interactions only and update-only (no creates
 // through this endpoint; clients still POST/PUT new rows via the
 // existing per-resource endpoints).
+//
+// @Summary     Push a batch of client changes
+// @Description Applies client ops with per-field last-writer-wins. Every op comes back with its own status, so a partial success is normal and the client clears only the ops it sees applied. Update-only in v1: create new rows through the per-resource endpoints.
+// @Tags        sync
+// @Accept      json
+// @Produce     json
+// @Security    BearerAuth
+// @Param       body  body      github_com_fireball1725_librarium-api_internal_api_responses.SyncApplyRequest  true  "Ops to apply, at most 1000"
+// @Success     200   {object}  github_com_fireball1725_librarium-api_internal_api_responses.SyncApplyResponse
+// @Failure     400   {object}  object{error=string}
+// @Failure     401   {object}  object{error=string}
+// @Router      /sync/apply [post]
 func (h *SyncHandler) ApplyChanges(w http.ResponseWriter, r *http.Request) {
 	claims := middleware.ClaimsFromContext(r.Context())
 	if claims == nil {

--- a/internal/api/responses/responses.go
+++ b/internal/api/responses/responses.go
@@ -1,14 +1,30 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 FireBall1725 (Adaléa)
 
-// Package responses contains named structs used exclusively as swaggo/swag
-// annotation targets. They mirror the JSON shapes produced by the handler
-// body-helper functions so that the generated OpenAPI spec has proper schemas
+// Package responses contains named structs describing the JSON shapes the
+// handlers produce, so the generated OpenAPI spec carries proper schemas
 // instead of empty `{}` objects.
 //
-// These types are NOT used at runtime — handlers still build their responses
-// via the existing map[string]any helpers. Only the documentation annotations
-// reference this package.
+// Most are annotation targets only: the handler builds its response with the
+// existing map[string]any body helpers and the struct here mirrors the result.
+// The sync types are the exception and are marshalled directly by
+// handlers/sync.go, so a change to those is a change to the wire.
+//
+// # Referring to these types from an annotation
+//
+// Use the full mangled package path, not the short alias:
+//
+//	@Success 200 {object} github_com_fireball1725_librarium-api_internal_api_responses.BookResponse
+//
+// swag resolves a short alias like `responses.BookResponse` against the imports
+// of the file the comment sits in, and a handler file has no reason to import a
+// package it only names in comments — so the short form fails with "cannot find
+// type definition" for every file except sync.go, which imports it for real.
+// One unresolvable annotation fails the whole `swag init` run, which is what
+// left `make docs` broken and the committed spec missing eleven routes.
+//
+// The mangled form is what swag calls the package internally, and it is already
+// how the spec names every cross-package type from internal/models.
 package responses
 
 import (

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -129,6 +129,7 @@ func NewRouter(ctx context.Context, db *pgxpool.Pool, cfg *config.Config, riverC
 	contributorHandler := handlers.NewContributorHandler(contributorSvc)
 	dashboardHandler := handlers.NewDashboardHandler(bookRepo)
 	meLookupHandler := handlers.NewMeLookupHandler(libSvc, seriesRepo, tagRepo)
+	meBrowseHandler := handlers.NewMeBrowseHandler(libraryRepo, seriesRepo, contributorRepo)
 
 	releaseChecker := background.NewReleaseChecker(releaseSyncSvc, 24*time.Hour)
 	go releaseChecker.Start(ctx)
@@ -253,6 +254,9 @@ func NewRouter(ctx context.Context, db *pgxpool.Pool, cfg *config.Config, riverC
 
 	// User-scoped lookup endpoints (aggregated across the caller's libraries)
 	mux.Handle("GET /api/v1/me/series", requireAuth(http.HandlerFunc(meLookupHandler.SearchSeries)))
+	mux.Handle("GET /api/v1/me/series/index", requireAuth(http.HandlerFunc(meBrowseHandler.SeriesIndex)))
+	mux.Handle("GET /api/v1/me/authors/index", requireAuth(http.HandlerFunc(meBrowseHandler.AuthorsIndex)))
+	mux.Handle("GET /api/v1/me/counts", requireAuth(http.HandlerFunc(meBrowseHandler.Counts)))
 	mux.Handle("GET /api/v1/me/tags", requireAuth(http.HandlerFunc(meLookupHandler.SearchTags)))
 
 	// User-scoped AI suggestions

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -317,6 +317,7 @@ func NewRouter(ctx context.Context, db *pgxpool.Pool, cfg *config.Config, riverC
 	mux.Handle("POST /api/v1/libraries/{library_id}/books/bulk/enrich", requireLibraryPerm("books:update", http.HandlerFunc(bookHandler.BulkEnrich)))
 	mux.Handle("POST /api/v1/libraries/{library_id}/books/bulk/cover", requireLibraryPerm("books:update", http.HandlerFunc(bookHandler.BulkRefreshCovers)))
 	mux.Handle("GET /api/v1/libraries/{library_id}/books", requireLibraryPerm("books:read", http.HandlerFunc(bookHandler.ListBooks)))
+	mux.Handle("GET /api/v1/libraries/{library_id}/books/facets", requireLibraryPerm("books:read", http.HandlerFunc(bookHandler.Facets)))
 	mux.Handle("POST /api/v1/libraries/{library_id}/books", requireLibraryPerm("books:create", http.HandlerFunc(bookHandler.CreateBook)))
 	mux.Handle("GET /api/v1/libraries/{library_id}/books/{book_id}", requireLibraryPerm("books:read", http.HandlerFunc(bookHandler.GetBook)))
 	mux.Handle("PUT /api/v1/libraries/{library_id}/books/{book_id}", requireLibraryPerm("books:update", http.HandlerFunc(bookHandler.UpdateBook)))

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -181,6 +181,7 @@ func NewRouter(ctx context.Context, db *pgxpool.Pool, cfg *config.Config, riverC
 	mux.Handle("PUT /api/v1/auth/me", requireAuth(http.HandlerFunc(authHandler.UpdateMe)))
 	mux.Handle("PUT /api/v1/auth/me/password", requireAuth(http.HandlerFunc(authHandler.UpdatePassword)))
 	mux.Handle("GET /api/v1/auth/me/preferences", requireAuth(http.HandlerFunc(authHandler.GetPreferences)))
+	mux.Handle("GET /api/v1/me/libraries", requireAuth(http.HandlerFunc(libraryHandler.ListMyAccess)))
 	mux.Handle("PATCH /api/v1/auth/me/preferences", requireAuth(http.HandlerFunc(authHandler.PatchPreferences)))
 
 	// Personal access tokens

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -112,7 +112,7 @@ func NewRouter(ctx context.Context, db *pgxpool.Pool, cfg *config.Config, riverC
 	setupHandler := handlers.NewSetupHandler(authSvc, userRepo)
 	adminHandler := handlers.NewAdminHandler(authSvc)
 	libraryHandler := handlers.NewLibraryHandler(libSvc)
-	bookHandler := handlers.NewBookHandler(bookSvc, bookRepo, loanRepo, riverClient, enrichmentBatchRepo, editionFileSvc)
+	bookHandler := handlers.NewBookHandler(bookSvc, bookRepo, loanRepo, riverClient, enrichmentBatchRepo, editionFileSvc, libraryRepo)
 	shelfHandler := handlers.NewShelfHandler(shelfSvc)
 	loanHandler := handlers.NewLoanHandler(loanSvc)
 	seriesHandler := handlers.NewSeriesHandler(seriesSvc, releaseSyncSvc)
@@ -182,6 +182,8 @@ func NewRouter(ctx context.Context, db *pgxpool.Pool, cfg *config.Config, riverC
 	mux.Handle("PUT /api/v1/auth/me/password", requireAuth(http.HandlerFunc(authHandler.UpdatePassword)))
 	mux.Handle("GET /api/v1/auth/me/preferences", requireAuth(http.HandlerFunc(authHandler.GetPreferences)))
 	mux.Handle("GET /api/v1/me/libraries", requireAuth(http.HandlerFunc(libraryHandler.ListMyAccess)))
+	mux.Handle("GET /api/v1/me/books", requireAuth(http.HandlerFunc(bookHandler.ListMyBooks)))
+	mux.Handle("GET /api/v1/me/books/facets", requireAuth(http.HandlerFunc(bookHandler.MyBookFacets)))
 	mux.Handle("PATCH /api/v1/auth/me/preferences", requireAuth(http.HandlerFunc(authHandler.PatchPreferences)))
 
 	// Personal access tokens

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -129,7 +129,7 @@ func NewRouter(ctx context.Context, db *pgxpool.Pool, cfg *config.Config, riverC
 	contributorHandler := handlers.NewContributorHandler(contributorSvc)
 	dashboardHandler := handlers.NewDashboardHandler(bookRepo)
 	meLookupHandler := handlers.NewMeLookupHandler(libSvc, seriesRepo, tagRepo)
-	meBrowseHandler := handlers.NewMeBrowseHandler(libraryRepo, seriesRepo, contributorRepo)
+	meBrowseHandler := handlers.NewMeBrowseHandler(libraryRepo, seriesRepo, contributorRepo, shelfRepo, loanRepo)
 
 	releaseChecker := background.NewReleaseChecker(releaseSyncSvc, 24*time.Hour)
 	go releaseChecker.Start(ctx)
@@ -151,6 +151,15 @@ func NewRouter(ctx context.Context, db *pgxpool.Pool, cfg *config.Config, riverC
 	mux.HandleFunc("GET /api/docs", handlers.ServeScalarUI)
 
 	mux.HandleFunc("GET /health", handlers.Health)
+
+	// What this server is built from, for the clients' licences page.
+	// Authenticated, unlike /health: the version alone is one fact, but a full
+	// dependency inventory with versions is a shopping list of which CVEs to
+	// try, and an instance on the public internet should not hand that to
+	// anyone who asks. The AGPL's notice obligation travels with the source,
+	// not with an anonymous HTTP endpoint, so nothing is lost by asking for a
+	// login here.
+	mux.Handle("GET /api/v1/components", requireAuth(http.HandlerFunc(handlers.ListComponents)))
 
 	// Dashboard
 	mux.Handle("GET /api/v1/dashboard/currently-reading", requireAuth(http.HandlerFunc(dashboardHandler.GetCurrentlyReading)))
@@ -184,6 +193,9 @@ func NewRouter(ctx context.Context, db *pgxpool.Pool, cfg *config.Config, riverC
 	mux.Handle("GET /api/v1/auth/me/preferences", requireAuth(http.HandlerFunc(authHandler.GetPreferences)))
 	mux.Handle("GET /api/v1/me/libraries", requireAuth(http.HandlerFunc(libraryHandler.ListMyAccess)))
 	mux.Handle("GET /api/v1/me/books", requireAuth(http.HandlerFunc(bookHandler.ListMyBooks)))
+	mux.Handle("GET /api/v1/me/loans", requireAuth(http.HandlerFunc(meBrowseHandler.MyLoans)))
+	mux.Handle("GET /api/v1/me/shelves", requireAuth(http.HandlerFunc(meBrowseHandler.MyShelves)))
+	mux.Handle("GET /api/v1/me/books/grouped", requireAuth(http.HandlerFunc(bookHandler.ListMyBooksGrouped)))
 	mux.Handle("GET /api/v1/me/books/facets", requireAuth(http.HandlerFunc(bookHandler.MyBookFacets)))
 	mux.Handle("PATCH /api/v1/auth/me/preferences", requireAuth(http.HandlerFunc(authHandler.PatchPreferences)))
 

--- a/internal/licences/README.md
+++ b/internal/licences/README.md
@@ -1,0 +1,83 @@
+# Refreshing the component licence map
+
+`GET /api/v1/components` reports every Go module linked into the API binary so
+clients can render the notices on their licences page. The module list and the
+versions come from the binary's own build info at runtime, so they are never out
+of date and nothing has to be maintained for them.
+
+The one part a program cannot work out is the licence. A Go module does not
+declare one anywhere machine-readable, so `internal/licences/licences.go` carries
+a map from module path to SPDX identifier, read from each module's own `LICENSE`
+file.
+
+## When it needs refreshing
+
+`TestEveryRequirementHasALicence` fails and names the module:
+
+```
+module github.com/example/thing has no SPDX identifier in spdxByModule.
+Read its LICENSE under $(go env GOMODCACHE) and add a row.
+```
+
+That test reads `go.mod`, not build info, because a test binary reports zero
+dependencies from `debug.ReadBuildInfo` — the call succeeds and `Deps` is empty,
+so a test written against build info would pass by checking nothing.
+
+## Reading one licence by hand
+
+For a single new dependency this is usually quicker than the script:
+
+```sh
+ls "$(go env GOMODCACHE)/github.com/example/thing@v1.2.3"
+head -5 "$(go env GOMODCACHE)/github.com/example/thing@v1.2.3/LICENSE"
+```
+
+Two things to watch for:
+
+- **Uppercase in a module path is escaped in the cache.** `github.com/KyleBanks`
+  is stored as `github.com/!kyle!banks`. A lookup that ignores this finds
+  nothing and looks like a module with no licence.
+- **Some modules ship no `LICENSE` file at all.** `github.com/mattn/go-localereader`
+  states MIT in its README and nowhere else. Record where you found it in a
+  comment above the row, so the next person does not go hunting for a file that
+  is not there.
+
+## Regenerating the whole map
+
+After a dependency sweep, this prints a row per linked module:
+
+```sh
+go build -o /tmp/lib-api ./cmd/api
+MODCACHE=$(go env GOMODCACHE)
+go version -m /tmp/lib-api | awk '$1=="dep"{print $2"\t"$3}' | while IFS=$'\t' read -r mod ver; do
+  # Escape uppercase the way the module cache does: Foo -> !foo
+  esc=$(printf '%s' "$mod" | perl -pe 's/([A-Z])/"!".lc($1)/ge')
+  dir="$MODCACHE/$esc@$ver"
+  lic=""
+  for f in LICENSE LICENSE.md LICENSE.txt COPYING LICENCE; do
+    [ -f "$dir/$f" ] && { lic="$dir/$f"; break; }
+  done
+  if [ -z "$lic" ]; then printf '\t"%s": "CHECK BY HAND",\n' "$mod"; continue; fi
+  head -60 "$lic" > /tmp/l.txt
+  if   grep -qi "Apache License"                                  /tmp/l.txt; then id="Apache-2.0"
+  elif grep -qi "Mozilla Public License"                          /tmp/l.txt; then id="MPL-2.0"
+  elif grep -qi "GNU LESSER"                                      /tmp/l.txt; then id="LGPL"
+  elif grep -qi "GNU GENERAL"                                     /tmp/l.txt; then id="GPL"
+  elif grep -qi "Redistributions of source code must retain"      /tmp/l.txt; then
+       if grep -qi "Neither the name" /tmp/l.txt; then id="BSD-3-Clause"; else id="BSD-2-Clause"; fi
+  elif grep -qi "Permission is hereby granted, free of charge"    /tmp/l.txt; then id="MIT"
+  elif grep -qi "ISC License"                                     /tmp/l.txt; then id="ISC"
+  else id="CHECK BY HAND"; fi
+  printf '\t"%s": "%s",\n' "$mod" "$id"
+done | sort
+```
+
+It matches on licence text, so treat it as a first pass rather than an answer:
+check every `CHECK BY HAND` row yourself, and spot-check the rest. `gofmt -w`
+the file afterwards to align the map.
+
+Note the script lists what the **binary links**, whereas the test checks what
+**go.mod requires**. go.mod is the larger set — a couple of modules are required
+but never linked — so the test will still ask for rows the script did not print.
+That is the safe direction: a spare row costs nothing, a shipped module with no
+notice does not.

--- a/internal/licences/licences.go
+++ b/internal/licences/licences.go
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725 (Adaléa)
+
+// Package licences reports what the API server is built from.
+//
+// The AGPL obliges us to carry each dependency's notice, and a self-hosted
+// application should be able to answer "what is running on my machine" without
+// its operator reading a lockfile. Both wants the same list, so the API serves
+// it and every client renders it.
+//
+// The module list is NOT written down here. It comes from the binary's own
+// build info, so it describes the server that answers the request rather than
+// whatever the source tree looked like when someone last remembered to update a
+// page. A client talking to three Librarium instances on three versions gets
+// three honest answers. Only the SPDX identifier is curated, because a Go
+// module does not declare its licence anywhere a program can read at runtime.
+//
+// Adding a dependency therefore cannot drop a component from this list; it can
+// only leave the new module's licence blank, and the package test fails on that.
+// The list stays complete on its own and CI catches the one part that needs a
+// human.
+//
+// The test reads go.mod rather than build info, because a *test* binary reports
+// zero dependencies from debug.ReadBuildInfo — the call succeeds and Deps is
+// simply empty, so a test written against it passes by iterating over nothing
+// while a missing licence sails through. go.mod is a superset of what gets
+// linked, which errs the safe way: a row for something we do not ship costs
+// nothing, a shipped module with no notice is the failure that matters.
+package licences
+
+import (
+	"runtime/debug"
+	"sort"
+	"strings"
+)
+
+// Component is one module linked into this binary.
+type Component struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	// Licence is the SPDX identifier, or "" when the module is missing from
+	// spdxByModule. Empty is deliberately serialised rather than dropped: a
+	// component with an unknown licence is exactly the one worth showing.
+	Licence string `json:"licence"`
+}
+
+// spdxByModule maps a module path to its SPDX identifier.
+//
+// Read from each module's own LICENSE file in the module cache. README.md in
+// this package has the detector script and the two traps worth knowing about;
+// the package test tells you when a refresh is due.
+var spdxByModule = map[string]string{
+	"github.com/anthropics/anthropic-sdk-go": "MIT",
+	"github.com/aymanbagabas/go-osc52/v2":    "MIT",
+	"github.com/bahlo/generic-list-go":       "BSD-3-Clause",
+	"github.com/buger/jsonparser":            "MIT",
+	"github.com/charmbracelet/bubbletea":     "MIT",
+	"github.com/charmbracelet/colorprofile":  "MIT",
+	"github.com/charmbracelet/lipgloss":      "MIT",
+	"github.com/charmbracelet/x/ansi":        "MIT",
+	"github.com/charmbracelet/x/cellbuf":     "MIT",
+	"github.com/charmbracelet/x/term":        "MIT",
+	"github.com/davecgh/go-spew":             "ISC",
+	"github.com/erikgeiser/coninput":         "MIT",
+	"github.com/go-openapi/jsonpointer":      "Apache-2.0",
+	"github.com/go-openapi/jsonreference":    "Apache-2.0",
+	"github.com/go-openapi/spec":             "Apache-2.0",
+	"github.com/go-openapi/swag":             "Apache-2.0",
+	"github.com/golang-jwt/jwt/v5":           "MIT",
+	"github.com/golang-migrate/migrate/v4":   "MIT",
+	"github.com/google/uuid":                 "BSD-3-Clause",
+	"github.com/invopop/jsonschema":          "MIT",
+	"github.com/jackc/pgerrcode":             "MIT",
+	"github.com/jackc/pgpassfile":            "MIT",
+	"github.com/jackc/pgservicefile":         "MIT",
+	"github.com/jackc/pgx/v5":                "MIT",
+	"github.com/jackc/puddle/v2":             "MIT",
+	"github.com/josharian/intern":            "MIT",
+	"github.com/KyleBanks/depth":             "MIT",
+	"github.com/lucasb-eyer/go-colorful":     "MIT",
+	"github.com/mailru/easyjson":             "MIT",
+	"github.com/mattn/go-isatty":             "MIT",
+	// No LICENSE file in the module; its README states MIT.
+	"github.com/mattn/go-localereader":                         "MIT",
+	"github.com/mattn/go-runewidth":                            "MIT",
+	"github.com/muesli/ansi":                                   "MIT",
+	"github.com/muesli/cancelreader":                           "MIT",
+	"github.com/muesli/termenv":                                "MIT",
+	"github.com/pb33f/ordered-map/v2":                          "Apache-2.0",
+	"github.com/pmezard/go-difflib":                            "BSD-2-Clause",
+	"github.com/PuerkitoBio/purell":                            "BSD-3-Clause",
+	"github.com/PuerkitoBio/urlesc":                            "BSD-3-Clause",
+	"github.com/riverqueue/river":                              "MPL-2.0",
+	"github.com/riverqueue/river/riverdriver":                  "MPL-2.0",
+	"github.com/riverqueue/river/riverdriver/riverpgxv5":       "MPL-2.0",
+	"github.com/riverqueue/river/rivershared":                  "MPL-2.0",
+	"github.com/riverqueue/river/rivertype":                    "MPL-2.0",
+	"github.com/rivo/uniseg":                                   "MIT",
+	"github.com/robfig/cron/v3":                                "MIT",
+	"github.com/standard-webhooks/standard-webhooks/libraries": "MIT",
+	"github.com/stretchr/testify":                              "MIT",
+	"github.com/swaggo/swag":                                   "MIT",
+	"github.com/tidwall/gjson":                                 "MIT",
+	"github.com/tidwall/match":                                 "MIT",
+	"github.com/tidwall/pretty":                                "MIT",
+	"github.com/tidwall/sjson":                                 "MIT",
+	"github.com/xo/terminfo":                                   "MIT",
+	"go.uber.org/goleak":                                       "MIT",
+	"go.yaml.in/yaml/v4":                                       "Apache-2.0",
+	"golang.org/x/crypto":                                      "BSD-3-Clause",
+	"golang.org/x/mod":                                         "BSD-3-Clause",
+	"golang.org/x/net":                                         "BSD-3-Clause",
+	"golang.org/x/sync":                                        "BSD-3-Clause",
+	"golang.org/x/sys":                                         "BSD-3-Clause",
+	"golang.org/x/text":                                        "BSD-3-Clause",
+	"golang.org/x/tools":                                       "BSD-3-Clause",
+	"gopkg.in/yaml.v2":                                         "Apache-2.0",
+	"gopkg.in/yaml.v3":                                         "Apache-2.0",
+}
+
+// Components returns every module linked into this binary, sorted by name.
+//
+// Returns nil when build info is unavailable, which happens for a binary built
+// outside module mode. Callers report that as an empty list rather than an
+// error: not knowing the dependency set is not a server fault, and a licences
+// page that renders nothing is more honest than one that renders a 500.
+func Components() []Component {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return nil
+	}
+	return componentsFrom(info.Deps)
+}
+
+// componentsFrom is the whole of Components' logic, split out so it can be
+// tested: a test binary's own build info carries no dependencies, so a test
+// calling Components() would only ever see an empty list.
+func componentsFrom(deps []*debug.Module) []Component {
+	out := make([]Component, 0, len(deps))
+	for _, d := range deps {
+		// A replaced module reports its replacement's path and version, which
+		// is what is actually compiled in and therefore what carries the notice.
+		m := d
+		if m.Replace != nil {
+			m = m.Replace
+		}
+		out = append(out, Component{
+			Name:    m.Path,
+			Version: m.Version,
+			Licence: spdxByModule[m.Path],
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return strings.ToLower(out[i].Name) < strings.ToLower(out[j].Name)
+	})
+	return out
+}

--- a/internal/licences/licences_test.go
+++ b/internal/licences/licences_test.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725 (Adaléa)
+
+package licences
+
+import (
+	"bufio"
+	"os"
+	"runtime/debug"
+	"strings"
+	"testing"
+)
+
+// TestEveryRequirementHasALicence is the reason the module list is derived
+// rather than written down.
+//
+// A hand-kept list fails silently: you add a dependency, forget the row, and
+// the licences page keeps rendering, just missing one. Here the module arrives
+// on its own, so the only thing that can be missing is its SPDX identifier,
+// and that is what this fails on.
+//
+// It reads go.mod, not debug.ReadBuildInfo. A test binary reports zero
+// dependencies from build info — the call succeeds and Deps is empty — so the
+// obvious version of this test passes by checking nothing. go.mod is a superset
+// of the linked set, which is the safe direction to be wrong in.
+func TestEveryRequirementHasALicence(t *testing.T) {
+	mods, err := requirementsFromGoMod("../../go.mod")
+	if err != nil {
+		t.Fatalf("reading go.mod: %v", err)
+	}
+	if len(mods) < 10 {
+		t.Fatalf("parsed only %d requirements from go.mod; the parser is wrong, "+
+			"and a parser that finds nothing would make this test pass on an empty map", len(mods))
+	}
+	for _, m := range mods {
+		if spdxByModule[m] == "" {
+			t.Errorf("module %s has no SPDX identifier in spdxByModule.\n"+
+				"Read its LICENSE under $(go env GOMODCACHE) and add a row.", m)
+		}
+	}
+}
+
+// TestComponentsFromSortsAndResolves covers the shape clients depend on:
+// case-insensitive ordering, a resolved licence where one is known, and an
+// empty one where it is not — dropped rows would hide exactly the component
+// worth showing.
+func TestComponentsFromSortsAndResolves(t *testing.T) {
+	got := componentsFrom([]*debug.Module{
+		{Path: "github.com/zzz/last", Version: "v1.0.0"},
+		{Path: "github.com/google/uuid", Version: "v1.6.0"},
+		{Path: "github.com/Aaa/upper", Version: "v0.1.0"},
+	})
+
+	names := make([]string, len(got))
+	for i, c := range got {
+		names[i] = c.Name
+	}
+	want := []string{"github.com/Aaa/upper", "github.com/google/uuid", "github.com/zzz/last"}
+	if strings.Join(names, ",") != strings.Join(want, ",") {
+		t.Errorf("sorted %v, want %v", names, want)
+	}
+
+	byName := map[string]Component{}
+	for _, c := range got {
+		byName[c.Name] = c
+	}
+	if l := byName["github.com/google/uuid"].Licence; l != "BSD-3-Clause" {
+		t.Errorf("uuid licence = %q, want BSD-3-Clause", l)
+	}
+	if l := byName["github.com/zzz/last"].Licence; l != "" {
+		t.Errorf("unknown module licence = %q, want empty", l)
+	}
+	if v := byName["github.com/google/uuid"].Version; v != "v1.6.0" {
+		t.Errorf("version = %q, want v1.6.0", v)
+	}
+}
+
+// TestComponentsFromPrefersTheReplacement checks that a replaced module reports
+// what is actually compiled in, since that is what carries the notice.
+func TestComponentsFromPrefersTheReplacement(t *testing.T) {
+	got := componentsFrom([]*debug.Module{{
+		Path:    "github.com/original/thing",
+		Version: "v1.0.0",
+		Replace: &debug.Module{Path: "github.com/google/uuid", Version: "v1.6.0"},
+	}})
+	if len(got) != 1 {
+		t.Fatalf("got %d components, want 1", len(got))
+	}
+	if got[0].Name != "github.com/google/uuid" || got[0].Version != "v1.6.0" {
+		t.Errorf("got %s@%s, want the replacement", got[0].Name, got[0].Version)
+	}
+	if got[0].Licence != "BSD-3-Clause" {
+		t.Errorf("licence = %q, want the replacement's", got[0].Licence)
+	}
+}
+
+// requirementsFromGoMod pulls every module path out of go.mod's require
+// directives, both the block and single-line forms. Indirect requirements count
+// too: they are linked into the binary and shipped like anything else.
+//
+// A hand-rolled scanner rather than golang.org/x/mod, which would mean taking a
+// dependency in order to list dependencies.
+func requirementsFromGoMod(path string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var mods []string
+	inRequireBlock := false
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if i := strings.Index(line, "//"); i >= 0 {
+			line = strings.TrimSpace(line[:i]) // drops "// indirect" and comments
+		}
+		switch {
+		case line == "":
+		case inRequireBlock && line == ")":
+			inRequireBlock = false
+		case line == "require (":
+			inRequireBlock = true
+		case strings.HasPrefix(line, "require "):
+			// Single-line form: require example.com/mod v1.2.3
+			if fields := strings.Fields(line); len(fields) >= 3 {
+				mods = append(mods, fields[1])
+			}
+		case inRequireBlock:
+			// Only require blocks are scanned, so an exclude or replace block
+			// cannot leak entries in here.
+			if fields := strings.Fields(line); len(fields) >= 2 && strings.HasPrefix(fields[1], "v") {
+				mods = append(mods, fields[0])
+			}
+		}
+	}
+	return mods, sc.Err()
+}

--- a/internal/models/loan.go
+++ b/internal/models/loan.go
@@ -10,15 +10,19 @@ import (
 )
 
 type Loan struct {
-	ID         uuid.UUID  `json:"id"`
-	LibraryID  uuid.UUID  `json:"library_id"`
-	BookID     uuid.UUID  `json:"book_id"`
-	BookTitle  string     `json:"book_title"`
-	LoanedTo   string     `json:"loaned_to"`
-	LoanedAt   time.Time  `json:"loaned_at"`
-	DueDate    *time.Time `json:"due_date"`
-	ReturnedAt *time.Time `json:"returned_at"`
-	Notes      string     `json:"notes"`
-	CreatedAt  time.Time  `json:"created_at"`
-	UpdatedAt  time.Time  `json:"updated_at"`
+	ID        uuid.UUID `json:"id"`
+	LibraryID uuid.UUID `json:"library_id"`
+	BookID    uuid.UUID `json:"book_id"`
+	BookTitle string    `json:"book_title"`
+	// LibraryName is populated by the cross-library list only. A loans list
+	// spanning libraries has to say which one each row belongs to; a
+	// per-library list already knows and leaves this empty.
+	LibraryName string     `json:"library_name,omitempty"`
+	LoanedTo    string     `json:"loaned_to"`
+	LoanedAt    time.Time  `json:"loaned_at"`
+	DueDate     *time.Time `json:"due_date"`
+	ReturnedAt  *time.Time `json:"returned_at"`
+	Notes       string     `json:"notes"`
+	CreatedAt   time.Time  `json:"created_at"`
+	UpdatedAt   time.Time  `json:"updated_at"`
 }

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -102,6 +102,12 @@ type MetadataProvider interface {
 }
 
 // BookISBNProvider can look up a book by ISBN-10 or ISBN-13.
+//
+// Same bound as BookSearchProvider: implementations must bound their own call
+// via an http.Client Timeout or equivalent. Registry.LookupISBN starts its
+// deadline once some provider has answered, so before the first result the
+// only things that end the wait are a provider returning and the context being
+// cancelled.
 type BookISBNProvider interface {
 	MetadataProvider
 	LookupByISBN(ctx context.Context, isbn string) (*BookResult, error)

--- a/internal/providers/registry.go
+++ b/internal/providers/registry.go
@@ -90,30 +90,71 @@ func (r *Registry) LookupISBN(ctx context.Context, isbn string) []*BookResult {
 	}
 
 	type result struct {
+		name string
 		book *BookResult
 	}
 
 	ch := make(chan result, len(providers))
 	for _, p := range providers {
 		go func(bp BookISBNProvider) {
+			name := bp.Info().Name
 			book, err := bp.LookupByISBN(ctx, isbn)
-			if err != nil || book == nil {
-				ch <- result{}
+			if err != nil {
+				slog.WarnContext(ctx, "isbn lookup provider error", "provider", name, "isbn", isbn, "error", err)
+				ch <- result{name: name}
 				return
 			}
-			ch <- result{book: book}
+			ch <- result{name: name, book: book}
 		}(p)
 	}
 
+	// Same shape as SearchBooks: once one provider has answered, the rest get
+	// isbnDeadline and then we return what we have.
+	//
+	// Without this the lookup took as long as the slowest provider, so a
+	// single unreachable one cost every scan its full HTTP timeout even when
+	// another provider had already returned the book. Reported by a user on
+	// 2026-08-17 as scan timeouts on both iOS and web during an Open Library
+	// outage; Open Library was hanging rather than refusing, so it burned its
+	// whole 15s on every scan.
+	var deadlineC <-chan time.Time
+
 	var out []*BookResult
-	for range providers {
-		res := <-ch
-		if res.book != nil {
-			out = append(out, res.book)
+	remaining := len(providers)
+	for remaining > 0 {
+		select {
+		case res := <-ch:
+			if res.book != nil {
+				out = append(out, res.book)
+			}
+			remaining--
+			if deadlineC == nil {
+				deadline := time.NewTimer(isbnDeadline)
+				defer deadline.Stop()
+				deadlineC = deadline.C
+			}
+		case <-deadlineC:
+			slog.InfoContext(ctx, "isbn lookup deadline reached, returning partial results",
+				"isbn", isbn, "waiting_on", remaining, "results_so_far", len(out))
+			return out
+		case <-ctx.Done():
+			return out
 		}
 	}
 	return out
 }
+
+// isbnDeadline is how long LookupISBN waits for lagging providers once at
+// least one has answered.
+//
+// Tighter than searchDeadline because the two are not the same act. A search
+// produces a list to browse, and a wider net is worth a wait. An ISBN lookup
+// is someone standing at a shelf with a book in their hand and a scanner
+// pointed at it, where a second provider's extra fields are worth much less
+// than answering promptly.
+//
+// var, not const, so tests can shrink it rather than sleeping real seconds.
+var isbnDeadline = 3 * time.Second
 
 // BookSearchProviders returns all enabled providers with the book_search capability.
 func (r *Registry) BookSearchProviders() []BookSearchProvider {
@@ -253,6 +294,8 @@ func (r *Registry) SearchSeries(ctx context.Context, query string) []SeriesResul
 		go func(sp SeriesSearchProvider) {
 			items, err := sp.SearchSeries(ctx, query)
 			if err != nil {
+				slog.WarnContext(ctx, "series search provider error",
+					"provider", sp.Info().Name, "error", err)
 				ch <- result{}
 				return
 			}
@@ -260,10 +303,31 @@ func (r *Registry) SearchSeries(ctx context.Context, query string) []SeriesResul
 		}(p)
 	}
 
+	// The third fan-out, and it had the same unbounded wait LookupISBN did:
+	// one provider that hangs holds up a search every other provider has
+	// already answered. searchDeadline rather than isbnDeadline because this
+	// is a search, and the wider net is worth the wait.
+	var deadlineC <-chan time.Time
+
 	var out []SeriesResult
-	for range providers {
-		res := <-ch
-		out = append(out, res.items...)
+	remaining := len(providers)
+	for remaining > 0 {
+		select {
+		case res := <-ch:
+			out = append(out, res.items...)
+			remaining--
+			if deadlineC == nil {
+				deadline := time.NewTimer(searchDeadline)
+				defer deadline.Stop()
+				deadlineC = deadline.C
+			}
+		case <-deadlineC:
+			slog.InfoContext(ctx, "series search deadline reached, returning partial results",
+				"query", query, "waiting_on", remaining, "results_so_far", len(out))
+			return out
+		case <-ctx.Done():
+			return out
+		}
 	}
 	return out
 }

--- a/internal/providers/registry_test.go
+++ b/internal/providers/registry_test.go
@@ -85,3 +85,70 @@ func TestSearchBooks_DropsStragglerPastGracePeriodAfterFirstResult(t *testing.T)
 		t.Fatalf("got %+v, want exactly the fast provider's result — the straggler should have been dropped", out)
 	}
 }
+
+// fakeISBNProvider is a BookISBNProvider whose lookup blocks for `delay`
+// before returning a single result named after the provider.
+type fakeISBNProvider struct {
+	name  string
+	delay time.Duration
+}
+
+func (p *fakeISBNProvider) Info() ProviderInfo {
+	return ProviderInfo{Name: p.name, DisplayName: p.name, Capabilities: []string{CapBookISBN}}
+}
+func (p *fakeISBNProvider) Configure(map[string]string) {}
+func (p *fakeISBNProvider) Enabled() bool               { return true }
+func (p *fakeISBNProvider) LookupByISBN(ctx context.Context, isbn string) (*BookResult, error) {
+	select {
+	case <-time.After(p.delay):
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	return &BookResult{Provider: p.name, Title: p.name}, nil
+}
+
+func withISBNDeadline(t *testing.T, d time.Duration) {
+	t.Helper()
+	orig := isbnDeadline
+	isbnDeadline = d
+	t.Cleanup(func() { isbnDeadline = orig })
+}
+
+// Regression test for the bug reported 2026-08-17: LookupISBN waited for every
+// provider with no aggregate deadline, so one unreachable provider cost every
+// scan its full HTTP timeout even when another had already returned the book.
+// Reported as scan timeouts on iOS and web during an Open Library outage,
+// where Open Library hung rather than refusing.
+func TestLookupISBN_DoesNotWaitForAHungProviderOnceOneAnswered(t *testing.T) {
+	withISBNDeadline(t, 50*time.Millisecond)
+
+	r := NewRegistry()
+	r.Register(&fakeISBNProvider{name: "fast", delay: 0})
+	// Stands in for a provider that hangs until its own HTTP timeout.
+	r.Register(&fakeISBNProvider{name: "hung", delay: 10 * time.Second})
+
+	start := time.Now()
+	out := r.LookupISBN(context.Background(), "9780441172719")
+	elapsed := time.Since(start)
+
+	if elapsed > 2*time.Second {
+		t.Fatalf("waited %v for a hung provider; the scan should return once a fast one answered", elapsed)
+	}
+	if len(out) != 1 || out[0].Provider != "fast" {
+		t.Fatalf("want the fast provider's result, got %+v", out)
+	}
+}
+
+// The deadline must not start before anything has answered, or a lookup where
+// every provider is merely slow returns nothing at all.
+func TestLookupISBN_DeadlineStartsAfterFirstResult(t *testing.T) {
+	withISBNDeadline(t, 50*time.Millisecond)
+
+	r := NewRegistry()
+	r.Register(&fakeISBNProvider{name: "slow", delay: 200 * time.Millisecond})
+
+	out := r.LookupISBN(context.Background(), "9780441172719")
+	if len(out) != 1 {
+		t.Fatalf("want the slow provider's result once it arrives, got %d results", len(out))
+	}
+}

--- a/internal/repository/book_facets.go
+++ b/internal/repository/book_facets.go
@@ -29,6 +29,7 @@ type BookFacets struct {
 	MediaType  []FacetValue `json:"media_type"`
 	Genre      []FacetValue `json:"genre"`
 	Tag        []FacetValue `json:"tag"`
+	Shelf      []FacetValue `json:"shelf"`
 	Rating     []FacetValue `json:"rating"`
 }
 
@@ -47,14 +48,18 @@ type FacetSelection struct {
 	MediaTypes []string // media_types.name
 	Genres     []string
 	Tags       []string
-	Ratings    []int32
+	// Shelves are hand-picked sets rather than a property of a book, but they
+	// narrow the list exactly like a tag does, so they are a facet dimension.
+	Shelves []uuid.UUID
+	Ratings []int32
 }
 
 func emptyFacets() *BookFacets {
 	return &BookFacets{
 		Ownership: []FacetValue{},
 		Library:   []FacetValue{}, ReadStatus: []FacetValue{}, MediaType: []FacetValue{},
-		Genre: []FacetValue{}, Tag: []FacetValue{}, Rating: []FacetValue{},
+		Genre: []FacetValue{}, Tag: []FacetValue{}, Shelf: []FacetValue{},
+		Rating: []FacetValue{},
 	}
 }
 
@@ -79,6 +84,7 @@ func (r *BookRepo) Facets(
 	accessible []uuid.UUID,
 	sel FacetSelection,
 	query string,
+	seriesIDs []uuid.UUID,
 	callerID uuid.UUID,
 ) (*BookFacets, error) {
 	if len(accessible) == 0 {
@@ -115,6 +121,16 @@ func (r *BookRepo) Facets(
             WHERE bc.book_id = b.id AND c.name ILIKE %[1]s))`, p)
 	}
 
+	// Drilling into a series narrows every dimension, for the same reason the
+	// text search does: it is not one of the facets, so no dimension owns it and
+	// none may count around it. Without this the rail reported the whole shelf
+	// beside a list showing one run.
+	if len(seriesIDs) > 0 {
+		p := arg(seriesIDs)
+		textWhere += fmt.Sprintf(` AND EXISTS (
+            SELECT 1 FROM book_series bs_f WHERE bs_f.book_id = b.id AND bs_f.series_id = ANY(%s))`, p)
+	}
+
 	interCTE := "SELECT NULL::uuid AS book_id, NULL::text AS read_status, NULL::int AS rating WHERE false"
 	if callerID != uuid.Nil {
 		p := arg(callerID)
@@ -136,6 +152,7 @@ func (r *BookRepo) Facets(
 	mOwn := "TRUE"
 	mLib, mStatus, mType := "TRUE", "TRUE", "TRUE"
 	mGenre, mTag, mRating := "TRUE", "TRUE", "TRUE"
+	mShelf := "TRUE"
 
 	if len(sel.Ownership) > 0 {
 		mOwn = fmt.Sprintf("s.ownership = ANY(%s)", arg(sel.Ownership))
@@ -161,6 +178,12 @@ func (r *BookRepo) Facets(
 		mTag = fmt.Sprintf(`EXISTS (SELECT 1 FROM book_tags bt2 JOIN tags t2 ON t2.id = bt2.tag_id
                  WHERE bt2.book_id = s.id AND bt2.deleted_at IS NULL AND t2.name = ANY(%s))`, arg(sel.Tags))
 	}
+	// By id, not name: a shelf name is only unique within its library, so two
+	// libraries can both have "Favourites" and they are different shelves.
+	if len(sel.Shelves) > 0 {
+		mShelf = fmt.Sprintf(`EXISTS (SELECT 1 FROM book_shelves bsh2
+                 WHERE bsh2.book_id = s.id AND bsh2.shelf_id = ANY(%s))`, arg(sel.Shelves))
+	}
 	if len(sel.Ratings) > 0 {
 		mRating = fmt.Sprintf(`x.rating = ANY(%s)`, arg(sel.Ratings))
 	}
@@ -170,9 +193,10 @@ func (r *BookRepo) Facets(
 		all := map[string]string{
 			"own": "f.m_own",
 			"lib": "f.m_lib", "status": "f.m_status", "type": "f.m_type",
-			"genre": "f.m_genre", "tag": "f.m_tag", "rating": "f.m_rating",
+			"genre": "f.m_genre", "tag": "f.m_tag", "shelf": "f.m_shelf",
+			"rating": "f.m_rating",
 		}
-		parts := make([]string, 0, 6)
+		parts := make([]string, 0, 7)
 		for k, v := range all {
 			if k != skip {
 				parts = append(parts, v)
@@ -195,7 +219,7 @@ f AS (
            COALESCE(x.read_status, 'unread') AS read_status,
            x.rating,
            %s AS m_own, %s AS m_lib, %s AS m_status, %s AS m_type,
-           %s AS m_genre, %s AS m_tag, %s AS m_rating
+           %s AS m_genre, %s AS m_tag, %s AS m_shelf, %s AS m_rating
     FROM scope s LEFT JOIN inter x ON x.book_id = s.id
 )
 SELECT 'ownership' AS dim, f.ownership AS value, f.ownership AS label, COUNT(*) AS n
@@ -223,16 +247,22 @@ FROM f JOIN book_tags bt ON bt.book_id = f.id AND bt.deleted_at IS NULL
        JOIN tags t ON t.id = bt.tag_id AND t.deleted_at IS NULL
 WHERE %s GROUP BY t.name
 UNION ALL
+SELECT 'shelf', sh.id::text, sh.name, COUNT(DISTINCT f.id)
+FROM f JOIN book_shelves bsh ON bsh.book_id = f.id
+       JOIN shelves sh ON sh.id = bsh.shelf_id
+WHERE sh.library_id = ANY($1) AND %s
+GROUP BY sh.id, sh.name
+UNION ALL
 SELECT 'rating', f.rating::text, f.rating::text, COUNT(*)
 FROM f WHERE f.rating IS NOT NULL AND %s GROUP BY f.rating
 ORDER BY 1, 4 DESC, 3`,
 		// The scope CTE comes first now: it holds the caller's own placeholder,
 		// so it has to be built before the text filter's is counted.
 		scopeSQL, textWhere, interCTE,
-		mOwn, mLib, mStatus, mType, mGenre, mTag, mRating,
+		mOwn, mLib, mStatus, mType, mGenre, mTag, mShelf, mRating,
 		others("own"),
 		others("lib"), others("status"), others("type"),
-		others("genre"), others("tag"), others("rating"))
+		others("genre"), others("tag"), others("shelf"), others("rating"))
 
 	rows, err := r.db.Query(ctx, q, args...)
 	if err != nil {
@@ -260,6 +290,8 @@ ORDER BY 1, 4 DESC, 3`,
 			out.Genre = append(out.Genre, fv)
 		case "tag":
 			out.Tag = append(out.Tag, fv)
+		case "shelf":
+			out.Shelf = append(out.Shelf, fv)
 		case "rating":
 			out.Rating = append(out.Rating, fv)
 		}

--- a/internal/repository/book_facets.go
+++ b/internal/repository/book_facets.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/fireball1725/librarium-api/internal/models"
 	"github.com/google/uuid"
 )
 
@@ -41,8 +42,19 @@ type BookFacets struct {
 //
 // Best status wins, read > reading > did_not_finish > unread, because "have I
 // read this" is a question about the work rather than about one printing.
-func (r *BookRepo) Facets(ctx context.Context, libraryID uuid.UUID, opts ListBooksOpts) (*BookFacets, error) {
-	f := r.buildBookFilter(libraryID, opts)
+// libraryIDs scopes the counts. A single entry serves the per-library route;
+// the caller's whole membership set serves the cross-library Books surface.
+func (r *BookRepo) Facets(ctx context.Context, libraryIDs []uuid.UUID, opts ListBooksOpts) (*BookFacets, error) {
+	if len(libraryIDs) == 0 {
+		// No accessible libraries is a legitimate state, not an error: a new
+		// user, or one whose only membership was revoked. Empty facets let the
+		// client render its own empty state instead of a failure.
+		return &BookFacets{
+			ReadStatus: []FacetValue{}, MediaType: []FacetValue{}, Genre: []FacetValue{},
+			Tag: []FacetValue{}, Rating: []FacetValue{},
+		}, nil
+	}
+	f := r.buildBookFilter(libraryIDs, opts)
 
 	args := f.args
 	callerArg := 0
@@ -139,4 +151,58 @@ ORDER BY 1, 4 DESC, 2`, f.scopeJoin, f.where, interJoin)
 		return nil, fmt.Errorf("reading facet rows: %w", err)
 	}
 	return out, nil
+}
+
+// LibraryFacet counts the filtered books per library.
+//
+// Kept out of Facets because it only means anything across several libraries:
+// on a per-library route it would return one value whose count equals the
+// total, which is noise rather than a filter.
+func (r *BookRepo) LibraryFacet(ctx context.Context, libraryIDs []uuid.UUID, opts ListBooksOpts) ([]FacetValue, error) {
+	if len(libraryIDs) == 0 {
+		return []FacetValue{}, nil
+	}
+	f := r.buildBookFilter(libraryIDs, opts)
+
+	// COUNT(DISTINCT b.id): a work held by two libraries is one book in each,
+	// not two, and the junction would otherwise multiply it.
+	// Unlike every other facet this one wants a row per (book, library), so it
+	// joins the junction directly instead of the deduping scope join and
+	// reapplies the library predicate itself. COUNT(DISTINCT b.id) still
+	// guards against a book appearing twice within one library.
+	query := fmt.Sprintf(`
+		SELECT l.id::text, l.name, COUNT(DISTINCT b.id)
+		FROM books b
+		JOIN media_types mt ON mt.id = b.media_type_id
+		JOIN library_books lbx ON lbx.book_id = b.id AND lbx.deleted_at IS NULL
+		JOIN libraries l ON l.id = lbx.library_id
+		%s
+		AND lbx.library_id = ANY($1)
+		GROUP BY l.id, l.name
+		ORDER BY 3 DESC, 2`, f.where)
+
+	rows, err := r.db.Query(ctx, query, f.args...)
+	if err != nil {
+		return nil, fmt.Errorf("counting library facet: %w", err)
+	}
+	defer rows.Close()
+
+	out := []FacetValue{}
+	for rows.Next() {
+		var fv FacetValue
+		if err := rows.Scan(&fv.Value, &fv.Label, &fv.Count); err != nil {
+			return nil, fmt.Errorf("scanning library facet: %w", err)
+		}
+		out = append(out, fv)
+	}
+	return out, rows.Err()
+}
+
+// ListAcross lists books spanning several libraries, deduplicated: a work held
+// by two libraries appears once, not twice.
+func (r *BookRepo) ListAcross(ctx context.Context, libraryIDs []uuid.UUID, opts ListBooksOpts) ([]*models.Book, int, error) {
+	if len(libraryIDs) == 0 {
+		return []*models.Book{}, 0, nil
+	}
+	return r.listScoped(ctx, libraryIDs, opts)
 }

--- a/internal/repository/book_facets.go
+++ b/internal/repository/book_facets.go
@@ -101,11 +101,7 @@ func (r *BookRepo) Facets(
 		p := arg(callerID)
 		interCTE = fmt.Sprintf(`
             SELECT e.book_id,
-                   CASE min(CASE i.read_status
-                                WHEN 'read' THEN 1 WHEN 'reading' THEN 2
-                                WHEN 'did_not_finish' THEN 3 ELSE 4 END)
-                        WHEN 1 THEN 'read' WHEN 2 THEN 'reading'
-                        WHEN 3 THEN 'did_not_finish' ELSE 'unread' END AS read_status,
+                   `+bestReadStatusExpr+` AS read_status,
                    max(i.rating) AS rating
             FROM user_book_interactions i
             JOIN book_editions e ON e.id = i.book_edition_id

--- a/internal/repository/book_facets.go
+++ b/internal/repository/book_facets.go
@@ -23,6 +23,7 @@ type FacetValue struct {
 // BookFacets is the counts block returned alongside a book search, so a client
 // can render a filter rail without a request per value.
 type BookFacets struct {
+	Ownership  []FacetValue `json:"ownership"`
 	Library    []FacetValue `json:"library"`
 	ReadStatus []FacetValue `json:"read_status"`
 	MediaType  []FacetValue `json:"media_type"`
@@ -38,6 +39,9 @@ type BookFacets struct {
 // dimension has to be counted with its OWN selection removed, which is
 // impossible once the conditions have been flattened into one WHERE string.
 type FacetSelection struct {
+	// Ownership is where a book stands in relation to the caller: on the
+	// shelf, wishlisted, suggested, or a gap in a series. See book_ownership.go.
+	Ownership  []string
 	Libraries  []uuid.UUID
 	ReadStatus []string
 	MediaTypes []string // media_types.name
@@ -48,7 +52,8 @@ type FacetSelection struct {
 
 func emptyFacets() *BookFacets {
 	return &BookFacets{
-		Library: []FacetValue{}, ReadStatus: []FacetValue{}, MediaType: []FacetValue{},
+		Ownership: []FacetValue{},
+		Library:   []FacetValue{}, ReadStatus: []FacetValue{}, MediaType: []FacetValue{},
 		Genre: []FacetValue{}, Tag: []FacetValue{}, Rating: []FacetValue{},
 	}
 }
@@ -86,6 +91,20 @@ func (r *BookRepo) Facets(
 		return fmt.Sprintf("$%d", len(args))
 	}
 
+	// Scope first, because it binds the caller's own placeholder and the
+	// numbering follows the order arg() is called in, not the order the pieces
+	// appear in the format string.
+	//
+	// The caller is bound once here and again for the interaction CTE below.
+	// Two binds of the same value is cheaper than threading one placeholder
+	// through both and getting the numbering wrong.
+	scopeCallerArg := 0
+	if callerID != uuid.Nil {
+		arg(callerID)
+		scopeCallerArg = len(args)
+	}
+	scopeSQL := bookScopeCTE(1, scopeCallerArg)
+
 	// Text search is not a facet, so it narrows every dimension including the
 	// one being counted, and belongs in the base scope.
 	textWhere := ""
@@ -114,8 +133,13 @@ func (r *BookRepo) Facets(
 	// arguments eagerly, so building the expression unconditionally would append
 	// an arg whose placeholder never reaches the SQL, and Postgres then fails
 	// with "could not determine data type of parameter $N".
+	mOwn := "TRUE"
 	mLib, mStatus, mType := "TRUE", "TRUE", "TRUE"
 	mGenre, mTag, mRating := "TRUE", "TRUE", "TRUE"
+
+	if len(sel.Ownership) > 0 {
+		mOwn = fmt.Sprintf("s.ownership = ANY(%s)", arg(sel.Ownership))
+	}
 
 	if len(sel.Libraries) > 0 {
 		mLib = fmt.Sprintf(`EXISTS (SELECT 1 FROM library_books lb2 WHERE lb2.book_id = s.id
@@ -144,10 +168,11 @@ func (r *BookRepo) Facets(
 	// Every flag except the dimension's own.
 	others := func(skip string) string {
 		all := map[string]string{
+			"own": "f.m_own",
 			"lib": "f.m_lib", "status": "f.m_status", "type": "f.m_type",
 			"genre": "f.m_genre", "tag": "f.m_tag", "rating": "f.m_rating",
 		}
-		parts := make([]string, 0, 5)
+		parts := make([]string, 0, 6)
 		for k, v := range all {
 			if k != skip {
 				parts = append(parts, v)
@@ -159,22 +184,24 @@ func (r *BookRepo) Facets(
 
 	q := fmt.Sprintf(`
 WITH scope AS (
-    SELECT DISTINCT b.id, b.media_type_id
+    SELECT DISTINCT b.id, b.media_type_id, lb.ownership
     FROM books b
-    JOIN (SELECT DISTINCT book_id FROM library_books
-          WHERE library_id = ANY($1) AND deleted_at IS NULL) lb ON lb.book_id = b.id
+    JOIN (%s) lb ON lb.book_id = b.id
     WHERE TRUE %s
 ),
 inter AS (%s),
 f AS (
-    SELECT s.id, s.media_type_id,
+    SELECT s.id, s.media_type_id, s.ownership,
            COALESCE(x.read_status, 'unread') AS read_status,
            x.rating,
-           %s AS m_lib, %s AS m_status, %s AS m_type,
+           %s AS m_own, %s AS m_lib, %s AS m_status, %s AS m_type,
            %s AS m_genre, %s AS m_tag, %s AS m_rating
     FROM scope s LEFT JOIN inter x ON x.book_id = s.id
 )
-SELECT 'library' AS dim, l.id::text AS value, l.name AS label, COUNT(DISTINCT f.id) AS n
+SELECT 'ownership' AS dim, f.ownership AS value, f.ownership AS label, COUNT(*) AS n
+FROM f WHERE %s GROUP BY f.ownership
+UNION ALL
+SELECT 'library', l.id::text, l.name, COUNT(DISTINCT f.id)
 FROM f JOIN library_books lb3 ON lb3.book_id = f.id AND lb3.deleted_at IS NULL
        JOIN libraries l ON l.id = lb3.library_id
 WHERE lb3.library_id = ANY($1) AND %s
@@ -199,8 +226,11 @@ UNION ALL
 SELECT 'rating', f.rating::text, f.rating::text, COUNT(*)
 FROM f WHERE f.rating IS NOT NULL AND %s GROUP BY f.rating
 ORDER BY 1, 4 DESC, 3`,
-		textWhere, interCTE,
-		mLib, mStatus, mType, mGenre, mTag, mRating,
+		// The scope CTE comes first now: it holds the caller's own placeholder,
+		// so it has to be built before the text filter's is counted.
+		scopeSQL, textWhere, interCTE,
+		mOwn, mLib, mStatus, mType, mGenre, mTag, mRating,
+		others("own"),
 		others("lib"), others("status"), others("type"),
 		others("genre"), others("tag"), others("rating"))
 
@@ -218,6 +248,8 @@ ORDER BY 1, 4 DESC, 3`,
 			return nil, fmt.Errorf("scanning facet row: %w", err)
 		}
 		switch dim {
+		case "ownership":
+			out.Ownership = append(out.Ownership, fv)
 		case "library":
 			out.Library = append(out.Library, fv)
 		case "read_status":

--- a/internal/repository/book_facets.go
+++ b/internal/repository/book_facets.go
@@ -6,6 +6,7 @@ package repository
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/fireball1725/librarium-api/internal/models"
 	"github.com/google/uuid"
@@ -22,6 +23,7 @@ type FacetValue struct {
 // BookFacets is the counts block returned alongside a book search, so a client
 // can render a filter rail without a request per value.
 type BookFacets struct {
+	Library    []FacetValue `json:"library"`
 	ReadStatus []FacetValue `json:"read_status"`
 	MediaType  []FacetValue `json:"media_type"`
 	Genre      []FacetValue `json:"genre"`
@@ -29,105 +31,190 @@ type BookFacets struct {
 	Rating     []FacetValue `json:"rating"`
 }
 
-// Facets counts books per facet value over the whole filtered set, not the
-// page. Everything is one round trip: a query per facet would multiply with the
-// number of dimensions and each would have to rebuild the same filter.
+// FacetSelection is what the user has ticked in each facet. An empty slice
+// means that facet is not filtering.
+//
+// Passed as structured values rather than as opaque filter JSON because each
+// dimension has to be counted with its OWN selection removed, which is
+// impossible once the conditions have been flattened into one WHERE string.
+type FacetSelection struct {
+	Libraries  []uuid.UUID
+	ReadStatus []string
+	MediaTypes []string // media_types.name
+	Genres     []string
+	Tags       []string
+	Ratings    []int32
+}
+
+func emptyFacets() *BookFacets {
+	return &BookFacets{
+		Library: []FacetValue{}, ReadStatus: []FacetValue{}, MediaType: []FacetValue{},
+		Genre: []FacetValue{}, Tag: []FacetValue{}, Rating: []FacetValue{},
+	}
+}
+
+// Facets counts books per facet value over the whole filtered set, not the page.
+//
+// Each dimension is counted with its own selection EXCLUDED. Applying every
+// filter uniformly collapses the facet you just used: tick Fantasy and the
+// genre list shows only Fantasy, so adding Science Fiction becomes impossible
+// without clearing first. Excluding a dimension's own selection answers the
+// question the rail is actually asking, which is "what would I get if I picked
+// this one as well".
+//
+// One pass, not a query per dimension. Match flags are computed once per row and
+// each dimension aggregates using the five flags it does not own.
 //
 // Read status and rating come from user_book_interactions, which is keyed on
-// book_edition_id rather than book_id. Joining editions directly would count a
-// work with three editions three times, so interactions are collapsed to one
-// row per book first. Measured during the spike: 1,000 extra editions inflated
-// the status counts by exactly 1,000 before this was fixed, and fixing it cost
-// nothing (338ms against 340ms at 100k books).
-//
-// Best status wins, read > reading > did_not_finish > unread, because "have I
-// read this" is a question about the work rather than about one printing.
-// libraryIDs scopes the counts. A single entry serves the per-library route;
-// the caller's whole membership set serves the cross-library Books surface.
-func (r *BookRepo) Facets(ctx context.Context, libraryIDs []uuid.UUID, opts ListBooksOpts) (*BookFacets, error) {
-	if len(libraryIDs) == 0 {
-		// No accessible libraries is a legitimate state, not an error: a new
-		// user, or one whose only membership was revoked. Empty facets let the
-		// client render its own empty state instead of a failure.
-		return &BookFacets{
-			ReadStatus: []FacetValue{}, MediaType: []FacetValue{}, Genre: []FacetValue{},
-			Tag: []FacetValue{}, Rating: []FacetValue{},
-		}, nil
-	}
-	f := r.buildBookFilter(libraryIDs, opts)
-
-	args := f.args
-	callerArg := 0
-	if opts.CallerID != uuid.Nil {
-		args = append(args, opts.CallerID)
-		callerArg = f.nextArg
+// book_edition_id. Joining editions directly counts a work with three editions
+// three times, so interactions collapse to one row per book first, best status
+// winning: read > reading > did_not_finish > unread.
+func (r *BookRepo) Facets(
+	ctx context.Context,
+	accessible []uuid.UUID,
+	sel FacetSelection,
+	query string,
+	callerID uuid.UUID,
+) (*BookFacets, error) {
+	if len(accessible) == 0 {
+		return emptyFacets(), nil
 	}
 
-	// The filtered set of book ids, computed once and reused by every facet.
-	interJoin := "SELECT NULL::uuid AS book_id, NULL::text AS read_status, NULL::int AS rating WHERE false"
-	if callerArg > 0 {
-		interJoin = fmt.Sprintf(`
-			SELECT e.book_id,
-			       CASE min(CASE i.read_status
-			                    WHEN 'read' THEN 1 WHEN 'reading' THEN 2
-			                    WHEN 'did_not_finish' THEN 3 ELSE 4 END)
-			            WHEN 1 THEN 'read' WHEN 2 THEN 'reading'
-			            WHEN 3 THEN 'did_not_finish' ELSE 'unread' END AS read_status,
-			       max(i.rating) AS rating
-			FROM user_book_interactions i
-			JOIN book_editions e ON e.id = i.book_edition_id
-			WHERE i.user_id = $%d AND i.deleted_at IS NULL
-			GROUP BY e.book_id`, callerArg)
+	args := []any{accessible}
+	arg := func(v any) string {
+		args = append(args, v)
+		return fmt.Sprintf("$%d", len(args))
 	}
 
-	query := fmt.Sprintf(`
+	// Text search is not a facet, so it narrows every dimension including the
+	// one being counted, and belongs in the base scope.
+	textWhere := ""
+	if query != "" {
+		p := arg("%" + query + "%")
+		textWhere = fmt.Sprintf(`AND (b.title ILIKE %[1]s OR EXISTS (
+            SELECT 1 FROM book_contributors bc JOIN contributors c ON c.id = bc.contributor_id
+            WHERE bc.book_id = b.id AND c.name ILIKE %[1]s))`, p)
+	}
+
+	interCTE := "SELECT NULL::uuid AS book_id, NULL::text AS read_status, NULL::int AS rating WHERE false"
+	if callerID != uuid.Nil {
+		p := arg(callerID)
+		interCTE = fmt.Sprintf(`
+            SELECT e.book_id,
+                   CASE min(CASE i.read_status
+                                WHEN 'read' THEN 1 WHEN 'reading' THEN 2
+                                WHEN 'did_not_finish' THEN 3 ELSE 4 END)
+                        WHEN 1 THEN 'read' WHEN 2 THEN 'reading'
+                        WHEN 3 THEN 'did_not_finish' ELSE 'unread' END AS read_status,
+                   max(i.rating) AS rating
+            FROM user_book_interactions i
+            JOIN book_editions e ON e.id = i.book_edition_id
+            WHERE i.user_id = %s AND i.deleted_at IS NULL
+            GROUP BY e.book_id`, p)
+	}
+
+	// One flag per dimension. An unused facet is always TRUE so it narrows
+	// nothing, and critically its parameter is never bound: Go evaluates call
+	// arguments eagerly, so building the expression unconditionally would append
+	// an arg whose placeholder never reaches the SQL, and Postgres then fails
+	// with "could not determine data type of parameter $N".
+	mLib, mStatus, mType := "TRUE", "TRUE", "TRUE"
+	mGenre, mTag, mRating := "TRUE", "TRUE", "TRUE"
+
+	if len(sel.Libraries) > 0 {
+		mLib = fmt.Sprintf(`EXISTS (SELECT 1 FROM library_books lb2 WHERE lb2.book_id = s.id
+                 AND lb2.deleted_at IS NULL AND lb2.library_id = ANY(%s))`, arg(sel.Libraries))
+	}
+	if len(sel.ReadStatus) > 0 {
+		mStatus = fmt.Sprintf(`COALESCE(x.read_status, 'unread') = ANY(%s)`, arg(sel.ReadStatus))
+	}
+	if len(sel.MediaTypes) > 0 {
+		mType = fmt.Sprintf(
+			`EXISTS (SELECT 1 FROM media_types mt2 WHERE mt2.id = s.media_type_id AND mt2.name = ANY(%s))`,
+			arg(sel.MediaTypes))
+	}
+	if len(sel.Genres) > 0 {
+		mGenre = fmt.Sprintf(`EXISTS (SELECT 1 FROM book_genres bg2 JOIN genres g2 ON g2.id = bg2.genre_id
+                 WHERE bg2.book_id = s.id AND g2.name = ANY(%s))`, arg(sel.Genres))
+	}
+	if len(sel.Tags) > 0 {
+		mTag = fmt.Sprintf(`EXISTS (SELECT 1 FROM book_tags bt2 JOIN tags t2 ON t2.id = bt2.tag_id
+                 WHERE bt2.book_id = s.id AND bt2.deleted_at IS NULL AND t2.name = ANY(%s))`, arg(sel.Tags))
+	}
+	if len(sel.Ratings) > 0 {
+		mRating = fmt.Sprintf(`x.rating = ANY(%s)`, arg(sel.Ratings))
+	}
+
+	// Every flag except the dimension's own.
+	others := func(skip string) string {
+		all := map[string]string{
+			"lib": "f.m_lib", "status": "f.m_status", "type": "f.m_type",
+			"genre": "f.m_genre", "tag": "f.m_tag", "rating": "f.m_rating",
+		}
+		parts := make([]string, 0, 5)
+		for k, v := range all {
+			if k != skip {
+				parts = append(parts, v)
+			}
+		}
+		insertionSort(parts) // deterministic SQL, so it diffs cleanly in logs
+		return strings.Join(parts, " AND ")
+	}
+
+	q := fmt.Sprintf(`
 WITH scope AS (
     SELECT DISTINCT b.id, b.media_type_id
     FROM books b
-    JOIN media_types mt ON mt.id = b.media_type_id
-    %s
-    %s
+    JOIN (SELECT DISTINCT book_id FROM library_books
+          WHERE library_id = ANY($1) AND deleted_at IS NULL) lb ON lb.book_id = b.id
+    WHERE TRUE %s
 ),
 inter AS (%s),
-joined AS (
+f AS (
     SELECT s.id, s.media_type_id,
            COALESCE(x.read_status, 'unread') AS read_status,
-           x.rating
-    FROM scope s
-    LEFT JOIN inter x ON x.book_id = s.id
+           x.rating,
+           %s AS m_lib, %s AS m_status, %s AS m_type,
+           %s AS m_genre, %s AS m_tag, %s AS m_rating
+    FROM scope s LEFT JOIN inter x ON x.book_id = s.id
 )
-SELECT 'read_status' AS dim, read_status AS value, read_status AS label, count(*) AS n
-FROM joined GROUP BY 2, 3
+SELECT 'library' AS dim, l.id::text AS value, l.name AS label, COUNT(DISTINCT f.id) AS n
+FROM f JOIN library_books lb3 ON lb3.book_id = f.id AND lb3.deleted_at IS NULL
+       JOIN libraries l ON l.id = lb3.library_id
+WHERE lb3.library_id = ANY($1) AND %s
+GROUP BY l.id, l.name
 UNION ALL
-SELECT 'media_type', mt.name, mt.display_name, count(*)
-FROM joined j JOIN media_types mt ON mt.id = j.media_type_id GROUP BY 2, 3
+SELECT 'read_status', f.read_status, f.read_status, COUNT(*)
+FROM f WHERE %s GROUP BY f.read_status
 UNION ALL
-SELECT 'genre', g.name, g.name, count(*)
-FROM joined j JOIN book_genres bg ON bg.book_id = j.id JOIN genres g ON g.id = bg.genre_id
-GROUP BY 2, 3
+SELECT 'media_type', mt.name, mt.display_name, COUNT(*)
+FROM f JOIN media_types mt ON mt.id = f.media_type_id
+WHERE %s GROUP BY mt.name, mt.display_name
 UNION ALL
-SELECT 'tag', t.name, t.name, count(*)
-FROM joined j JOIN book_tags bt ON bt.book_id = j.id AND bt.deleted_at IS NULL
-              JOIN tags t ON t.id = bt.tag_id AND t.deleted_at IS NULL
-GROUP BY 2, 3
+SELECT 'genre', g.name, g.name, COUNT(*)
+FROM f JOIN book_genres bg ON bg.book_id = f.id JOIN genres g ON g.id = bg.genre_id
+WHERE %s GROUP BY g.name
 UNION ALL
-SELECT 'rating', rating::text, rating::text, count(*)
-FROM joined WHERE rating IS NOT NULL GROUP BY 2, 3
-ORDER BY 1, 4 DESC, 2`, f.scopeJoin, f.where, interJoin)
+SELECT 'tag', t.name, t.name, COUNT(*)
+FROM f JOIN book_tags bt ON bt.book_id = f.id AND bt.deleted_at IS NULL
+       JOIN tags t ON t.id = bt.tag_id AND t.deleted_at IS NULL
+WHERE %s GROUP BY t.name
+UNION ALL
+SELECT 'rating', f.rating::text, f.rating::text, COUNT(*)
+FROM f WHERE f.rating IS NOT NULL AND %s GROUP BY f.rating
+ORDER BY 1, 4 DESC, 3`,
+		textWhere, interCTE,
+		mLib, mStatus, mType, mGenre, mTag, mRating,
+		others("lib"), others("status"), others("type"),
+		others("genre"), others("tag"), others("rating"))
 
-	rows, err := r.db.Query(ctx, query, args...)
+	rows, err := r.db.Query(ctx, q, args...)
 	if err != nil {
 		return nil, fmt.Errorf("counting book facets: %w", err)
 	}
 	defer rows.Close()
 
-	out := &BookFacets{
-		ReadStatus: []FacetValue{},
-		MediaType:  []FacetValue{},
-		Genre:      []FacetValue{},
-		Tag:        []FacetValue{},
-		Rating:     []FacetValue{},
-	}
+	out := emptyFacets()
 	for rows.Next() {
 		var dim string
 		var fv FacetValue
@@ -135,6 +222,8 @@ ORDER BY 1, 4 DESC, 2`, f.scopeJoin, f.where, interJoin)
 			return nil, fmt.Errorf("scanning facet row: %w", err)
 		}
 		switch dim {
+		case "library":
+			out.Library = append(out.Library, fv)
 		case "read_status":
 			out.ReadStatus = append(out.ReadStatus, fv)
 		case "media_type":
@@ -147,55 +236,16 @@ ORDER BY 1, 4 DESC, 2`, f.scopeJoin, f.where, interJoin)
 			out.Rating = append(out.Rating, fv)
 		}
 	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("reading facet rows: %w", err)
-	}
-	return out, nil
+	return out, rows.Err()
 }
 
-// LibraryFacet counts the filtered books per library.
-//
-// Kept out of Facets because it only means anything across several libraries:
-// on a per-library route it would return one value whose count equals the
-// total, which is noise rather than a filter.
-func (r *BookRepo) LibraryFacet(ctx context.Context, libraryIDs []uuid.UUID, opts ListBooksOpts) ([]FacetValue, error) {
-	if len(libraryIDs) == 0 {
-		return []FacetValue{}, nil
-	}
-	f := r.buildBookFilter(libraryIDs, opts)
-
-	// COUNT(DISTINCT b.id): a work held by two libraries is one book in each,
-	// not two, and the junction would otherwise multiply it.
-	// Unlike every other facet this one wants a row per (book, library), so it
-	// joins the junction directly instead of the deduping scope join and
-	// reapplies the library predicate itself. COUNT(DISTINCT b.id) still
-	// guards against a book appearing twice within one library.
-	query := fmt.Sprintf(`
-		SELECT l.id::text, l.name, COUNT(DISTINCT b.id)
-		FROM books b
-		JOIN media_types mt ON mt.id = b.media_type_id
-		JOIN library_books lbx ON lbx.book_id = b.id AND lbx.deleted_at IS NULL
-		JOIN libraries l ON l.id = lbx.library_id
-		%s
-		AND lbx.library_id = ANY($1)
-		GROUP BY l.id, l.name
-		ORDER BY 3 DESC, 2`, f.where)
-
-	rows, err := r.db.Query(ctx, query, f.args...)
-	if err != nil {
-		return nil, fmt.Errorf("counting library facet: %w", err)
-	}
-	defer rows.Close()
-
-	out := []FacetValue{}
-	for rows.Next() {
-		var fv FacetValue
-		if err := rows.Scan(&fv.Value, &fv.Label, &fv.Count); err != nil {
-			return nil, fmt.Errorf("scanning library facet: %w", err)
+// insertionSort keeps a six-element slice ordered without reaching for sort.
+func insertionSort(s []string) {
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && s[j] < s[j-1]; j-- {
+			s[j], s[j-1] = s[j-1], s[j]
 		}
-		out = append(out, fv)
 	}
-	return out, rows.Err()
 }
 
 // ListAcross lists books spanning several libraries, deduplicated: a work held

--- a/internal/repository/book_facets.go
+++ b/internal/repository/book_facets.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725 (Adaléa)
+
+package repository
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+// FacetValue is one selectable value in a facet, with the number of books that
+// would match if it were chosen.
+type FacetValue struct {
+	Value string `json:"value"`
+	Label string `json:"label"`
+	Count int    `json:"count"`
+}
+
+// BookFacets is the counts block returned alongside a book search, so a client
+// can render a filter rail without a request per value.
+type BookFacets struct {
+	ReadStatus []FacetValue `json:"read_status"`
+	MediaType  []FacetValue `json:"media_type"`
+	Genre      []FacetValue `json:"genre"`
+	Tag        []FacetValue `json:"tag"`
+	Rating     []FacetValue `json:"rating"`
+}
+
+// Facets counts books per facet value over the whole filtered set, not the
+// page. Everything is one round trip: a query per facet would multiply with the
+// number of dimensions and each would have to rebuild the same filter.
+//
+// Read status and rating come from user_book_interactions, which is keyed on
+// book_edition_id rather than book_id. Joining editions directly would count a
+// work with three editions three times, so interactions are collapsed to one
+// row per book first. Measured during the spike: 1,000 extra editions inflated
+// the status counts by exactly 1,000 before this was fixed, and fixing it cost
+// nothing (338ms against 340ms at 100k books).
+//
+// Best status wins, read > reading > did_not_finish > unread, because "have I
+// read this" is a question about the work rather than about one printing.
+func (r *BookRepo) Facets(ctx context.Context, libraryID uuid.UUID, opts ListBooksOpts) (*BookFacets, error) {
+	f := r.buildBookFilter(libraryID, opts)
+
+	args := f.args
+	callerArg := 0
+	if opts.CallerID != uuid.Nil {
+		args = append(args, opts.CallerID)
+		callerArg = f.nextArg
+	}
+
+	// The filtered set of book ids, computed once and reused by every facet.
+	interJoin := "SELECT NULL::uuid AS book_id, NULL::text AS read_status, NULL::int AS rating WHERE false"
+	if callerArg > 0 {
+		interJoin = fmt.Sprintf(`
+			SELECT e.book_id,
+			       CASE min(CASE i.read_status
+			                    WHEN 'read' THEN 1 WHEN 'reading' THEN 2
+			                    WHEN 'did_not_finish' THEN 3 ELSE 4 END)
+			            WHEN 1 THEN 'read' WHEN 2 THEN 'reading'
+			            WHEN 3 THEN 'did_not_finish' ELSE 'unread' END AS read_status,
+			       max(i.rating) AS rating
+			FROM user_book_interactions i
+			JOIN book_editions e ON e.id = i.book_edition_id
+			WHERE i.user_id = $%d AND i.deleted_at IS NULL
+			GROUP BY e.book_id`, callerArg)
+	}
+
+	query := fmt.Sprintf(`
+WITH scope AS (
+    SELECT DISTINCT b.id, b.media_type_id
+    FROM books b
+    JOIN media_types mt ON mt.id = b.media_type_id
+    %s
+    %s
+),
+inter AS (%s),
+joined AS (
+    SELECT s.id, s.media_type_id,
+           COALESCE(x.read_status, 'unread') AS read_status,
+           x.rating
+    FROM scope s
+    LEFT JOIN inter x ON x.book_id = s.id
+)
+SELECT 'read_status' AS dim, read_status AS value, read_status AS label, count(*) AS n
+FROM joined GROUP BY 2, 3
+UNION ALL
+SELECT 'media_type', mt.name, mt.display_name, count(*)
+FROM joined j JOIN media_types mt ON mt.id = j.media_type_id GROUP BY 2, 3
+UNION ALL
+SELECT 'genre', g.name, g.name, count(*)
+FROM joined j JOIN book_genres bg ON bg.book_id = j.id JOIN genres g ON g.id = bg.genre_id
+GROUP BY 2, 3
+UNION ALL
+SELECT 'tag', t.name, t.name, count(*)
+FROM joined j JOIN book_tags bt ON bt.book_id = j.id AND bt.deleted_at IS NULL
+              JOIN tags t ON t.id = bt.tag_id AND t.deleted_at IS NULL
+GROUP BY 2, 3
+UNION ALL
+SELECT 'rating', rating::text, rating::text, count(*)
+FROM joined WHERE rating IS NOT NULL GROUP BY 2, 3
+ORDER BY 1, 4 DESC, 2`, f.scopeJoin, f.where, interJoin)
+
+	rows, err := r.db.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("counting book facets: %w", err)
+	}
+	defer rows.Close()
+
+	out := &BookFacets{
+		ReadStatus: []FacetValue{},
+		MediaType:  []FacetValue{},
+		Genre:      []FacetValue{},
+		Tag:        []FacetValue{},
+		Rating:     []FacetValue{},
+	}
+	for rows.Next() {
+		var dim string
+		var fv FacetValue
+		if err := rows.Scan(&dim, &fv.Value, &fv.Label, &fv.Count); err != nil {
+			return nil, fmt.Errorf("scanning facet row: %w", err)
+		}
+		switch dim {
+		case "read_status":
+			out.ReadStatus = append(out.ReadStatus, fv)
+		case "media_type":
+			out.MediaType = append(out.MediaType, fv)
+		case "genre":
+			out.Genre = append(out.Genre, fv)
+		case "tag":
+			out.Tag = append(out.Tag, fv)
+		case "rating":
+			out.Rating = append(out.Rating, fv)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("reading facet rows: %w", err)
+	}
+	return out, nil
+}

--- a/internal/repository/book_grouping.go
+++ b/internal/repository/book_grouping.go
@@ -1,0 +1,309 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725
+//
+// Books with each series collapsed into one entry.
+//
+// Browsing a shelf by title means scrolling past thirty-four volumes of one
+// series to reach the next thing. Grouped, a run and a standalone book are
+// peers: one entry each.
+//
+// Four decisions are baked into the SQL here, because each one has a defensible
+// alternative and the wrong choice is invisible until someone notices a number
+// that does not add up:
+//
+//  1. A group appears when ANY of its books match the filter, and the count it
+//     reports is how many MATCHED, not how big the series is. Filtering to
+//     "reading" and seeing "Berserk 34" when one volume is in progress would
+//     describe the shelf rather than the filter. Both numbers are returned so
+//     the client can say "1 of 34".
+//  2. Paging is over entries, not books. A page of 50 entries is not 50 books,
+//     so the book total is returned alongside and the client has to show both.
+//     The facet rail still counts books, and a rail disagreeing with the list
+//     beside it is the failure this is written to avoid.
+//  3. A book in two series is counted once, under the series whose name sorts
+//     first. Showing it twice would make the entry counts stop summing to the
+//     book total.
+//  4. Sorting is by the entry's label. A group has no author and no publish
+//     date, so the other sort columns have nothing to sort a group by.
+//
+// The filter itself is buildBookFilter, unchanged and shared with the ungrouped
+// list and the facet counts. Reimplementing it here is how the three drift.
+
+package repository
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/fireball1725/librarium-api/internal/models"
+)
+
+// SeriesGroup is a run of books shown as one entry.
+type SeriesGroup struct {
+	ID   uuid.UUID
+	Name string
+	// Matched is how many books in this series match the current filter.
+	Matched int
+	// Owned is how many the caller's libraries hold in total, filter ignored,
+	// so the client can say "3 of 34" rather than just "3".
+	Owned int
+	// Read is how many of the owned books the caller has finished.
+	Read int
+	// TotalCount is the series' own published length where it is known, which
+	// is what "missing volumes" is measured against.
+	TotalCount *int
+	// CoverBookID is the volume whose cover represents the run: the lowest
+	// position that actually has one.
+	CoverBookID    *uuid.UUID
+	CoverUpdatedAt *time.Time
+}
+
+// GroupedEntry is either a series or a single book. Exactly one is non-nil.
+type GroupedEntry struct {
+	Series *SeriesGroup
+	Book   *models.Book
+}
+
+// seriesKeyExpr picks the one series a book is grouped under.
+//
+// Deterministic on name then id so the same book lands in the same group on
+// every query. A book in no series gets NULL and stays a standalone entry.
+const seriesKeyExpr = `(
+	SELECT bs.series_id
+	FROM book_series bs
+	JOIN series s_k ON s_k.id = bs.series_id
+	WHERE bs.book_id = b.id
+	ORDER BY lower(s_k.name), s_k.id
+	LIMIT 1
+)`
+
+// ListGroupedBySeries returns one page of entries plus the entry total and the
+// book total the entries were collapsed from.
+func (r *BookRepo) ListGroupedBySeries(
+	ctx context.Context, libraryIDs []uuid.UUID, opts ListBooksOpts,
+) (entries []GroupedEntry, entryTotal, bookTotal int, err error) {
+	if len(libraryIDs) == 0 {
+		return nil, 0, 0, nil
+	}
+	if opts.PerPage <= 0 || opts.PerPage > 200 {
+		opts.PerPage = 25
+	}
+	if opts.Page <= 0 {
+		opts.Page = 1
+	}
+	offset := (opts.Page - 1) * opts.PerPage
+
+	f := r.buildBookFilter(libraryIDs, opts)
+	args := append([]any{}, f.args...)
+	argIdx := f.nextArg
+
+	// The filtered set, each book tagged with the series it groups under.
+	matched := `
+	matched AS (
+		SELECT b.id AS book_id, ` + seriesKeyExpr + ` AS series_id
+		FROM books b
+		JOIN media_types mt ON mt.id = b.media_type_id
+		` + f.scopeJoin + f.where + `
+	)`
+
+	// One row per entry: a series, or a book that is in none.
+	entriesCTE := `
+	entries AS (
+		SELECT 'series' AS kind, m.series_id AS id, s.name AS label, count(*)::int AS matched
+		FROM matched m
+		JOIN series s ON s.id = m.series_id
+		WHERE m.series_id IS NOT NULL
+		GROUP BY m.series_id, s.name
+		UNION ALL
+		SELECT 'book', m.book_id, b.title, 1
+		FROM matched m
+		JOIN books b ON b.id = m.book_id
+		WHERE m.series_id IS NULL
+	)`
+
+	sortDir := "ASC"
+	if opts.SortDir == "desc" {
+		sortDir = "DESC"
+	}
+
+	countQ := "WITH " + matched + ", " + entriesCTE + `
+	SELECT (SELECT count(*) FROM entries), (SELECT count(*) FROM matched)`
+	if err := r.db.QueryRow(ctx, countQ, args...).Scan(&entryTotal, &bookTotal); err != nil {
+		return nil, 0, 0, fmt.Errorf("counting grouped entries: %w", err)
+	}
+
+	args = append(args, opts.PerPage, offset)
+	pageQ := "WITH " + matched + ", " + entriesCTE + fmt.Sprintf(`
+	SELECT kind, id, matched FROM entries
+	ORDER BY natural_sort_key(label) %s, label %s
+	LIMIT $%d OFFSET $%d`, sortDir, sortDir, argIdx, argIdx+1)
+
+	rows, err := r.db.Query(ctx, pageQ, args...)
+	if err != nil {
+		return nil, 0, 0, fmt.Errorf("listing grouped entries: %w", err)
+	}
+
+	type ref struct {
+		kind    string
+		id      uuid.UUID
+		matched int
+	}
+	var refs []ref
+	var seriesIDs, bookIDs []uuid.UUID
+	for rows.Next() {
+		var x ref
+		if err := rows.Scan(&x.kind, &x.id, &x.matched); err != nil {
+			rows.Close()
+			return nil, 0, 0, err
+		}
+		refs = append(refs, x)
+		if x.kind == "series" {
+			seriesIDs = append(seriesIDs, x.id)
+		} else {
+			bookIDs = append(bookIDs, x.id)
+		}
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, 0, 0, err
+	}
+
+	groups, err := r.seriesGroups(ctx, libraryIDs, opts.CallerID, seriesIDs)
+	if err != nil {
+		return nil, 0, 0, err
+	}
+	books, err := r.booksByID(ctx, libraryIDs, opts.CallerID, bookIDs)
+	if err != nil {
+		return nil, 0, 0, err
+	}
+
+	// Rebuilt in the page's order. The hydration queries return their own
+	// order, and using it would re-sort the page the database already sorted.
+	for _, x := range refs {
+		if x.kind == "series" {
+			g, ok := groups[x.id]
+			if !ok {
+				continue
+			}
+			g.Matched = x.matched
+			entries = append(entries, GroupedEntry{Series: g})
+			continue
+		}
+		if b, ok := books[x.id]; ok {
+			entries = append(entries, GroupedEntry{Book: b})
+		}
+	}
+	return entries, entryTotal, bookTotal, nil
+}
+
+// seriesGroups loads the per-series numbers the entry row shows.
+//
+// Owned and Read ignore the filter on purpose: they describe the run, so that
+// a filtered view can say "3 of 34" instead of leaving the reader to guess how
+// much of the series they are not looking at.
+func (r *BookRepo) seriesGroups(
+	ctx context.Context, libraryIDs []uuid.UUID, callerID uuid.UUID, ids []uuid.UUID,
+) (map[uuid.UUID]*SeriesGroup, error) {
+	out := make(map[uuid.UUID]*SeriesGroup, len(ids))
+	if len(ids) == 0 {
+		return out, nil
+	}
+
+	readExpr := "0"
+	args := []any{ids, libraryIDs}
+	if callerID != uuid.Nil {
+		args = append(args, callerID)
+		readExpr = `(
+			SELECT count(DISTINCT bs_r.book_id)::int
+			FROM book_series bs_r
+			JOIN library_books lb_r ON lb_r.book_id = bs_r.book_id
+				AND lb_r.library_id = ANY($2) AND lb_r.deleted_at IS NULL
+			JOIN book_editions be_r ON be_r.book_id = bs_r.book_id
+			JOIN user_book_interactions ubi_r ON ubi_r.book_edition_id = be_r.id
+				AND ubi_r.user_id = $3 AND ubi_r.read_status = 'read'
+			WHERE bs_r.series_id = s.id
+		)`
+	}
+
+	q := `
+	SELECT s.id, s.name, s.total_count,
+		(
+			SELECT count(DISTINCT bs_o.book_id)::int
+			FROM book_series bs_o
+			JOIN library_books lb_o ON lb_o.book_id = bs_o.book_id
+				AND lb_o.library_id = ANY($2) AND lb_o.deleted_at IS NULL
+			WHERE bs_o.series_id = s.id
+		) AS owned,
+		` + readExpr + ` AS read_count,
+		(
+			SELECT bs_c.book_id
+			FROM book_series bs_c
+			JOIN library_books lb_c ON lb_c.book_id = bs_c.book_id
+				AND lb_c.library_id = ANY($2) AND lb_c.deleted_at IS NULL
+			WHERE bs_c.series_id = s.id
+			  AND EXISTS (
+				SELECT 1 FROM cover_images ci
+				WHERE ci.entity_type = 'book' AND ci.entity_id = bs_c.book_id
+				  AND ci.is_primary = true
+			  )
+			ORDER BY bs_c.position NULLS LAST
+			LIMIT 1
+		) AS cover_book_id
+	FROM series s
+	WHERE s.id = ANY($1)`
+
+	rows, err := r.db.Query(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("loading series groups: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var g SeriesGroup
+		var total *int
+		var coverID *uuid.UUID
+		if err := rows.Scan(&g.ID, &g.Name, &total, &g.Owned, &g.Read, &coverID); err != nil {
+			return nil, err
+		}
+		g.TotalCount = total
+		g.CoverBookID = coverID
+		out[g.ID] = &g
+	}
+	return out, rows.Err()
+}
+
+// booksByID hydrates the standalone entries through the same select the
+// ungrouped list uses, so a book looks identical either way.
+func (r *BookRepo) booksByID(
+	ctx context.Context, libraryIDs []uuid.UUID, callerID uuid.UUID, ids []uuid.UUID,
+) (map[uuid.UUID]*models.Book, error) {
+	out := make(map[uuid.UUID]*models.Book, len(ids))
+	if len(ids) == 0 {
+		return out, nil
+	}
+
+	args := []any{libraryIDs, ids}
+	sel := booksSelect(0, 1, true)
+	if callerID != uuid.Nil {
+		args = append(args, callerID)
+		sel = booksSelect(3, 1, true)
+	}
+
+	rows, err := r.db.Query(ctx, sel+" WHERE b.id = ANY($2)", args...)
+	if err != nil {
+		return nil, fmt.Errorf("loading grouped books: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		b, err := scanBook(rows)
+		if err != nil {
+			return nil, err
+		}
+		out[b.ID] = b
+	}
+	return out, rows.Err()
+}

--- a/internal/repository/book_ownership.go
+++ b/internal/repository/book_ownership.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725 (Adaléa)
+
+package repository
+
+import "fmt"
+
+// Ownership: where a book stands in relation to the caller.
+//
+// Until now the book surface meant "books in libraries you can read", which is
+// a join. That cannot express a book you do not own, and every interesting
+// ownership state is exactly that: a book you were suggested, one you put on a
+// wishlist, or a volume missing from a series you hold part of.
+//
+// So the scope becomes a union rather than a join. Each arm contributes book
+// ids from a different source, and each source carries its own permission:
+// library membership for the shelf, the caller's own rows for wishlist and
+// suggestions, library membership again for the series a gap belongs to. A
+// book nobody can justify seeing appears in no arm and is therefore invisible,
+// which is the same guarantee the join gave.
+
+// OwnershipShelf and friends are the values the client filters on.
+const (
+	OwnershipShelf     = "shelf"
+	OwnershipWishlist  = "wishlist"
+	OwnershipSuggested = "suggested"
+	OwnershipGap       = "gap"
+)
+
+// OwnershipValues is the display order of the facet, which is also the order
+// the reader reads: what you have, then what you want, then what was proposed,
+// then what is missing.
+var OwnershipValues = []string{
+	OwnershipShelf, OwnershipWishlist, OwnershipSuggested, OwnershipGap,
+}
+
+// ownershipRank decides which state wins when a book qualifies for several.
+//
+// The states have to be mutually exclusive or the facet counts stop summing to
+// the total, and a reader who ticks every box would see some books twice. The
+// order is not arbitrary: owning a book beats every hypothetical about it, and
+// putting something on a wishlist is the reader's own act, so it outranks a
+// machine's suggestion. A gap is what is left when nothing else applies.
+const ownershipRank = `CASE o.ownership
+        WHEN '` + OwnershipShelf + `' THEN 1
+        WHEN '` + OwnershipWishlist + `' THEN 2
+        WHEN '` + OwnershipSuggested + `' THEN 3
+        ELSE 4 END`
+
+// bookScopeCTE builds the scope: one row per book, carrying the single
+// ownership state that won.
+//
+// libraryArg holds the caller's readable library ids; callerArg holds the user
+// id, or 0 when there is no caller, in which case the two personal arms are
+// omitted rather than bound to nothing.
+func bookScopeCTE(libraryArg, callerArg int) string {
+	personal := ""
+	if callerArg > 0 {
+		personal = fmt.Sprintf(`
+        UNION ALL
+        SELECT w.book_id, '%s' FROM wishlist_items w
+        WHERE w.user_id = $%d AND w.book_id IS NOT NULL
+        UNION ALL
+        SELECT s.book_id, '%s' FROM ai_suggestions s
+        WHERE s.user_id = $%d AND s.status = 'new'`,
+			OwnershipWishlist, callerArg, OwnershipSuggested, callerArg)
+	}
+
+	return fmt.Sprintf(`
+    SELECT DISTINCT ON (o.book_id) o.book_id, o.ownership
+    FROM (
+        SELECT lb.book_id, '%s' AS ownership FROM library_books lb
+        WHERE lb.library_id = ANY($%d) AND lb.deleted_at IS NULL%s
+        UNION ALL
+        -- A gap is a book already recorded against a series in one of your
+        -- libraries that no library holds. Series membership is what makes it
+        -- yours to see; without that arm a volume you have never heard of
+        -- would surface just because someone else lacks it too.
+        SELECT bs.book_id, '%s' FROM book_series bs
+        JOIN series se ON se.id = bs.series_id
+        WHERE se.library_id = ANY($%d)
+    ) o
+    ORDER BY o.book_id, %s`,
+		OwnershipShelf, libraryArg, personal, OwnershipGap, libraryArg, ownershipRank)
+}

--- a/internal/repository/books.go
+++ b/internal/repository/books.go
@@ -454,7 +454,27 @@ type ListBooksOpts struct {
 	IsRegex    bool             // if true, use b.title ~* $query instead of ILIKE
 	Groups     []ConditionGroup // from query language parser; groups are ANDed together
 	CallerID   uuid.UUID        // when non-zero, includes user_read_status for this user
+
+	// Selection is the faceted filter behind the Books rail. It is structured
+	// rather than folded into Groups because the query language has no field for
+	// read status, rating, or library, and because Facets has to count each
+	// dimension with its own selection removed, which is impossible once the
+	// conditions have been flattened into one WHERE string.
+	Selection FacetSelection
 }
+
+// bestReadStatusExpr collapses a user's per-edition statuses to one per work:
+// read beats reading beats did_not_finish beats unread. It aggregates, so it
+// belongs under a GROUP BY or in a scalar subquery.
+//
+// Declared once because the list filter and the facet counts both need it, and
+// any disagreement between them surfaces as a facet count that does not match
+// the rows sitting next to it.
+const bestReadStatusExpr = `CASE min(CASE i.read_status
+            WHEN 'read' THEN 1 WHEN 'reading' THEN 2
+            WHEN 'did_not_finish' THEN 3 ELSE 4 END)
+        WHEN 1 THEN 'read' WHEN 2 THEN 'reading'
+        WHEN 3 THEN 'did_not_finish' ELSE 'unread' END`
 
 // bookFilter is the WHERE clause for a book query, plus the args it binds.
 // List and Facets must build this identically: a facet count that disagrees
@@ -707,6 +727,75 @@ func (r *BookRepo) buildBookFilter(libraryIDs []uuid.UUID, opts ListBooksOpts) b
 				joined = "(" + joined + ")"
 			}
 			conditions = append(conditions, joined)
+		}
+	}
+
+	// Faceted selection. Values within a dimension are OR (ANY), dimensions are
+	// AND, which is what the rail's checkboxes mean: ticking two genres widens,
+	// ticking a genre and a tag narrows.
+	//
+	// sel.Libraries is deliberately absent: the library facet narrows libraryIDs
+	// at the caller instead, so it already lives in the scope join. Filtering on
+	// it here as well would apply the same restriction twice.
+	sel := opts.Selection
+
+	if len(sel.MediaTypes) > 0 {
+		conditions = append(conditions, fmt.Sprintf("mt.name = ANY($%d)", argIdx))
+		args = append(args, sel.MediaTypes)
+		argIdx++
+	}
+
+	if len(sel.Genres) > 0 {
+		conditions = append(conditions, fmt.Sprintf(`EXISTS (
+            SELECT 1 FROM book_genres bg2 JOIN genres g2 ON g2.id = bg2.genre_id
+            WHERE bg2.book_id = b.id AND g2.name = ANY($%d)
+        )`, argIdx))
+		args = append(args, sel.Genres)
+		argIdx++
+	}
+
+	if len(sel.Tags) > 0 {
+		conditions = append(conditions, fmt.Sprintf(`EXISTS (
+            SELECT 1 FROM book_tags bt3 JOIN tags t3 ON t3.id = bt3.tag_id
+            WHERE bt3.book_id = b.id AND bt3.deleted_at IS NULL AND t3.name = ANY($%d)
+        )`, argIdx))
+		args = append(args, sel.Tags)
+		argIdx++
+	}
+
+	// Read status and rating live on user_book_interactions, which is keyed on
+	// book_edition_id. A correlated scalar subquery per book, rather than a
+	// join: joining editions directly would multiply a work with three editions
+	// into three rows and inflate the count.
+	if len(sel.ReadStatus) > 0 {
+		if opts.CallerID == uuid.Nil {
+			// No caller means no interactions, so every book reads as unread.
+			// Say that in SQL rather than silently dropping the filter.
+			conditions = append(conditions, fmt.Sprintf("'unread' = ANY($%d)", argIdx))
+			args = append(args, sel.ReadStatus)
+			argIdx++
+		} else {
+			conditions = append(conditions, fmt.Sprintf(`COALESCE((
+            SELECT %s
+            FROM user_book_interactions i JOIN book_editions e ON e.id = i.book_edition_id
+            WHERE i.user_id = $%d AND i.deleted_at IS NULL AND e.book_id = b.id
+        ), 'unread') = ANY($%d)`, bestReadStatusExpr, argIdx, argIdx+1))
+			args = append(args, opts.CallerID, sel.ReadStatus)
+			argIdx += 2
+		}
+	}
+
+	if len(sel.Ratings) > 0 {
+		if opts.CallerID == uuid.Nil {
+			conditions = append(conditions, "FALSE") // nobody's ratings to match
+		} else {
+			conditions = append(conditions, fmt.Sprintf(`(
+            SELECT max(i.rating)
+            FROM user_book_interactions i JOIN book_editions e ON e.id = i.book_edition_id
+            WHERE i.user_id = $%d AND i.deleted_at IS NULL AND e.book_id = b.id
+        ) = ANY($%d)`, argIdx, argIdx+1))
+			args = append(args, opts.CallerID, sel.Ratings)
+			argIdx += 2
 		}
 	}
 

--- a/internal/repository/books.go
+++ b/internal/repository/books.go
@@ -799,13 +799,33 @@ func (r *BookRepo) buildBookFilter(libraryIDs []uuid.UUID, opts ListBooksOpts) b
 		}
 	}
 
-	// Library scope routes through the library_books junction.
-	// The scope join deduplicates. Under the book/library junction a work held
-	// by two libraries has two junction rows, so a plain join would list it
-	// twice and inflate every count. Selecting distinct book_ids inside the
-	// join fixes both at once, and it carries the library predicate because the
-	// subquery is the only place library_id is still in scope.
-	scopeJoin := " JOIN (SELECT DISTINCT book_id FROM library_books WHERE library_id = ANY($1) AND deleted_at IS NULL) lb ON lb.book_id = b.id "
+	// Scope is a union over the places a book can be yours to see, one row per
+	// book carrying the ownership state that won. It replaces the plain
+	// library_books join, which could only ever express "on the shelf" and so
+	// made every other ownership state unrepresentable.
+	//
+	// It still deduplicates, which the join needed too: under the m2m junction
+	// a work held by two libraries has two rows, and a plain join would list it
+	// twice and inflate every count.
+	//
+	// The caller argument is passed only when there is one. Go evaluates
+	// arguments eagerly, so building the personal arms unconditionally would
+	// bind a parameter whose placeholder never reaches the SQL.
+	callerArg := 0
+	if opts.CallerID != uuid.Nil {
+		args = append(args, opts.CallerID)
+		callerArg = len(args)
+		argIdx = len(args) + 1
+	}
+	scopeJoin := " JOIN (" + bookScopeCTE(1, callerArg) + ") lb ON lb.book_id = b.id "
+
+	// Ownership filters against the scope's own column rather than re-deriving
+	// it, so the list and the counts cannot disagree about what a book is.
+	if len(sel.Ownership) > 0 {
+		conditions = append(conditions, fmt.Sprintf("lb.ownership = ANY($%d)", argIdx))
+		args = append(args, sel.Ownership)
+		argIdx++
+	}
 
 	where := ""
 	for i, c := range conditions {

--- a/internal/repository/books.go
+++ b/internal/repository/books.go
@@ -68,7 +68,12 @@ func (r *BookRepo) ListMediaTypes(ctx context.Context) ([]*models.MediaType, err
 // When loanLibraryArg > 0, active_loan_count is scoped to that library_id
 // arg (used by ListBooks). When 0, it counts active loans across every
 // library the book belongs to (used by FindByID).
-func booksSelect(userStatusArg, loanLibraryArg int) string {
+// loanLibraryIsSet says whether loanLibraryArg binds a uuid[] rather than a
+// single uuid. The cross-library Books surface scopes by a set; FindByID and
+// ListByContributor still scope by one library. Getting this wrong is a runtime
+// "operator does not exist: uuid = uuid[]", not a compile error, so it is a
+// parameter rather than something inferred.
+func booksSelect(userStatusArg, loanLibraryArg int, loanLibraryIsSet bool) string {
 	// All three caller-scoped subqueries (status / rating / progress) use
 	// the same ORDER BY so they pick the same interaction row, keeping the
 	// returned values internally consistent for users who own multiple
@@ -114,9 +119,17 @@ func booksSelect(userStatusArg, loanLibraryArg int) string {
 
 	var activeLoanExpr string
 	if loanLibraryArg > 0 {
+		// $1 is the library SCOPE and is always an array now, one entry for a
+		// per-library call and the caller's whole set for the cross-library
+		// Books surface. `= ANY` covers both; `=` broke the moment the scope
+		// stopped being a single id.
+		match := "library_id = $%d"
+		if loanLibraryIsSet {
+			match = "library_id = ANY($%d)"
+		}
 		activeLoanExpr = fmt.Sprintf(`(
 		SELECT COUNT(*) FROM loans
-		WHERE book_id = b.id AND library_id = $%d AND returned_at IS NULL
+		WHERE book_id = b.id AND `+match+` AND returned_at IS NULL
 	) AS active_loan_count`, loanLibraryArg)
 	} else {
 		activeLoanExpr = `(
@@ -311,7 +324,7 @@ func (r *BookRepo) FindByID(ctx context.Context, id uuid.UUID, callerID uuid.UUI
 		loanLibraryArg = len(args)
 	}
 
-	q := booksSelect(callerArg, loanLibraryArg) + ` WHERE b.id = $1`
+	q := booksSelect(callerArg, loanLibraryArg, false) + ` WHERE b.id = $1`
 
 	book, err := scanBook(r.db.QueryRow(ctx, q, args...))
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -338,10 +351,10 @@ func (r *BookRepo) ListByContributor(ctx context.Context, libraryID, contributor
 		  )
 		ORDER BY natural_sort_key(b.title)`
 	if callerID != uuid.Nil {
-		q = booksSelect(3, 1) + scope
+		q = booksSelect(3, 1, false) + scope
 		args = []any{libraryID, contributorID, callerID}
 	} else {
-		q = booksSelect(0, 1) + scope
+		q = booksSelect(0, 1, false) + scope
 		args = []any{libraryID, contributorID}
 	}
 
@@ -781,9 +794,9 @@ func (r *BookRepo) listScoped(ctx context.Context, libraryIDs []uuid.UUID, opts 
 		args = append(args, opts.CallerID)
 		userArgIdx := argIdx
 		argIdx++
-		selectQuery = booksSelect(userArgIdx, 1)
+		selectQuery = booksSelect(userArgIdx, 1, true)
 	} else {
-		selectQuery = booksSelect(0, 1)
+		selectQuery = booksSelect(0, 1, true)
 	}
 
 	// List

--- a/internal/repository/books.go
+++ b/internal/repository/books.go
@@ -138,6 +138,49 @@ func booksSelect(userStatusArg, loanLibraryArg int, loanLibraryIsSet bool) strin
 	) AS active_loan_count`
 	}
 
+	// A book's tags, scoped to the libraries in play.
+	//
+	// Tags are a per-library vocabulary (UNIQUE (library_id, name)) but
+	// book_tags is work-level, so an unfiltered subquery returns the tags every
+	// library has put on the book, including libraries the caller cannot read.
+	// Invisible while no book is held by two libraries, and a disclosure the
+	// moment one is. Scoped like the loan count beside it.
+	tagsScope := ""
+	if loanLibraryArg > 0 {
+		match := " AND t.library_id = $%d"
+		if loanLibraryIsSet {
+			match = " AND t.library_id = ANY($%d)"
+		}
+		tagsScope = fmt.Sprintf(match, loanLibraryArg)
+	}
+
+	// Which libraries hold this book.
+	//
+	// The list used to send none, so every row on the cross-library Books
+	// surface arrived with library_id null: book detail linked to a route that
+	// does not exist, and a bulk edit had no library to make the request
+	// through. The per-library grid never noticed because it knew the library
+	// from the URL.
+	//
+	// Constrained to the caller's scope for the same reason the loan count is:
+	// a book the caller reaches through one library must not disclose the name
+	// of another library holding it.
+	librariesExpr := `(
+		SELECT COALESCE(json_agg(json_build_object('id', l.id, 'name', l.name)
+			ORDER BY lower(l.name)), '[]'::json)
+		FROM library_books lb_h
+		JOIN libraries l ON l.id = lb_h.library_id
+		WHERE lb_h.book_id = b.id`
+	if loanLibraryArg > 0 {
+		match := " AND lb_h.library_id = $%d"
+		if loanLibraryIsSet {
+			match = " AND lb_h.library_id = ANY($%d)"
+		}
+		librariesExpr += fmt.Sprintf(match, loanLibraryArg)
+	}
+	librariesExpr += `
+	) AS holding_libraries`
+
 	return `
 	SELECT
 		b.id, b.title, b.subtitle,
@@ -169,7 +212,7 @@ func booksSelect(userStatusArg, loanLibraryArg int, loanLibraryIsSet bool) strin
 			)
 			FROM book_tags bt
 			JOIN tags t ON t.id = bt.tag_id
-			WHERE bt.book_id = b.id
+			WHERE bt.book_id = b.id` + tagsScope + `
 		) AS tags,
 		(
 			SELECT COALESCE(
@@ -232,7 +275,8 @@ func booksSelect(userStatusArg, loanLibraryArg int, loanLibraryIsSet bool) strin
 		` + userReadStatusExpr + `,
 		` + userRatingExpr + `,
 		` + userProgressExpr + `,
-		` + activeLoanExpr + `
+		` + activeLoanExpr + `,
+		` + librariesExpr + `
 	FROM books b
 	JOIN media_types mt ON mt.id = b.media_type_id`
 }
@@ -450,6 +494,8 @@ type ListBooksOpts struct {
 	SortDir    string           // "asc" | "desc"; default "asc"
 	Letter     string           // single char: 'a'-'z' matches LIKE 'letter%'
 	TagFilter  string           // filter to books that have a tag with this exact name (case-insensitive)
+	SeriesIDs  []uuid.UUID      // filter to books in any of these series; how a collapsed series group is opened
+	ShelfIDs   []uuid.UUID      // filter to books on any of these shelves
 	TypeFilter string           // filter by media type display name (case-insensitive), e.g. "Novel"
 	IsRegex    bool             // if true, use b.title ~* $query instead of ILIKE
 	Groups     []ConditionGroup // from query language parser; groups are ANDed together
@@ -526,6 +572,30 @@ func (r *BookRepo) buildBookFilter(libraryIDs []uuid.UUID, opts ListBooksOpts) b
 	}
 
 	// Tag filter
+	// Opening a series group from the grouped list. In buildBookFilter rather
+	// than bolted onto the list query, so the facet counts narrow with it: drill
+	// into a 34-volume run and the rail describes those 34 books.
+	if len(opts.SeriesIDs) > 0 {
+		conditions = append(conditions, fmt.Sprintf(`EXISTS (
+            SELECT 1 FROM book_series bs2
+            WHERE bs2.book_id = b.id AND bs2.series_id = ANY($%d)
+        )`, argIdx))
+		args = append(args, opts.SeriesIDs)
+		argIdx++
+	}
+
+	// A shelf is a hand-picked set rather than a property of the book, but it
+	// narrows the list the same way a tag does, so it lives with the rest of
+	// the conditions and the facet counts pick it up for free.
+	if len(opts.ShelfIDs) > 0 {
+		conditions = append(conditions, fmt.Sprintf(`EXISTS (
+            SELECT 1 FROM book_shelves bsh
+            WHERE bsh.book_id = b.id AND bsh.shelf_id = ANY($%d)
+        )`, argIdx))
+		args = append(args, opts.ShelfIDs)
+		argIdx++
+	}
+
 	if opts.TagFilter != "" {
 		conditions = append(conditions, fmt.Sprintf(`EXISTS (
             SELECT 1 FROM book_tags bt2
@@ -1048,6 +1118,7 @@ func scanBook(s scanner) (*models.Book, error) {
 		userRating     int
 		userProgress   pgtype.Numeric
 		activeLoans    int
+		librariesJSON  []byte
 		b              models.Book
 	)
 
@@ -1058,6 +1129,7 @@ func scanBook(s scanner) (*models.Book, error) {
 		&contribJSON, &tagsJSON, &genresJSON, &b.HasCover,
 		&seriesJSON, &shelvesJSON, &publisher, &publishYear, &language,
 		&userReadStatus, &userRating, &userProgress, &activeLoans,
+		&librariesJSON,
 	)
 	if err != nil {
 		return nil, err
@@ -1114,6 +1186,15 @@ func scanBook(s scanner) (*models.Book, error) {
 	if len(shelvesJSON) > 0 {
 		if err := json.Unmarshal(shelvesJSON, &b.Shelves); err != nil {
 			return nil, fmt.Errorf("unmarshaling shelves: %w", err)
+		}
+	}
+
+	// Empty rather than nil: a floating book genuinely holds no library, and a
+	// nil slice marshals to null, which the React client does not survive.
+	b.Libraries = []models.BookLibraryRef{}
+	if len(librariesJSON) > 0 {
+		if err := json.Unmarshal(librariesJSON, &b.Libraries); err != nil {
+			return nil, fmt.Errorf("unmarshaling libraries: %w", err)
 		}
 	}
 

--- a/internal/repository/books.go
+++ b/internal/repository/books.go
@@ -443,43 +443,20 @@ type ListBooksOpts struct {
 	CallerID   uuid.UUID        // when non-zero, includes user_read_status for this user
 }
 
-func (r *BookRepo) List(ctx context.Context, libraryID uuid.UUID, opts ListBooksOpts) ([]*models.Book, int, error) {
-	if opts.PerPage <= 0 || opts.PerPage > 200 {
-		opts.PerPage = 25
-	}
-	if opts.Page <= 0 {
-		opts.Page = 1
-	}
-	offset := (opts.Page - 1) * opts.PerPage
+// bookFilter is the WHERE clause for a book query, plus the args it binds.
+// List and Facets must build this identically: a facet count that disagrees
+// with the list beside it is worse than no count at all.
+type bookFilter struct {
+	where     string
+	scopeJoin string
+	args      []any
+	nextArg   int // next free positional parameter, for callers appending their own
+}
 
-	// Validate sort — title sort uses natural_sort_key() which strips leading articles,
-	// lowercases, and pads digit sequences so #2 sorts before #10.
-	sortCol := "natural_sort_key(b.title)"
-	switch opts.Sort {
-	case "created_at":
-		sortCol = "b.created_at"
-	case "media_type":
-		sortCol = "lower(mt.display_name)"
-	case "publish_date":
-		sortCol = "(SELECT be.publish_date FROM book_editions be WHERE be.book_id = b.id AND be.is_primary = true AND be.publish_date IS NOT NULL LIMIT 1)"
-	case "author":
-		// Sort by the first contributor's lowercased name (display
-		// order ascending so the "primary" credit wins). Books with
-		// no contributors fall to the end via NULLS LAST below.
-		sortCol = `(
-			SELECT lower(c.name)
-			FROM book_contributors bc
-			JOIN contributors c ON c.id = bc.contributor_id
-			WHERE bc.book_id = b.id
-			ORDER BY bc.display_order, c.name
-			LIMIT 1
-		)`
-	}
-	sortDir := "ASC"
-	if opts.SortDir == "desc" {
-		sortDir = "DESC"
-	}
-
+// buildBookFilter assembles the library scope and every active filter from
+// opts. Extracted from List so Facets can reuse it verbatim rather than
+// reimplementing the same conditions and drifting.
+func (r *BookRepo) buildBookFilter(libraryID uuid.UUID, opts ListBooksOpts) bookFilter {
 	args := []any{libraryID} // $1
 	argIdx := 2
 
@@ -723,6 +700,49 @@ func (r *BookRepo) List(ctx context.Context, libraryID uuid.UUID, opts ListBooks
 		where += " AND " + c
 	}
 	scopeJoin := " JOIN library_books lb ON lb.book_id = b.id "
+
+	return bookFilter{where: where, scopeJoin: scopeJoin, args: args, nextArg: argIdx}
+}
+
+func (r *BookRepo) List(ctx context.Context, libraryID uuid.UUID, opts ListBooksOpts) ([]*models.Book, int, error) {
+	if opts.PerPage <= 0 || opts.PerPage > 200 {
+		opts.PerPage = 25
+	}
+	if opts.Page <= 0 {
+		opts.Page = 1
+	}
+	offset := (opts.Page - 1) * opts.PerPage
+
+	// Validate sort — title sort uses natural_sort_key() which strips leading articles,
+	// lowercases, and pads digit sequences so #2 sorts before #10.
+	sortCol := "natural_sort_key(b.title)"
+	switch opts.Sort {
+	case "created_at":
+		sortCol = "b.created_at"
+	case "media_type":
+		sortCol = "lower(mt.display_name)"
+	case "publish_date":
+		sortCol = "(SELECT be.publish_date FROM book_editions be WHERE be.book_id = b.id AND be.is_primary = true AND be.publish_date IS NOT NULL LIMIT 1)"
+	case "author":
+		// Sort by the first contributor's lowercased name (display
+		// order ascending so the "primary" credit wins). Books with
+		// no contributors fall to the end via NULLS LAST below.
+		sortCol = `(
+			SELECT lower(c.name)
+			FROM book_contributors bc
+			JOIN contributors c ON c.id = bc.contributor_id
+			WHERE bc.book_id = b.id
+			ORDER BY bc.display_order, c.name
+			LIMIT 1
+		)`
+	}
+	sortDir := "ASC"
+	if opts.SortDir == "desc" {
+		sortDir = "DESC"
+	}
+
+	f := r.buildBookFilter(libraryID, opts)
+	where, scopeJoin, args, argIdx := f.where, f.scopeJoin, f.args, f.nextArg
 
 	// Count
 	var total int

--- a/internal/repository/books.go
+++ b/internal/repository/books.go
@@ -456,8 +456,11 @@ type bookFilter struct {
 // buildBookFilter assembles the library scope and every active filter from
 // opts. Extracted from List so Facets can reuse it verbatim rather than
 // reimplementing the same conditions and drifting.
-func (r *BookRepo) buildBookFilter(libraryID uuid.UUID, opts ListBooksOpts) bookFilter {
-	args := []any{libraryID} // $1
+// libraryIDs is the scope: one entry for a per-library route, the caller's
+// whole membership set for the cross-library Books surface. Passing a set
+// rather than a single id keeps both on one filter implementation.
+func (r *BookRepo) buildBookFilter(libraryIDs []uuid.UUID, opts ListBooksOpts) bookFilter {
+	args := []any{libraryIDs} // $1
 	argIdx := 2
 
 	// Build WHERE conditions
@@ -695,16 +698,37 @@ func (r *BookRepo) buildBookFilter(libraryID uuid.UUID, opts ListBooksOpts) book
 	}
 
 	// Library scope routes through the library_books junction.
-	where := "WHERE lb.library_id = $1"
-	for _, c := range conditions {
-		where += " AND " + c
+	// The scope join deduplicates. Under the book/library junction a work held
+	// by two libraries has two junction rows, so a plain join would list it
+	// twice and inflate every count. Selecting distinct book_ids inside the
+	// join fixes both at once, and it carries the library predicate because the
+	// subquery is the only place library_id is still in scope.
+	scopeJoin := " JOIN (SELECT DISTINCT book_id FROM library_books WHERE library_id = ANY($1) AND deleted_at IS NULL) lb ON lb.book_id = b.id "
+
+	where := ""
+	for i, c := range conditions {
+		if i == 0 {
+			where = "WHERE " + c
+		} else {
+			where += " AND " + c
+		}
 	}
-	scopeJoin := " JOIN library_books lb ON lb.book_id = b.id "
+
+	// A join with no WHERE still needs valid SQL downstream.
+	if where == "" {
+		where = "WHERE TRUE"
+	}
 
 	return bookFilter{where: where, scopeJoin: scopeJoin, args: args, nextArg: argIdx}
 }
 
+// List is the per-library entry point. Both it and ListAcross delegate to
+// listScoped so the filter, sort, paging and scan logic exist once.
 func (r *BookRepo) List(ctx context.Context, libraryID uuid.UUID, opts ListBooksOpts) ([]*models.Book, int, error) {
+	return r.listScoped(ctx, []uuid.UUID{libraryID}, opts)
+}
+
+func (r *BookRepo) listScoped(ctx context.Context, libraryIDs []uuid.UUID, opts ListBooksOpts) ([]*models.Book, int, error) {
 	if opts.PerPage <= 0 || opts.PerPage > 200 {
 		opts.PerPage = 25
 	}
@@ -741,7 +765,7 @@ func (r *BookRepo) List(ctx context.Context, libraryID uuid.UUID, opts ListBooks
 		sortDir = "DESC"
 	}
 
-	f := r.buildBookFilter(libraryID, opts)
+	f := r.buildBookFilter(libraryIDs, opts)
 	where, scopeJoin, args, argIdx := f.where, f.scopeJoin, f.args, f.nextArg
 
 	// Count

--- a/internal/repository/contributor_index.go
+++ b/internal/repository/contributor_index.go
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725 (Adaléa)
+
+package repository
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"golang.org/x/text/unicode/norm"
+
+	"github.com/google/uuid"
+)
+
+// The Authors index: every contributor with books in the caller's libraries,
+// with the counts and thumbnails the index cards need.
+//
+// A projection rather than models.Contributor, which is the domain entity and
+// is already returned by six other paths. The index wants read counts, spine
+// thumbnails and library membership that nothing else needs, and widening the
+// shared struct for one screen makes every other caller pay to scan columns it
+// throws away.
+
+// AuthorSpine is one book thumbnail on an author card. Same shape as
+// SeriesPreviewBook, and converted to a wire body the same way, so a thumbnail
+// URL is built in one place rather than assembled by each client.
+type AuthorSpine struct {
+	BookID    uuid.UUID `json:"book_id"`
+	Title     string    `json:"title"`
+	HasCover  bool      `json:"has_cover"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// AuthorLibraryRef names a library the author has books in, so the card can
+// offer it as a jump into a filtered Books view.
+type AuthorLibraryRef struct {
+	ID   uuid.UUID `json:"id"`
+	Name string    `json:"name"`
+}
+
+type AuthorIndexEntry struct {
+	ID       uuid.UUID `json:"id"`
+	Name     string    `json:"name"`
+	SortName string    `json:"sort_name"`
+	HasPhoto bool      `json:"has_photo"`
+	// Letter the index files this author under, taken from sort_name so
+	// "Ursula K. Le Guin" appears under L rather than U. '#' for anything
+	// that does not start with a letter.
+	Letter    string             `json:"letter"`
+	BookCount int                `json:"book_count"`
+	ReadCount int                `json:"read_count"`
+	Spines    []AuthorSpine      `json:"spines"`
+	Libraries []AuthorLibraryRef `json:"libraries"`
+}
+
+// spinesPerCard is how many thumbnails a card shows. Five reads as a shelf
+// without wrapping at the narrowest card width.
+const spinesPerCard = 5
+
+// defaultAuthorRoles is what the Authors index means by "author".
+//
+// book_contributors carries a role, so translators, illustrators and editors
+// share the table. Listing them all under Authors would file a translator as
+// the writer of a book they translated, so the index filters and the caller
+// can widen it.
+var defaultAuthorRoles = []string{"author"}
+
+// ListAuthorIndex returns every contributor holding a matching role on a book
+// in the given libraries.
+//
+// Unpaged on purpose. The index draws an A-Z bar that has to know which letters
+// have anyone behind them, which means counting the whole set anyway; paging it
+// would cost a second query to answer the same question. Author counts run in
+// the hundreds, not the millions.
+func (r *ContributorRepo) ListAuthorIndex(
+	ctx context.Context,
+	libraryIDs []uuid.UUID,
+	callerID uuid.UUID,
+	roles []string,
+) ([]*AuthorIndexEntry, error) {
+	if len(libraryIDs) == 0 {
+		return []*AuthorIndexEntry{}, nil
+	}
+	if len(roles) == 0 {
+		roles = defaultAuthorRoles
+	}
+
+	args := []any{libraryIDs, roles}
+
+	// Read count is caller-relative, so it needs the caller. Without one every
+	// author reads as nothing read, which is correct rather than an error: a
+	// token with no user still gets a usable index.
+	readCount := "0"
+	if callerID != uuid.Nil {
+		args = append(args, callerID)
+		readCount = fmt.Sprintf(`COUNT(DISTINCT s.book_id) FILTER (WHERE EXISTS (
+            SELECT 1 FROM user_book_interactions i
+            JOIN book_editions e ON e.id = i.book_edition_id
+            WHERE e.book_id = s.book_id AND i.user_id = $%d
+              AND i.deleted_at IS NULL AND i.read_status = 'read'
+        ))`, len(args))
+	}
+
+	// The scope CTE is DISTINCT on (contributor, book) so a book credited to
+	// one person twice under two roles counts once. Without it an author with
+	// both "author" and "editor" credits on the same book shows double.
+	q := fmt.Sprintf(`
+WITH scope AS (
+    SELECT DISTINCT bc.contributor_id, b.id AS book_id
+    FROM book_contributors bc
+    JOIN books b ON b.id = bc.book_id
+    JOIN library_books lb ON lb.book_id = b.id AND lb.deleted_at IS NULL
+    WHERE lb.library_id = ANY($1) AND bc.role = ANY($2)
+)
+SELECT c.id,
+       c.name,
+       COALESCE(NULLIF(c.sort_name, ''), c.name) AS sort_name,
+       EXISTS(SELECT 1 FROM cover_images ci
+              WHERE ci.entity_type = 'contributor' AND ci.entity_id = c.id
+                AND ci.is_primary = true) AS has_photo,
+       COUNT(DISTINCT s.book_id)::int AS book_count,
+       %s::int AS read_count,
+       (
+           SELECT COALESCE(json_agg(jsonb_build_object(
+               'book_id', t.id, 'title', t.title,
+               'has_cover', t.has_cover, 'updated_at', t.updated_at
+           ) ORDER BY t.title), '[]'::json)
+           FROM (
+               SELECT DISTINCT b2.id, b2.title, b2.updated_at,
+                      EXISTS(SELECT 1 FROM cover_images ci2
+                             WHERE ci2.entity_type = 'book' AND ci2.entity_id = b2.id
+                               AND ci2.is_primary = true) AS has_cover
+               FROM book_contributors bc2
+               JOIN books b2 ON b2.id = bc2.book_id
+               JOIN library_books lb2 ON lb2.book_id = b2.id AND lb2.deleted_at IS NULL
+               WHERE bc2.contributor_id = c.id AND bc2.role = ANY($2)
+                 AND lb2.library_id = ANY($1)
+               ORDER BY b2.title
+               LIMIT %d
+           ) t
+       ) AS spines,
+       (
+           SELECT COALESCE(json_agg(DISTINCT jsonb_build_object('id', l.id, 'name', l.name)), '[]'::json)
+           FROM library_books lb3
+           JOIN libraries l ON l.id = lb3.library_id
+           JOIN book_contributors bc3 ON bc3.book_id = lb3.book_id
+           WHERE bc3.contributor_id = c.id AND bc3.role = ANY($2)
+             AND lb3.library_id = ANY($1) AND lb3.deleted_at IS NULL
+       ) AS libraries
+FROM contributors c
+JOIN scope s ON s.contributor_id = c.id
+GROUP BY c.id, c.name, c.sort_name
+ORDER BY lower(COALESCE(NULLIF(c.sort_name, ''), c.name)), c.name`, readCount, spinesPerCard)
+
+	rows, err := r.db.Query(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("listing author index: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]*AuthorIndexEntry, 0, 64)
+	for rows.Next() {
+		var (
+			e         = &AuthorIndexEntry{}
+			spineRaw  []byte
+			libraries []byte
+		)
+		if err := rows.Scan(
+			&e.ID, &e.Name, &e.SortName, &e.HasPhoto,
+			&e.BookCount, &e.ReadCount, &spineRaw, &libraries,
+		); err != nil {
+			return nil, fmt.Errorf("scanning author index row: %w", err)
+		}
+		e.Spines = make([]AuthorSpine, 0, spinesPerCard)
+		if len(spineRaw) > 0 {
+			if err := json.Unmarshal(spineRaw, &e.Spines); err != nil {
+				return nil, fmt.Errorf("decoding author spines: %w", err)
+			}
+		}
+		e.Libraries = make([]AuthorLibraryRef, 0, 2)
+		if len(libraries) > 0 {
+			if err := json.Unmarshal(libraries, &e.Libraries); err != nil {
+				return nil, fmt.Errorf("decoding author libraries: %w", err)
+			}
+		}
+		e.Letter = indexLetter(e.SortName)
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}
+
+// indexLetter is the A-Z bucket a name files under. Anything that does not
+// resolve to a letter goes to '#', which is where a reader looks for "1Q84" or
+// a name in a script the bar does not cover.
+//
+// Decoded as a rune rather than a byte, and folded before bucketing: slicing
+// one byte off a name starting with a multibyte character yields half a
+// character, and filing Émile Zola under '#' rather than E is how an index
+// loses the names it was built to find. NFD splits an accented letter into its
+// base plus a combining mark, so the base is simply the first rune out.
+func indexLetter(sortName string) string {
+	for _, r := range strings.TrimSpace(sortName) {
+		for _, base := range norm.NFD.String(string(r)) {
+			switch {
+			case base >= 'a' && base <= 'z':
+				return string(base - 32)
+			case base >= 'A' && base <= 'Z':
+				return string(base)
+			}
+			break
+		}
+		return "#"
+	}
+	return "#"
+}

--- a/internal/repository/contributor_index.go
+++ b/internal/repository/contributor_index.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"golang.org/x/text/unicode/norm"
 
@@ -202,17 +203,20 @@ ORDER BY lower(COALESCE(NULLIF(c.sort_name, ''), c.name)), c.name`, readCount, s
 // loses the names it was built to find. NFD splits an accented letter into its
 // base plus a combining mark, so the base is simply the first rune out.
 func indexLetter(sortName string) string {
-	for _, r := range strings.TrimSpace(sortName) {
-		for _, base := range norm.NFD.String(string(r)) {
-			switch {
-			case base >= 'a' && base <= 'z':
-				return string(base - 32)
-			case base >= 'A' && base <= 'Z':
-				return string(base)
-			}
-			break
-		}
+	trimmed := strings.TrimSpace(sortName)
+	if trimmed == "" {
 		return "#"
+	}
+	// Two "first rune of" steps, written as decodes rather than as range loops
+	// that break on their first iteration: staticcheck reads those as loops
+	// that cannot loop (SA4004), and it is right — nothing here repeats.
+	first, _ := utf8.DecodeRuneInString(trimmed)
+	base, _ := utf8.DecodeRuneInString(norm.NFD.String(string(first)))
+	switch {
+	case base >= 'a' && base <= 'z':
+		return string(base - 32)
+	case base >= 'A' && base <= 'Z':
+		return string(base)
 	}
 	return "#"
 }

--- a/internal/repository/contributor_index_test.go
+++ b/internal/repository/contributor_index_test.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725 (Adaléa)
+
+package repository
+
+import "testing"
+
+func TestIndexLetter(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain surname", "Atwood, Margaret", "A"},
+		{"lowercase sort name", "le Guin, Ursula K.", "L"},
+		{"leading space", "  Miura, Kentaro", "M"},
+		{"digit files under hash", "1Q84", "#"},
+		{"empty", "", "#"},
+		{"whitespace only", "   ", "#"},
+		// An index that files Émile under '#' has lost the name it exists to
+		// find, so accents fold to their base letter rather than falling out.
+		{"accent folds to its base letter", "Émile Zola", "E"},
+		{"nordic letter folds", "Ólafsdóttir, Auður", "O"},
+		{"punctuation first", "'t Hooft", "#"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := indexLetter(c.in); got != c.want {
+				t.Errorf("indexLetter(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/repository/library_permissions.go
+++ b/internal/repository/library_permissions.go
@@ -92,3 +92,42 @@ func (r *LibraryRepo) ListAccessForUser(ctx context.Context, userID uuid.UUID, i
 	}
 	return out, nil
 }
+
+// CollectionCounts is what the navigation shows beside Books, Series and
+// Authors.
+type CollectionCounts struct {
+	Books   int `json:"books"`
+	Series  int `json:"series"`
+	Authors int `json:"authors"`
+}
+
+// CountsForLibraries totals the collection across a set of libraries.
+//
+// One round trip with three scalar subqueries rather than three queries: the
+// navigation needs all three together on every page, and they are cheap counts
+// against indexed columns.
+//
+// Books counts DISTINCT book ids, not junction rows. A work held by two
+// libraries is one book on the shelf, and counting the junction would report a
+// number the Books page then contradicts.
+func (r *LibraryRepo) CountsForLibraries(ctx context.Context, libraryIDs []uuid.UUID) (*CollectionCounts, error) {
+	out := &CollectionCounts{}
+	if len(libraryIDs) == 0 {
+		return out, nil
+	}
+
+	const q = `
+SELECT
+  (SELECT COUNT(DISTINCT lb.book_id) FROM library_books lb
+    WHERE lb.library_id = ANY($1) AND lb.deleted_at IS NULL),
+  (SELECT COUNT(*) FROM series s WHERE s.library_id = ANY($1)),
+  (SELECT COUNT(DISTINCT bc.contributor_id)
+     FROM book_contributors bc
+     JOIN library_books lb2 ON lb2.book_id = bc.book_id AND lb2.deleted_at IS NULL
+    WHERE lb2.library_id = ANY($1) AND bc.role = 'author')`
+
+	if err := r.db.QueryRow(ctx, q, libraryIDs).Scan(&out.Books, &out.Series, &out.Authors); err != nil {
+		return nil, fmt.Errorf("counting collection: %w", err)
+	}
+	return out, nil
+}

--- a/internal/repository/library_permissions.go
+++ b/internal/repository/library_permissions.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725 (Adaléa)
+
+package repository
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+// LibraryAccess is one library the caller can reach, with the permissions they
+// effectively hold in it.
+//
+// Clients need this per library rather than per request because a single list
+// can mix libraries: a user may own one and have been invited to another as a
+// viewer. Gating a whole screen on one role is only correct while the screen
+// shows one library, which stops being true the moment books from several are
+// listed together. Without this a client either fires a permission check per
+// row or guesses, and guessing means rendering controls the API will reject.
+type LibraryAccess struct {
+	LibraryID   uuid.UUID `json:"library_id"`
+	Name        string    `json:"name"`
+	Slug        string    `json:"slug"`
+	Role        string    `json:"role"`
+	Permissions []string  `json:"permissions"`
+	BookCount   int       `json:"book_count"`
+}
+
+// ListAccessForUser returns every library the user can reach and the permission
+// names their role grants there.
+//
+// Instance admins are handled separately: RequireLibraryPermission lets them
+// past the membership check entirely, so reporting only their memberships would
+// under-report what they can actually do and the client would hide controls
+// that would in fact succeed.
+func (r *LibraryRepo) ListAccessForUser(ctx context.Context, userID uuid.UUID, isInstanceAdmin bool) ([]*LibraryAccess, error) {
+	// `lm.deleted_at IS NULL` is defensive. Membership removal is a hard DELETE
+	// today so the column is never set, but if that ever becomes a soft delete
+	// an unfiltered permission query would keep granting access to people who
+	// had been removed.
+	const memberQ = `
+		SELECT l.id, l.name, l.slug, ro.name AS role,
+		       COALESCE(array_agg(DISTINCT p.name) FILTER (WHERE p.name IS NOT NULL), '{}') AS perms,
+		       (SELECT COUNT(*) FROM library_books lb
+		         WHERE lb.library_id = l.id AND lb.deleted_at IS NULL) AS book_count
+		FROM library_memberships lm
+		JOIN libraries l         ON l.id = lm.library_id
+		JOIN roles ro            ON ro.id = lm.role_id
+		LEFT JOIN role_permissions rp ON rp.role_id = lm.role_id
+		LEFT JOIN permissions p       ON p.id = rp.permission_id
+		WHERE lm.user_id = $1 AND lm.deleted_at IS NULL
+		GROUP BY l.id, l.name, l.slug, ro.name
+		ORDER BY l.name`
+
+	// Every library, every permission: what an instance admin can actually do.
+	const adminQ = `
+		SELECT l.id, l.name, l.slug, 'instance_admin' AS role,
+		       (SELECT COALESCE(array_agg(name ORDER BY name), '{}') FROM permissions) AS perms,
+		       (SELECT COUNT(*) FROM library_books lb
+		         WHERE lb.library_id = l.id AND lb.deleted_at IS NULL) AS book_count
+		FROM libraries l
+		ORDER BY l.name`
+
+	q := memberQ
+	args := []any{userID}
+	if isInstanceAdmin {
+		q = adminQ
+		args = nil
+	}
+
+	rows, err := r.db.Query(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("listing library access: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]*LibraryAccess, 0)
+	for rows.Next() {
+		a := &LibraryAccess{}
+		if err := rows.Scan(&a.LibraryID, &a.Name, &a.Slug, &a.Role, &a.Permissions, &a.BookCount); err != nil {
+			return nil, fmt.Errorf("scanning library access: %w", err)
+		}
+		if a.Permissions == nil {
+			a.Permissions = []string{}
+		}
+		out = append(out, a)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("reading library access: %w", err)
+	}
+	return out, nil
+}

--- a/internal/repository/library_permissions.go
+++ b/internal/repository/library_permissions.go
@@ -99,12 +99,18 @@ type CollectionCounts struct {
 	Books   int `json:"books"`
 	Series  int `json:"series"`
 	Authors int `json:"authors"`
+	// Loans is what is still out, not every loan ever recorded. A nav count of
+	// every loan in history would climb forever and never mean anything.
+	Loans int `json:"loans"`
+	// LoansOverdue is the subset worth reacting to, so the rail can say which
+	// of those outstanding loans is late without a second request.
+	LoansOverdue int `json:"loans_overdue"`
 }
 
 // CountsForLibraries totals the collection across a set of libraries.
 //
-// One round trip with three scalar subqueries rather than three queries: the
-// navigation needs all three together on every page, and they are cheap counts
+// One round trip with a scalar subquery each rather than a query apiece: the
+// navigation needs them all together on every page, and they are cheap counts
 // against indexed columns.
 //
 // Books counts DISTINCT book ids, not junction rows. A work held by two
@@ -124,9 +130,16 @@ SELECT
   (SELECT COUNT(DISTINCT bc.contributor_id)
      FROM book_contributors bc
      JOIN library_books lb2 ON lb2.book_id = bc.book_id AND lb2.deleted_at IS NULL
-    WHERE lb2.library_id = ANY($1) AND bc.role = 'author')`
+    WHERE lb2.library_id = ANY($1) AND bc.role = 'author'),
+  (SELECT COUNT(*) FROM loans l
+    WHERE l.library_id = ANY($1) AND l.returned_at IS NULL),
+  (SELECT COUNT(*) FROM loans l
+    WHERE l.library_id = ANY($1) AND l.returned_at IS NULL
+      AND l.due_date IS NOT NULL AND l.due_date < CURRENT_DATE)`
 
-	if err := r.db.QueryRow(ctx, q, libraryIDs).Scan(&out.Books, &out.Series, &out.Authors); err != nil {
+	if err := r.db.QueryRow(ctx, q, libraryIDs).Scan(
+		&out.Books, &out.Series, &out.Authors, &out.Loans, &out.LoansOverdue,
+	); err != nil {
 		return nil, fmt.Errorf("counting collection: %w", err)
 	}
 	return out, nil

--- a/internal/repository/loans.go
+++ b/internal/repository/loans.go
@@ -174,3 +174,79 @@ func scanLoan(s scanner) (*models.Loan, error) {
 	}
 	return &l, nil
 }
+
+// ListAcross returns loans from every library the caller can read.
+//
+// A loan is a book, a person and some dates; the library is where the book
+// happens to live, not what the loan is about. "Who has my stuff" is not a
+// question anyone asks one library at a time, so this is the shape the Loans
+// page actually wants, and the per-library List stays for the routes that are
+// already scoped.
+//
+// Overdue is computed here rather than filtered in the client: a client that
+// only has the current page cannot tell you how many overdue loans exist.
+func (r *LoanRepo) ListAcross(
+	ctx context.Context,
+	libraryIDs []uuid.UUID,
+	includeReturned bool,
+	overdueOnly bool,
+	search string,
+) ([]*models.Loan, error) {
+	if len(libraryIDs) == 0 {
+		return []*models.Loan{}, nil
+	}
+
+	args := []any{libraryIDs, includeReturned}
+	where := `WHERE l.library_id = ANY($1) AND ($2 OR l.returned_at IS NULL)`
+	if search != "" {
+		args = append(args, "%"+search+"%")
+		where += fmt.Sprintf(` AND lower(l.loaned_to || ' ' || b.title) LIKE lower($%d)`, len(args))
+	}
+	if overdueOnly {
+		where += ` AND l.returned_at IS NULL AND l.due_date IS NOT NULL AND l.due_date < CURRENT_DATE`
+	}
+
+	q := `
+	SELECT l.id, l.library_id, l.book_id, b.title, lib.name,
+	       l.loaned_to, l.loaned_at, l.due_date, l.returned_at,
+	       COALESCE(l.notes, ''),
+	       l.created_at, l.updated_at
+	FROM loans l
+	JOIN books b ON b.id = l.book_id
+	JOIN libraries lib ON lib.id = l.library_id
+	` + where + `
+	-- Outstanding first, then the most pressing due date, so the top of the
+	-- list is what needs chasing rather than what happened most recently.
+	ORDER BY (l.returned_at IS NOT NULL),
+	         l.due_date ASC NULLS LAST,
+	         l.loaned_at DESC`
+
+	rows, err := r.db.Query(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("listing loans across libraries: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]*models.Loan, 0)
+	for rows.Next() {
+		var l models.Loan
+		var due, returned pgtype.Date
+		if err := rows.Scan(
+			&l.ID, &l.LibraryID, &l.BookID, &l.BookTitle, &l.LibraryName,
+			&l.LoanedTo, &l.LoanedAt, &due, &returned, &l.Notes,
+			&l.CreatedAt, &l.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		if due.Valid {
+			d := due.Time
+			l.DueDate = &d
+		}
+		if returned.Valid {
+			d := returned.Time
+			l.ReturnedAt = &d
+		}
+		out = append(out, &l)
+	}
+	return out, rows.Err()
+}

--- a/internal/repository/series.go
+++ b/internal/repository/series.go
@@ -73,6 +73,29 @@ func readStateSubqueries(callerArg int) string {
           ) = 'reading') AS reading_count`, callerArg, callerArg)
 }
 
+// seriesBookCountExpr counts the volumes of a series the library actually holds.
+//
+// It used to be a plain COUNT over book_series, which counts every book recorded
+// against the series whatever its ownership: wishlist entries, AI suggestions,
+// and the gap rows that exist precisely to represent volumes nobody has. Those
+// are all real book_series rows, so a series you own half of counted as whole.
+// Every series on the index reported "own N of N" and wore a "complete" badge
+// while the Books page, which filters on ownership, disagreed about the same
+// series in the same session.
+//
+// Holding is a row in library_books, matching the shelf arm of bookScopeCTE. The
+// series' own library is the one asked about: a series record belongs to one
+// library and its counts describe that library's copies, which is why a series
+// held twice is two rows rather than a merged total.
+const seriesBookCountExpr = `COUNT(bs.book_id) FILTER (
+	           WHERE EXISTS (
+	               SELECT 1 FROM library_books lb
+	               WHERE lb.book_id = bs.book_id
+	                 AND lb.library_id = s.library_id
+	                 AND lb.deleted_at IS NULL
+	           )
+	       ) AS book_count`
+
 // ─── Series CRUD ──────────────────────────────────────────────────────────────
 
 // List is the per-library entry point.
@@ -128,7 +151,7 @@ func (r *SeriesRepo) listScoped(ctx context.Context, libraryIDs []uuid.UUID, cal
 		       COALESCE(s.external_id,''), COALESCE(s.external_source,''),
 		       (SELECT MAX(sv.release_date) FROM series_volumes sv WHERE sv.series_id = s.id AND sv.release_date <= CURRENT_DATE) AS last_release_date,
 		       (SELECT MIN(sv.release_date) FROM series_volumes sv WHERE sv.series_id = s.id AND sv.release_date > CURRENT_DATE) AS next_release_date,
-		       COUNT(bs.book_id) AS book_count,
+		       ` + seriesBookCountExpr + `,
 		       (SELECT COUNT(*) FROM series_arcs sa WHERE sa.series_id = s.id) AS arc_count,
 		       ` + readStateSubqueries(callerArg) + `,
 		       (
@@ -187,7 +210,7 @@ func (r *SeriesRepo) FindByID(ctx context.Context, id, callerID uuid.UUID) (*mod
 		       COALESCE(s.external_id,''), COALESCE(s.external_source,''),
 		       (SELECT MAX(sv.release_date) FROM series_volumes sv WHERE sv.series_id = s.id AND sv.release_date <= CURRENT_DATE) AS last_release_date,
 		       (SELECT MIN(sv.release_date) FROM series_volumes sv WHERE sv.series_id = s.id AND sv.release_date > CURRENT_DATE) AS next_release_date,
-		       COUNT(bs.book_id) AS book_count,
+		       ` + seriesBookCountExpr + `,
 		       (SELECT COUNT(*) FROM series_arcs sa WHERE sa.series_id = s.id) AS arc_count,
 		       ` + readStateSubqueries(callerArg) + `,
 		       (

--- a/internal/repository/series.go
+++ b/internal/repository/series.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 
 	"github.com/fireball1725/librarium-api/internal/models"
 	"github.com/google/uuid"
@@ -74,9 +75,38 @@ func readStateSubqueries(callerArg int) string {
 
 // ─── Series CRUD ──────────────────────────────────────────────────────────────
 
+// List is the per-library entry point.
 func (r *SeriesRepo) List(ctx context.Context, libraryID, callerID uuid.UUID, search, tagFilter string) ([]*models.Series, error) {
-	args := []any{libraryID}
-	where := `WHERE s.library_id = $1`
+	return r.listScoped(ctx, []uuid.UUID{libraryID}, callerID, search, tagFilter, defaultPreviewBooks)
+}
+
+// ListAcross lists series spanning several libraries, for the cross-library
+// Series surface. Series are a per-library record, so a series held by two
+// libraries is genuinely two rows and appears twice rather than being merged:
+// the counts on each row describe that library's copies, and collapsing them
+// would report a total nobody owns.
+//
+// previewBooks caps the volumes returned per series. The index draws a strip of
+// every volume it can, so it asks for far more than the four a detail panel
+// needs, but still a bounded number: a series with a thousand entries must not
+// become a thousand-element payload per row.
+func (r *SeriesRepo) ListAcross(ctx context.Context, libraryIDs []uuid.UUID, callerID uuid.UUID, search string, previewBooks int) ([]*models.Series, error) {
+	if len(libraryIDs) == 0 {
+		return []*models.Series{}, nil
+	}
+	return r.listScoped(ctx, libraryIDs, callerID, search, "", previewBooks)
+}
+
+// defaultPreviewBooks is what a series card shows: enough to suggest the run
+// without paying for the whole thing.
+const defaultPreviewBooks = 4
+
+func (r *SeriesRepo) listScoped(ctx context.Context, libraryIDs []uuid.UUID, callerID uuid.UUID, search, tagFilter string, previewBooks int) ([]*models.Series, error) {
+	if previewBooks <= 0 {
+		previewBooks = defaultPreviewBooks
+	}
+	args := []any{libraryIDs}
+	where := `WHERE s.library_id = ANY($1)`
 	if search != "" {
 		args = append(args, "%"+search+"%")
 		where += fmt.Sprintf(` AND lower(s.name) LIKE lower($%d)`, len(args))
@@ -115,7 +145,7 @@ func (r *SeriesRepo) List(ctx context.Context, libraryID, callerID uuid.UUID, se
 		               FROM book_series bs2 JOIN books b ON b.id = bs2.book_id
 		               WHERE bs2.series_id = s.id
 		               ORDER BY bs2.position
-		               LIMIT 4
+		               LIMIT ` + strconv.Itoa(previewBooks) + `
 		           ) t
 		       ) AS preview_books,
 		       s.created_at, s.updated_at,

--- a/internal/repository/shelves.go
+++ b/internal/repository/shelves.go
@@ -72,6 +72,46 @@ func (r *ShelfRepo) List(ctx context.Context, libraryID uuid.UUID, search, tagFi
 	return out, rows.Err()
 }
 
+// ListAcross returns every shelf in the given libraries, for the rail.
+//
+// The rail lists shelves the way it lists libraries and views, so it needs them
+// across the caller's whole scope rather than one library at a time. Ordered by
+// library first so the rows group by the library they belong to without the
+// rail having to sort them itself.
+func (r *ShelfRepo) ListAcross(ctx context.Context, libraryIDs []uuid.UUID) ([]*models.Shelf, error) {
+	if len(libraryIDs) == 0 {
+		return []*models.Shelf{}, nil
+	}
+	q := `
+		SELECT s.id, s.library_id, s.name, COALESCE(s.description,''),
+		       COALESCE(s.color,''), COALESCE(s.icon,''), s.display_order,
+		       COUNT(bs.book_id) AS book_count,
+		       s.created_at, s.updated_at,
+		       ` + shelfTagsSubquery + ` AS tags
+		FROM shelves s
+		LEFT JOIN book_shelves bs ON bs.shelf_id = s.id
+		JOIN libraries l ON l.id = s.library_id
+		WHERE s.library_id = ANY($1)
+		GROUP BY s.id, l.name
+		ORDER BY lower(l.name), s.display_order, s.name`
+
+	rows, err := r.db.Query(ctx, q, libraryIDs)
+	if err != nil {
+		return nil, fmt.Errorf("listing shelves across libraries: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]*models.Shelf, 0)
+	for rows.Next() {
+		sh, err := scanShelf(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, sh)
+	}
+	return out, rows.Err()
+}
+
 func (r *ShelfRepo) FindByID(ctx context.Context, id uuid.UUID) (*models.Shelf, error) {
 	q := `
 		SELECT s.id, s.library_id, s.name, COALESCE(s.description,''),

--- a/internal/repository/shelves.go
+++ b/internal/repository/shelves.go
@@ -167,7 +167,7 @@ func (r *ShelfRepo) FindByBook(ctx context.Context, libraryID, bookID uuid.UUID)
 // ─── Shelf books ──────────────────────────────────────────────────────────────
 
 func (r *ShelfRepo) ListBooks(ctx context.Context, shelfID uuid.UUID) ([]*models.Book, error) {
-	q := booksSelect(0, 0) + `
+	q := booksSelect(0, 0, false) + `
 		JOIN book_shelves bs ON bs.book_id = b.id
 		WHERE bs.shelf_id = $1
 		ORDER BY bs.added_at DESC`

--- a/internal/service/library.go
+++ b/internal/service/library.go
@@ -207,3 +207,36 @@ func (s *LibraryService) RemoveMember(ctx context.Context, libraryID, targetUser
 
 	return s.memberships.Remove(ctx, libraryID, targetUserID)
 }
+
+// ListMyAccess returns the libraries the caller can reach with the permissions
+// they hold in each, capped by the token's scope.
+//
+// The scope cap matters: a personal access token can be minted with a narrower
+// set than the user holds, and RequireLibraryPermission enforces that on every
+// request. Reporting the user's full role here would have the client render
+// controls that the API then rejects, which reads as a bug rather than as a
+// deliberately limited token.
+func (s *LibraryService) ListMyAccess(
+	ctx context.Context,
+	userID uuid.UUID,
+	isInstanceAdmin bool,
+	scopeAllows func(string) bool,
+) ([]*repository.LibraryAccess, error) {
+	access, err := s.libraries.ListAccessForUser(ctx, userID, isInstanceAdmin)
+	if err != nil {
+		return nil, err
+	}
+	if scopeAllows == nil {
+		return access, nil
+	}
+	for _, a := range access {
+		allowed := make([]string, 0, len(a.Permissions))
+		for _, p := range a.Permissions {
+			if scopeAllows(p) {
+				allowed = append(allowed, p)
+			}
+		}
+		a.Permissions = allowed
+	}
+	return access, nil
+}


### PR DESCRIPTION
Backend for the client redesign: books, loans and shelves across every readable library, grouped by series and faceted by shelf.

- `GET /api/v1/components` lists the modules linked into the binary with their licences, read from build info rather than a written list.
- Fixes scan timeouts — one slow provider stalled every ISBN lookup.
- Fixes `make docs`, which had been failing on unresolvable swag annotations and left the spec 13 routes behind.