### PR TITLE
Zero-fill the fixed facet vocabularies, and count suggestions

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -11233,7 +11233,16 @@ const docTemplate = `{
                                 "books": {
                                     "type": "integer"
                                 },
+                                "loans": {
+                                    "type": "integer"
+                                },
+                                "loans_overdue": {
+                                    "type": "integer"
+                                },
                                 "series": {
+                                    "type": "integer"
+                                },
+                                "suggestions": {
                                     "type": "integer"
                                 }
                             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -11227,7 +11227,16 @@
                                 "books": {
                                     "type": "integer"
                                 },
+                                "loans": {
+                                    "type": "integer"
+                                },
+                                "loans_overdue": {
+                                    "type": "integer"
+                                },
                                 "series": {
+                                    "type": "integer"
+                                },
+                                "suggestions": {
                                     "type": "integer"
                                 }
                             }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -8734,7 +8734,13 @@ paths:
                 type: integer
               books:
                 type: integer
+              loans:
+                type: integer
+              loans_overdue:
+                type: integer
               series:
+                type: integer
+              suggestions:
                 type: integer
             type: object
         "401":

--- a/internal/api/handlers/me_browse.go
+++ b/internal/api/handlers/me_browse.go
@@ -111,7 +111,7 @@ func (h *MeBrowseHandler) SeriesIndex(w http.ResponseWriter, r *http.Request) {
 //	@Tags        me
 //	@Produce     json
 //	@Security    BearerAuth
-//	@Success     200  {object}  object{books=int,series=int,authors=int}
+//	@Success     200  {object}  object{books=int,series=int,authors=int,loans=int,loans_overdue=int,suggestions=int}
 //	@Failure     401  {object}  object{error=string}
 //	@Router      /me/counts [get]
 func (h *MeBrowseHandler) Counts(w http.ResponseWriter, r *http.Request) {
@@ -121,7 +121,14 @@ func (h *MeBrowseHandler) Counts(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	counts, err := h.libraries.CountsForLibraries(r.Context(), libraryIDs)
+	// Suggestions belong to the caller rather than to a library, so this count
+	// needs the user the other five do not.
+	var callerID uuid.UUID
+	if claims := middleware.ClaimsFromContext(r.Context()); claims != nil {
+		callerID = claims.UserID
+	}
+
+	counts, err := h.libraries.CountsForLibraries(r.Context(), libraryIDs, callerID)
 	if err != nil {
 		respond.ServerError(w, r, err)
 		return

--- a/internal/repository/book_facets.go
+++ b/internal/repository/book_facets.go
@@ -296,7 +296,56 @@ ORDER BY 1, 4 DESC, 3`,
 			out.Rating = append(out.Rating, fv)
 		}
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Closed vocabularies come back complete, zero-filled and in their own
+	// order.
+	//
+	// A GROUP BY only emits values something matched, which is right for
+	// genres and tags — nobody wants every unused tag listed at nought. It is
+	// wrong for a fixed set, because the filter then disappears from the rail
+	// exactly when the reader wants to know the answer is none. A collection
+	// with nothing on a wishlist offered no Wishlist filter at all, so "how
+	// many am I missing" had no way to be asked, and the same omission left
+	// every saved view built on a status with no number beside it.
+	out.Ownership = fillClosed(out.Ownership, OwnershipValues)
+	out.ReadStatus = fillClosed(out.ReadStatus, ReadStatusValues)
+
+	return out, nil
+}
+
+// ReadStatusValues is the read-status vocabulary, in the order a reader moves
+// through it. Mirrors the priority in bestReadStatusExpr, which is about which
+// status wins for a book with several editions rather than about display.
+var ReadStatusValues = []string{"unread", "reading", "read", "did_not_finish"}
+
+// fillClosed returns the facet in vocabulary order with every missing value
+// present at zero, and anything unexpected kept on the end rather than dropped:
+// a value the database holds but this list has not heard of is a schema change,
+// and silently hiding it would make that change invisible.
+func fillClosed(got []FacetValue, vocab []string) []FacetValue {
+	byValue := make(map[string]FacetValue, len(got))
+	for _, fv := range got {
+		byValue[fv.Value] = fv
+	}
+	out := make([]FacetValue, 0, len(vocab)+len(got))
+	for _, v := range vocab {
+		if fv, ok := byValue[v]; ok {
+			out = append(out, fv)
+			delete(byValue, v)
+			continue
+		}
+		out = append(out, FacetValue{Value: v, Label: v, Count: 0})
+	}
+	for _, fv := range got {
+		if _, unseen := byValue[fv.Value]; unseen {
+			out = append(out, fv)
+			delete(byValue, fv.Value)
+		}
+	}
+	return out
 }
 
 // insertionSort keeps a six-element slice ordered without reaching for sort.

--- a/internal/repository/book_facets_test.go
+++ b/internal/repository/book_facets_test.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725 (Adaléa)
+
+package repository
+
+import "testing"
+
+func names(vals []FacetValue) []string {
+	out := make([]string, len(vals))
+	for i, v := range vals {
+		out[i] = v.Value
+	}
+	return out
+}
+
+func equal(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestFillClosedZeroFills is the behaviour the rail depends on: a fixed
+// vocabulary is offered whole, so a filter does not vanish precisely when its
+// answer is none.
+func TestFillClosedZeroFills(t *testing.T) {
+	got := fillClosed(
+		[]FacetValue{{Value: "shelf", Label: "shelf", Count: 1425}},
+		OwnershipValues,
+	)
+	if !equal(names(got), OwnershipValues) {
+		t.Errorf("got %v, want the whole vocabulary %v", names(got), OwnershipValues)
+	}
+	for _, v := range got {
+		switch v.Value {
+		case "shelf":
+			if v.Count != 1425 {
+				t.Errorf("shelf count = %d, want the counted 1425", v.Count)
+			}
+		default:
+			if v.Count != 0 {
+				t.Errorf("%s count = %d, want 0", v.Value, v.Count)
+			}
+			if v.Label != v.Value {
+				t.Errorf("%s label = %q, want the value as a fallback label", v.Value, v.Label)
+			}
+		}
+	}
+}
+
+// TestFillClosedKeepsVocabularyOrder guards the display order, which is the
+// order a reader reads: what you have, then what you want, then what was
+// proposed, then what is missing.
+func TestFillClosedKeepsVocabularyOrder(t *testing.T) {
+	// Deliberately supplied in the wrong order, as a GROUP BY may well return it.
+	got := fillClosed([]FacetValue{
+		{Value: "gap", Count: 3},
+		{Value: "shelf", Count: 2},
+		{Value: "wishlist", Count: 1},
+		{Value: "suggested", Count: 4},
+	}, OwnershipValues)
+	if !equal(names(got), OwnershipValues) {
+		t.Errorf("got %v, want %v", names(got), OwnershipValues)
+	}
+}
+
+// TestFillClosedKeepsUnknownValues covers the case that would otherwise hide a
+// schema change: a value the database holds that the vocabulary has not heard
+// of is kept on the end rather than dropped.
+func TestFillClosedKeepsUnknownValues(t *testing.T) {
+	got := fillClosed([]FacetValue{
+		{Value: "shelf", Count: 5},
+		{Value: "borrowed", Count: 2},
+	}, OwnershipValues)
+
+	want := append(append([]string{}, OwnershipValues...), "borrowed")
+	if !equal(names(got), want) {
+		t.Errorf("got %v, want %v", names(got), want)
+	}
+	if got[len(got)-1].Count != 2 {
+		t.Errorf("unknown value lost its count: %d", got[len(got)-1].Count)
+	}
+}
+
+// TestFillClosedIsIdempotent — the facet is filled once per request today, but
+// filling an already-filled slice must not duplicate anything.
+func TestFillClosedIsIdempotent(t *testing.T) {
+	once := fillClosed([]FacetValue{{Value: "shelf", Count: 9}}, OwnershipValues)
+	twice := fillClosed(once, OwnershipValues)
+	if !equal(names(once), names(twice)) {
+		t.Errorf("second pass changed the set: %v then %v", names(once), names(twice))
+	}
+}
+
+// TestReadStatusVocabularyIsComplete pins the read statuses the rest of the
+// repository writes, so adding one to the schema without adding it here fails
+// rather than quietly dropping out of the rail.
+func TestReadStatusVocabularyIsComplete(t *testing.T) {
+	for _, want := range []string{"unread", "reading", "read", "did_not_finish"} {
+		found := false
+		for _, got := range ReadStatusValues {
+			if got == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("ReadStatusValues is missing %q", want)
+		}
+	}
+}

--- a/internal/repository/library_permissions.go
+++ b/internal/repository/library_permissions.go
@@ -105,6 +105,15 @@ type CollectionCounts struct {
 	// LoansOverdue is the subset worth reacting to, so the rail can say which
 	// of those outstanding loans is late without a second request.
 	LoansOverdue int `json:"loans_overdue"`
+	// Suggestions is the caller's undismissed suggestions, which is what the
+	// Suggestions page lists.
+	//
+	// Deliberately not the ownership facet's "suggested" tally. That one ranks
+	// a book by the strongest claim on it, so a suggestion for something
+	// already on the shelf counts as shelf and drops out — the facet answers
+	// "how many books are only ever suggestions", which is a smaller number and
+	// the wrong one to put beside a page listing all of them.
+	Suggestions int `json:"suggestions"`
 }
 
 // CountsForLibraries totals the collection across a set of libraries.
@@ -116,13 +125,25 @@ type CollectionCounts struct {
 // Books counts DISTINCT book ids, not junction rows. A work held by two
 // libraries is one book on the shelf, and counting the junction would report a
 // number the Books page then contradicts.
-func (r *LibraryRepo) CountsForLibraries(ctx context.Context, libraryIDs []uuid.UUID) (*CollectionCounts, error) {
+// callerID may be uuid.Nil, in which case Suggestions comes back 0: suggestions
+// belong to a user rather than to a library, so there is nothing to count
+// without one.
+func (r *LibraryRepo) CountsForLibraries(ctx context.Context, libraryIDs []uuid.UUID, callerID uuid.UUID) (*CollectionCounts, error) {
 	out := &CollectionCounts{}
 	if len(libraryIDs) == 0 {
 		return out, nil
 	}
 
-	const q = `
+	args := []any{libraryIDs}
+	suggestions := "0"
+	if callerID != uuid.Nil {
+		args = append(args, callerID)
+		suggestions = fmt.Sprintf(
+			`(SELECT COUNT(*) FROM ai_suggestions s WHERE s.user_id = $%d AND s.status = 'new')`,
+			len(args))
+	}
+
+	q := `
 SELECT
   (SELECT COUNT(DISTINCT lb.book_id) FROM library_books lb
     WHERE lb.library_id = ANY($1) AND lb.deleted_at IS NULL),
@@ -135,10 +156,11 @@ SELECT
     WHERE l.library_id = ANY($1) AND l.returned_at IS NULL),
   (SELECT COUNT(*) FROM loans l
     WHERE l.library_id = ANY($1) AND l.returned_at IS NULL
-      AND l.due_date IS NOT NULL AND l.due_date < CURRENT_DATE)`
+      AND l.due_date IS NOT NULL AND l.due_date < CURRENT_DATE),
+  ` + suggestions
 
-	if err := r.db.QueryRow(ctx, q, libraryIDs).Scan(
-		&out.Books, &out.Series, &out.Authors, &out.Loans, &out.LoansOverdue,
+	if err := r.db.QueryRow(ctx, q, args...).Scan(
+		&out.Books, &out.Series, &out.Authors, &out.Loans, &out.LoansOverdue, &out.Suggestions,
 	); err != nil {
 		return nil, fmt.Errorf("counting collection: %w", err)
 	}


### PR DESCRIPTION
Ownership and read status come back complete rather than only listing values something matched, so a filter no longer disappears when its answer is none — that is also why saved views on an empty status showed no number.

Adds `suggestions` to `/me/counts` for the nav row.