### PR TITLE
Re-copy the shared editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -24,6 +24,31 @@ indent_size = 4
 [*.{py,pyi}]
 indent_size = 4
 
+# C# is two-space like everything else here that gets a choice, with one-true-brace and
+# padded parentheses: `Foo( a, b )`, `if ( x )`, and no space between a name and its
+# opening paren.
+#
+# Adjacent parens stay tight, `Foo( Bar( x ))`, and Roslyn cannot express that: it pads
+# each pair independently and leaves `Foo( Bar( x ) )`. A C# repo therefore needs a second
+# pass after dotnet format; scripts/tighten_parens.py in this repo's templates does it, and
+# scaffold.sh copies it in.
+[*.cs]
+indent_size = 2
+csharp_new_line_before_open_brace = none
+csharp_new_line_before_else = false
+csharp_new_line_before_catch = false
+csharp_new_line_before_finally = false
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+csharp_space_between_method_call_parameter_list_parentheses = true
+csharp_space_between_method_declaration_parameter_list_parentheses = true
+csharp_space_between_parentheses = control_flow_statements,expressions,type_casts
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_empty_method_call_parentheses = false
+csharp_space_between_empty_method_declaration_parentheses = false
+
 [Makefile]
 indent_style = tab
 

--- a/.editorconfig-checker.json
+++ b/.editorconfig-checker.json
@@ -12,7 +12,8 @@
     "package-lock\\.json$",
     "\\.generated\\.swift$",
     "\\.min\\.(js|css)$",
-    "\\.(png|jpg|jpeg|gif|ico|icns|pdf|woff2?|ttf|dmg|zip)$"
+    "\\.(png|jpg|jpeg|gif|ico|icns|pdf|woff2?|ttf|dmg|zip)$",
+    "\\.(assets|fbx|blend)$"
   ],
   "Verbose": false,
   "IgnoreDefaults": false,


### PR DESCRIPTION
Picks up the C# style block and the binary excludes for `.assets`, `.fbx` and `.blend` added in [FireBall1725/workflows#4](https://github.com/FireBall1725/workflows/pull/4).

No C# in this repo, so nothing changes shape here. This is keeping `check-drift.sh` quiet, which reported all 8 repos drifted the moment the template changed.