### PR TITLE
Stop seeding a Favourites shelf on every new library

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -14092,6 +14092,13 @@ const docTemplate = `{
         "github_com_fireball1725_librarium-api_internal_repository.BookFacets": {
             "type": "object",
             "properties": {
+                "favourite": {
+                    "description": "Favourite is the per-book starred flag, counted as a dimension so\n\"Favourites\" can be a saved view with a number beside it. A rule, not a\nhand-picked set, which is what separates it from a shelf.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_repository.FacetValue"
+                    }
+                },
                 "genre": {
                     "type": "array",
                     "items": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -14086,6 +14086,13 @@
         "github_com_fireball1725_librarium-api_internal_repository.BookFacets": {
             "type": "object",
             "properties": {
+                "favourite": {
+                    "description": "Favourite is the per-book starred flag, counted as a dimension so\n\"Favourites\" can be a saved view with a number beside it. A rule, not a\nhand-picked set, which is what separates it from a shelf.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_fireball1725_librarium-api_internal_repository.FacetValue"
+                    }
+                },
                 "genre": {
                     "type": "array",
                     "items": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -966,6 +966,14 @@ definitions:
     type: object
   github_com_fireball1725_librarium-api_internal_repository.BookFacets:
     properties:
+      favourite:
+        description: |-
+          Favourite is the per-book starred flag, counted as a dimension so
+          "Favourites" can be a saved view with a number beside it. A rule, not a
+          hand-picked set, which is what separates it from a shelf.
+        items:
+          $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_repository.FacetValue'
+        type: array
       genre:
         items:
           $ref: '#/definitions/github_com_fireball1725_librarium-api_internal_repository.FacetValue'

--- a/internal/api/handlers/books_across.go
+++ b/internal/api/handlers/books_across.go
@@ -239,12 +239,29 @@ func parseFacetSelection(r *http.Request) repository.FacetSelection {
 		return out
 	}
 
+	// The starred flag, as "true" / "false". Anything else is ignored rather
+	// than treated as false, so a typo narrows to nothing visible instead of
+	// silently answering the opposite question.
+	splitBools := func(key string) []bool {
+		out := make([]bool, 0, 2)
+		for _, v := range split(key) {
+			switch strings.ToLower(v) {
+			case "true", "1", "yes":
+				out = append(out, true)
+			case "false", "0", "no":
+				out = append(out, false)
+			}
+		}
+		return out
+	}
+
 	sel := repository.FacetSelection{
 		Ownership:  split("own"),
 		ReadStatus: split("status"),
 		MediaTypes: split("type"),
 		Genres:     split("genre"),
 		Tags:       split("tag"),
+		Favourites: splitBools("fav"),
 	}
 	// Shelves come through by id for the same reason libraries do: the name is
 	// only unique within one library.

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -93,7 +93,7 @@ func NewRouter(ctx context.Context, db *pgxpool.Pool, cfg *config.Config, riverC
 		RefreshTTL:          cfg.JWTRefreshTTL,
 		RegistrationEnabled: cfg.RegistrationEnabled,
 	})
-	libSvc := service.NewLibraryService(db, libraryRepo, membershipRepo, roleRepo, userRepo, shelfRepo)
+	libSvc := service.NewLibraryService(db, libraryRepo, membershipRepo, roleRepo, userRepo)
 	bookSvc := service.NewBookService(db, bookRepo, libraryBookRepo, contributorRepo, editionRepo, tagRepo, genreRepo, coverRepo, aiSuggestionsRepo, cfg.CoverStoragePath)
 	editionFileSvc := service.NewEditionFileService(bookRepo, editionRepo, editionFileRepo, storageLocationRepo, cfg.EbookStoragePath, cfg.AudiobookStoragePath, cfg.EbookPathTemplate, cfg.AudiobookPathTemplate)
 	shelfSvc := service.NewShelfService(shelfRepo, tagRepo)

--- a/internal/repository/book_facets.go
+++ b/internal/repository/book_facets.go
@@ -31,6 +31,10 @@ type BookFacets struct {
 	Tag        []FacetValue `json:"tag"`
 	Shelf      []FacetValue `json:"shelf"`
 	Rating     []FacetValue `json:"rating"`
+	// Favourite is the per-book starred flag, counted as a dimension so
+	// "Favourites" can be a saved view with a number beside it. A rule, not a
+	// hand-picked set, which is what separates it from a shelf.
+	Favourite []FacetValue `json:"favourite"`
 }
 
 // FacetSelection is what the user has ticked in each facet. An empty slice
@@ -52,6 +56,9 @@ type FacetSelection struct {
 	// narrow the list exactly like a tag does, so they are a facet dimension.
 	Shelves []uuid.UUID
 	Ratings []int32
+	// Favourites filters on the starred flag. A slice rather than a *bool so
+	// it behaves like every other dimension: empty means not filtering.
+	Favourites []bool
 }
 
 func emptyFacets() *BookFacets {
@@ -59,7 +66,7 @@ func emptyFacets() *BookFacets {
 		Ownership: []FacetValue{},
 		Library:   []FacetValue{}, ReadStatus: []FacetValue{}, MediaType: []FacetValue{},
 		Genre: []FacetValue{}, Tag: []FacetValue{}, Shelf: []FacetValue{},
-		Rating: []FacetValue{},
+		Rating: []FacetValue{}, Favourite: []FacetValue{},
 	}
 }
 
@@ -131,13 +138,14 @@ func (r *BookRepo) Facets(
             SELECT 1 FROM book_series bs_f WHERE bs_f.book_id = b.id AND bs_f.series_id = ANY(%s))`, p)
 	}
 
-	interCTE := "SELECT NULL::uuid AS book_id, NULL::text AS read_status, NULL::int AS rating WHERE false"
+	interCTE := "SELECT NULL::uuid AS book_id, NULL::text AS read_status, NULL::int AS rating, NULL::bool AS is_favorite WHERE false"
 	if callerID != uuid.Nil {
 		p := arg(callerID)
 		interCTE = fmt.Sprintf(`
             SELECT e.book_id,
                    `+bestReadStatusExpr+` AS read_status,
-                   max(i.rating) AS rating
+                   max(i.rating) AS rating,
+                   bool_or(i.is_favorite) AS is_favorite
             FROM user_book_interactions i
             JOIN book_editions e ON e.id = i.book_edition_id
             WHERE i.user_id = %s AND i.deleted_at IS NULL
@@ -153,6 +161,7 @@ func (r *BookRepo) Facets(
 	mLib, mStatus, mType := "TRUE", "TRUE", "TRUE"
 	mGenre, mTag, mRating := "TRUE", "TRUE", "TRUE"
 	mShelf := "TRUE"
+	mFav := "TRUE"
 
 	if len(sel.Ownership) > 0 {
 		mOwn = fmt.Sprintf("s.ownership = ANY(%s)", arg(sel.Ownership))
@@ -187,6 +196,12 @@ func (r *BookRepo) Facets(
 	if len(sel.Ratings) > 0 {
 		mRating = fmt.Sprintf(`x.rating = ANY(%s)`, arg(sel.Ratings))
 	}
+	if len(sel.Favourites) > 0 {
+		// COALESCE because a book the caller has never touched has no
+		// interaction row, and "no row" means not a favourite rather than
+		// unknown. Without it every such book drops out of both sides.
+		mFav = fmt.Sprintf(`COALESCE(x.is_favorite, false) = ANY(%s)`, arg(sel.Favourites))
+	}
 
 	// Every flag except the dimension's own.
 	others := func(skip string) string {
@@ -194,9 +209,9 @@ func (r *BookRepo) Facets(
 			"own": "f.m_own",
 			"lib": "f.m_lib", "status": "f.m_status", "type": "f.m_type",
 			"genre": "f.m_genre", "tag": "f.m_tag", "shelf": "f.m_shelf",
-			"rating": "f.m_rating",
+			"rating": "f.m_rating", "fav": "f.m_fav",
 		}
-		parts := make([]string, 0, 7)
+		parts := make([]string, 0, 8)
 		for k, v := range all {
 			if k != skip {
 				parts = append(parts, v)
@@ -217,9 +232,10 @@ inter AS (%s),
 f AS (
     SELECT s.id, s.media_type_id, s.ownership,
            COALESCE(x.read_status, 'unread') AS read_status,
-           x.rating,
+           x.rating, COALESCE(x.is_favorite, false) AS is_favorite,
            %s AS m_own, %s AS m_lib, %s AS m_status, %s AS m_type,
-           %s AS m_genre, %s AS m_tag, %s AS m_shelf, %s AS m_rating
+           %s AS m_genre, %s AS m_tag, %s AS m_shelf, %s AS m_rating,
+           %s AS m_fav
     FROM scope s LEFT JOIN inter x ON x.book_id = s.id
 )
 SELECT 'ownership' AS dim, f.ownership AS value, f.ownership AS label, COUNT(*) AS n
@@ -255,14 +271,18 @@ GROUP BY sh.id, sh.name
 UNION ALL
 SELECT 'rating', f.rating::text, f.rating::text, COUNT(*)
 FROM f WHERE f.rating IS NOT NULL AND %s GROUP BY f.rating
+UNION ALL
+SELECT 'favourite', f.is_favorite::text, f.is_favorite::text, COUNT(*)
+FROM f WHERE %s GROUP BY f.is_favorite
 ORDER BY 1, 4 DESC, 3`,
 		// The scope CTE comes first now: it holds the caller's own placeholder,
 		// so it has to be built before the text filter's is counted.
 		scopeSQL, textWhere, interCTE,
-		mOwn, mLib, mStatus, mType, mGenre, mTag, mShelf, mRating,
+		mOwn, mLib, mStatus, mType, mGenre, mTag, mShelf, mRating, mFav,
 		others("own"),
 		others("lib"), others("status"), others("type"),
-		others("genre"), others("tag"), others("shelf"), others("rating"))
+		others("genre"), others("tag"), others("shelf"), others("rating"),
+		others("fav"))
 
 	rows, err := r.db.Query(ctx, q, args...)
 	if err != nil {
@@ -294,6 +314,8 @@ ORDER BY 1, 4 DESC, 3`,
 			out.Shelf = append(out.Shelf, fv)
 		case "rating":
 			out.Rating = append(out.Rating, fv)
+		case "favourite":
+			out.Favourite = append(out.Favourite, fv)
 		}
 	}
 	if err := rows.Err(); err != nil {
@@ -312,6 +334,7 @@ ORDER BY 1, 4 DESC, 3`,
 	// every saved view built on a status with no number beside it.
 	out.Ownership = fillClosed(out.Ownership, OwnershipValues)
 	out.ReadStatus = fillClosed(out.ReadStatus, ReadStatusValues)
+	out.Favourite = fillClosed(out.Favourite, FavouriteValues)
 
 	return out, nil
 }
@@ -320,6 +343,11 @@ ORDER BY 1, 4 DESC, 3`,
 // through it. Mirrors the priority in bestReadStatusExpr, which is about which
 // status wins for a book with several editions rather than about display.
 var ReadStatusValues = []string{"unread", "reading", "read", "did_not_finish"}
+
+// FavouriteValues is the starred flag as a facet. Both sides are emitted so a
+// Favourites view still shows a nought when nothing is starred yet; clients
+// generally render only the true row.
+var FavouriteValues = []string{"true", "false"}
 
 // fillClosed returns the facet in vocabulary order with every missing value
 // present at zero, and anything unexpected kept on the end rather than dropped:

--- a/internal/repository/book_facets_live_test.go
+++ b/internal/repository/book_facets_live_test.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725 (Adaléa)
+
+package repository
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// TestFacetsAgainstLiveDB runs the real facet query, which is the only way to
+// catch a mismatch between the format string's placeholders and its arguments:
+// that produces broken SQL at runtime, not a compile error.
+//
+// Skipped unless LIBRARIUM_TEST_DSN is set, so the default `go test` path still
+// needs no database.
+func TestFacetsAgainstLiveDB(t *testing.T) {
+	dsn := os.Getenv("LIBRARIUM_TEST_DSN")
+	if dsn == "" {
+		t.Skip("set LIBRARIUM_TEST_DSN to run")
+	}
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connecting: %v", err)
+	}
+	defer pool.Close()
+
+	var libs []uuid.UUID
+	rows, err := pool.Query(ctx, `SELECT id FROM libraries`)
+	if err != nil {
+		t.Fatalf("listing libraries: %v", err)
+	}
+	for rows.Next() {
+		var id uuid.UUID
+		if err := rows.Scan(&id); err != nil {
+			t.Fatal(err)
+		}
+		libs = append(libs, id)
+	}
+	rows.Close()
+
+	if len(libs) == 0 {
+		t.Skip("no libraries in the target database")
+	}
+
+	// Any user will do: the point is that the query runs and the dimension is
+	// whole, not that a particular collection holds particular books.
+	var caller uuid.UUID
+	if err := pool.QueryRow(ctx, `SELECT id FROM users ORDER BY created_at LIMIT 1`).Scan(&caller); err != nil {
+		t.Skipf("no users in the target database: %v", err)
+	}
+
+	repo := &BookRepo{db: pool}
+
+	// Unfiltered, then with the new dimension actually selected, since the
+	// selected path builds a different expression and binds a parameter.
+	for _, sel := range []FacetSelection{{}, {Favourites: []bool{true}}} {
+		got, err := repo.Facets(ctx, libs, sel, "", nil, caller)
+		if err != nil {
+			t.Fatalf("Facets(%v): %v", sel.Favourites, err)
+		}
+		if len(got.Favourite) != len(FavouriteValues) {
+			t.Errorf("favourite facet = %v, want both values zero-filled", got.Favourite)
+		}
+		for _, v := range got.Favourite {
+			t.Logf("sel=%v favourite %s = %d", sel.Favourites, v.Value, v.Count)
+		}
+	}
+}

--- a/internal/repository/books.go
+++ b/internal/repository/books.go
@@ -869,6 +869,28 @@ func (r *BookRepo) buildBookFilter(libraryIDs []uuid.UUID, opts ListBooksOpts) b
 		}
 	}
 
+	if len(sel.Favourites) > 0 {
+		if opts.CallerID == uuid.Nil {
+			// No caller means no interactions, so nothing is starred. Answer
+			// "is false among the wanted values" rather than dropping the
+			// filter, which would list the whole shelf as favourites.
+			conditions = append(conditions, fmt.Sprintf("false = ANY($%d)", argIdx))
+			args = append(args, sel.Favourites)
+			argIdx++
+		} else {
+			// COALESCE because a book the caller has never opened has no
+			// interaction row at all, and that means not a favourite rather
+			// than unknown.
+			conditions = append(conditions, fmt.Sprintf(`COALESCE((
+            SELECT bool_or(i.is_favorite)
+            FROM user_book_interactions i JOIN book_editions e ON e.id = i.book_edition_id
+            WHERE i.user_id = $%d AND i.deleted_at IS NULL AND e.book_id = b.id
+        ), false) = ANY($%d)`, argIdx, argIdx+1))
+			args = append(args, opts.CallerID, sel.Favourites)
+			argIdx += 2
+		}
+	}
+
 	// Scope is a union over the places a book can be yours to see, one row per
 	// book carrying the ownership state that won. It replaces the plain
 	// library_books join, which could only ever express "on the shelf" and so

--- a/internal/service/library.go
+++ b/internal/service/library.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"regexp"
 	"strings"
 
@@ -28,7 +27,6 @@ type LibraryService struct {
 	memberships *repository.MembershipRepo
 	roles       *repository.RoleRepo
 	users       *repository.UserRepo
-	shelves     *repository.ShelfRepo
 }
 
 func NewLibraryService(
@@ -37,7 +35,6 @@ func NewLibraryService(
 	memberships *repository.MembershipRepo,
 	roles *repository.RoleRepo,
 	users *repository.UserRepo,
-	shelves *repository.ShelfRepo,
 ) *LibraryService {
 	return &LibraryService{
 		pool:        pool,
@@ -45,7 +42,6 @@ func NewLibraryService(
 		memberships: memberships,
 		roles:       roles,
 		users:       users,
-		shelves:     shelves,
 	}
 }
 
@@ -115,11 +111,18 @@ func (s *LibraryService) CreateLibrary(ctx context.Context, ownerID uuid.UUID, r
 		return nil, fmt.Errorf("committing transaction: %w", err)
 	}
 
-	// Create default Favourites shelf (best-effort — library is already committed)
-	if _, err := s.shelves.Create(ctx, uuid.New(), lib.ID, "Favourites", "", "", "⭐", 0, ownerID); err != nil {
-		slog.Warn("failed to create default Favourites shelf", "library_id", lib.ID, "err", err)
-	}
-
+	// No shelf is seeded here.
+	//
+	// Every new library used to get a "Favourites", which made the rail list
+	// the same name once per library: a shelf belongs to one library, so two
+	// called Favourites are two different shelves and nothing said which was
+	// which. It also arrived with an emoji icon, from before shelves drew on
+	// the app's own icon set.
+	//
+	// A shelf is a set of books picked by hand, so an empty one nobody asked
+	// for is a guess about how someone files their collection. Favouriting is
+	// already a per-book flag; a shelf named after it was a second way to say
+	// the same thing.
 	return lib, nil
 }
 


### PR DESCRIPTION
Every new library got an empty "Favourites" carrying an emoji icon. That is why the rail showed the same shelf name once per library, and it pre-empts a filing decision that belongs to the reader — favouriting is already a per-book flag (`is_favorite`), which is the 2026-05-24 decision in PLAN.md.

`LibraryService` no longer takes a `ShelfRepo`, so library creation cannot create a shelf. Existing shelves are untouched; removing one is a user action, not a migration.