### PR TITLE
Correct a logged reading session with PATCH /sessions/{id}

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -14817,6 +14817,131 @@ const docTemplate = `{
                         }
                     }
                 }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Partial update. A field left out is untouched; send it as null to clear it, which is how a mistyped finish date is removed rather than overwritten.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "me"
+                ],
+                "summary": "Correct a logged reading session",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Session UUID",
+                        "name": "session_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "The changes",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "edition_id": {
+                                    "type": "string"
+                                },
+                                "finished_at": {
+                                    "type": "string"
+                                },
+                                "progress_unit": {
+                                    "type": "string"
+                                },
+                                "progress_value": {
+                                    "type": "number"
+                                },
+                                "started_at": {
+                                    "type": "string"
+                                },
+                                "status": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "book_id": {
+                                    "type": "string"
+                                },
+                                "finished_at": {
+                                    "type": "string"
+                                },
+                                "id": {
+                                    "type": "string"
+                                },
+                                "started_at": {
+                                    "type": "string"
+                                },
+                                "status": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
             }
         },
         "/setup/admin": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -14811,6 +14811,131 @@
                         }
                     }
                 }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Partial update. A field left out is untouched; send it as null to clear it, which is how a mistyped finish date is removed rather than overwritten.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "me"
+                ],
+                "summary": "Correct a logged reading session",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Session UUID",
+                        "name": "session_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "The changes",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "edition_id": {
+                                    "type": "string"
+                                },
+                                "finished_at": {
+                                    "type": "string"
+                                },
+                                "progress_unit": {
+                                    "type": "string"
+                                },
+                                "progress_value": {
+                                    "type": "number"
+                                },
+                                "started_at": {
+                                    "type": "string"
+                                },
+                                "status": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "book_id": {
+                                    "type": "string"
+                                },
+                                "finished_at": {
+                                    "type": "string"
+                                },
+                                "id": {
+                                    "type": "string"
+                                },
+                                "started_at": {
+                                    "type": "string"
+                                },
+                                "status": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
             }
         },
         "/setup/admin": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -11081,6 +11081,87 @@ paths:
       summary: Delete a reading session
       tags:
       - me
+    patch:
+      consumes:
+      - application/json
+      description: Partial update. A field left out is untouched; send it as null
+        to clear it, which is how a mistyped finish date is removed rather than overwritten.
+      parameters:
+      - description: Session UUID
+        in: path
+        name: session_id
+        required: true
+        type: string
+      - description: The changes
+        in: body
+        name: body
+        required: true
+        schema:
+          properties:
+            edition_id:
+              type: string
+            finished_at:
+              type: string
+            progress_unit:
+              type: string
+            progress_value:
+              type: number
+            started_at:
+              type: string
+            status:
+              type: string
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            properties:
+              book_id:
+                type: string
+              finished_at:
+                type: string
+              id:
+                type: string
+              started_at:
+                type: string
+              status:
+                type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+        "403":
+          description: Forbidden
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Correct a logged reading session
+      tags:
+      - me
   /setup/admin:
     post:
       consumes:

--- a/internal/api/handlers/reading_state.go
+++ b/internal/api/handlers/reading_state.go
@@ -290,6 +290,128 @@ func (h *ReadingStateHandler) CreateSession(w http.ResponseWriter, r *http.Reque
 	respond.JSON(w, http.StatusCreated, session)
 }
 
+type updateSessionBody struct {
+	EditionID     *string  `json:"edition_id"`
+	StartedAt     *string  `json:"started_at"`
+	FinishedAt    *string  `json:"finished_at"`
+	Status        *string  `json:"status"`
+	ProgressUnit  *string  `json:"progress_unit"`
+	ProgressValue *float64 `json:"progress_value"`
+}
+
+// UpdateSession godoc
+//
+// @Summary     Correct a logged reading session
+// @Description Partial update. A field left out is untouched; send it as null to clear it, which is how a mistyped finish date is removed rather than overwritten.
+// @Tags        me
+// @Accept      json
+// @Produce     json
+// @Security    BearerAuth
+// @Param       session_id  path  string  true  "Session UUID"
+// @Param       body  body  object{edition_id=string,started_at=string,finished_at=string,status=string,progress_unit=string,progress_value=number}  true  "The changes"
+// @Success     200  {object}  object{id=string,book_id=string,started_at=string,finished_at=string,status=string}
+// @Failure     400  {object}  object{error=string}
+// @Failure     401  {object}  object{error=string}
+// @Failure     403  {object}  object{error=string}
+// @Failure     404  {object}  object{error=string}
+// @Router      /sessions/{session_id} [patch]
+func (h *ReadingStateHandler) UpdateSession(w http.ResponseWriter, r *http.Request) {
+	sessionID, err := uuid.Parse(r.PathValue("session_id"))
+	if err != nil {
+		respond.Error(w, http.StatusBadRequest, "invalid session id")
+		return
+	}
+
+	// Decoding into a map as well as the struct is what separates "sent as
+	// null" from "not sent at all". A pointer alone cannot tell them apart, and
+	// they mean different things here: one clears a date, the other keeps it.
+	var raw map[string]json.RawMessage
+	if err := json.NewDecoder(r.Body).Decode(&raw); err != nil {
+		respond.Error(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	var body updateSessionBody
+	for key, target := range map[string]any{
+		"edition_id": &body.EditionID, "started_at": &body.StartedAt,
+		"finished_at": &body.FinishedAt, "status": &body.Status,
+		"progress_unit": &body.ProgressUnit, "progress_value": &body.ProgressValue,
+	} {
+		if v, ok := raw[key]; ok {
+			if err := json.Unmarshal(v, target); err != nil {
+				respond.Error(w, http.StatusBadRequest, "invalid value for "+key)
+				return
+			}
+		}
+	}
+
+	sent := func(key string) bool { _, ok := raw[key]; return ok }
+	in := repository.UpdateSessionInput{
+		StartedAt:     body.StartedAt,
+		ClearStarted:  sent("started_at") && body.StartedAt == nil,
+		FinishedAt:    body.FinishedAt,
+		ClearFinished: sent("finished_at") && body.FinishedAt == nil,
+		Status:        body.Status,
+		ProgressUnit:  body.ProgressUnit,
+		ProgressValue: body.ProgressValue,
+		ClearEdition:  sent("edition_id") && body.EditionID == nil,
+	}
+	if body.EditionID != nil && *body.EditionID != "" {
+		id, err := uuid.Parse(*body.EditionID)
+		if err != nil {
+			respond.Error(w, http.StatusBadRequest, "invalid edition id")
+			return
+		}
+		in.EditionID = &id
+	}
+
+	if !h.ownsSession(w, r, sessionID) {
+		return
+	}
+
+	session, err := h.sessions.Update(r.Context(), sessionID, in)
+	switch {
+	case errors.Is(err, repository.ErrPageNeedsEdition):
+		respond.Error(w, http.StatusBadRequest,
+			"page progress needs an edition, since page 200 of a paperback is not page 200 of the omnibus")
+		return
+	case errors.Is(err, repository.ErrNotFound):
+		respond.Error(w, http.StatusNotFound, "session not found")
+		return
+	case err != nil:
+		respond.Error(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	respond.JSON(w, http.StatusOK, session)
+}
+
+// ownsSession refuses a session belonging to somebody else.
+//
+// A session id is not a capability. Sessions are addressed by their own id
+// rather than under a book, so the ownership check cannot come from the path
+// the way it does everywhere else, and without this anyone holding an id could
+// read or destroy someone else's reading history.
+//
+// One implementation on purpose: the update and delete paths both need it, and
+// two copies of an authorisation check is how one of them drifts.
+func (h *ReadingStateHandler) ownsSession(w http.ResponseWriter, r *http.Request, sessionID uuid.UUID) bool {
+	existing, err := h.sessions.FindByID(r.Context(), sessionID)
+	if errors.Is(err, repository.ErrNotFound) {
+		respond.Error(w, http.StatusNotFound, "session not found")
+		return false
+	}
+	if err != nil {
+		respond.ServerError(w, r, err)
+		return false
+	}
+	if existing.UserID != callerOf(r) {
+		// 404 rather than 403: saying "forbidden" would confirm the session
+		// exists to somebody who cannot see it.
+		respond.Error(w, http.StatusNotFound, "session not found")
+		return false
+	}
+	return true
+}
+
 // DeleteSession godoc
 //
 // @Summary     Delete a reading session
@@ -308,15 +430,7 @@ func (h *ReadingStateHandler) DeleteSession(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	// Scoped to the caller: a session id is not a capability, and without this
-	// anyone holding one could delete someone else's reading history.
-	existing, err := h.sessions.FindByID(r.Context(), id)
-	if errors.Is(err, repository.ErrNotFound) || (err == nil && existing.UserID != callerOf(r)) {
-		respond.Error(w, http.StatusNotFound, "session not found")
-		return
-	}
-	if err != nil {
-		respond.ServerError(w, r, err)
+	if !h.ownsSession(w, r, id) {
 		return
 	}
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -231,6 +231,7 @@ func NewRouter(ctx context.Context, db *pgxpool.Pool, cfg *config.Config, riverC
 	mux.Handle("DELETE /api/v1/books/{book_id}/me", requireAuth(http.HandlerFunc(readingStateHandler.DeleteMyBook)))
 	mux.Handle("GET /api/v1/books/{book_id}/sessions", requireAuth(http.HandlerFunc(readingStateHandler.ListSessions)))
 	mux.Handle("POST /api/v1/books/{book_id}/sessions", requireAuth(http.HandlerFunc(readingStateHandler.CreateSession)))
+	mux.Handle("PATCH /api/v1/sessions/{session_id}", requireAuth(http.HandlerFunc(readingStateHandler.UpdateSession)))
 	mux.Handle("DELETE /api/v1/sessions/{session_id}", requireAuth(http.HandlerFunc(readingStateHandler.DeleteSession)))
 
 	// Lists are what shelves and saved views became.

--- a/internal/repository/reading_sessions.go
+++ b/internal/repository/reading_sessions.go
@@ -129,6 +129,73 @@ func (r *ReadingSessionRepo) Create(ctx context.Context, in CreateSessionInput) 
 	return r.FindByID(ctx, id)
 }
 
+// UpdateSessionInput carries only what a person may change about a pass they
+// already logged. UserID and BookID are absent: a session cannot move to
+// another work or another person without becoming a different session.
+type UpdateSessionInput struct {
+	EditionID     *uuid.UUID
+	ClearEdition  bool
+	StartedAt     *string
+	ClearStarted  bool
+	FinishedAt    *string
+	ClearFinished bool
+	Status        *string
+	ProgressUnit  *string
+	ProgressValue *float64
+}
+
+// Update edits a logged session. A nil field is left alone rather than cleared,
+// so a client correcting one date does not have to send the row back; clearing
+// is a separate flag, because "not mentioned" and "remove it" are different
+// requests and one nullable field cannot say both.
+func (r *ReadingSessionRepo) Update(ctx context.Context, id uuid.UUID, in UpdateSessionInput) (*models.ReadingSession, error) {
+	cur, err := r.FindByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	// The page-needs-an-edition rule has to hold after the edit, not just at
+	// create time. Checking the merged state rather than the request catches
+	// clearing the edition on a session that already counts pages.
+	unit := cur.ProgressUnit
+	if in.ProgressUnit != nil {
+		unit = *in.ProgressUnit
+	}
+	edition := cur.EditionID
+	switch {
+	case in.ClearEdition:
+		edition = nil
+	case in.EditionID != nil:
+		edition = in.EditionID
+	}
+	if unit == "page" && edition == nil {
+		return nil, ErrPageNeedsEdition
+	}
+
+	const q = `
+		UPDATE reading_sessions
+		   SET edition_id     = CASE WHEN $2 THEN NULL ELSE COALESCE($3, edition_id) END,
+		       started_at     = CASE WHEN $4 THEN NULL ELSE COALESCE($5::timestamptz, started_at) END,
+		       finished_at    = CASE WHEN $6 THEN NULL ELSE COALESCE($7::timestamptz, finished_at) END,
+		       status         = COALESCE($8, status),
+		       progress_unit  = COALESCE(NULLIF($9, ''), progress_unit),
+		       progress_value = COALESCE($10, progress_value)
+		 WHERE id = $1`
+
+	tag, err := r.db.Exec(ctx, q, id,
+		in.ClearEdition, in.EditionID,
+		in.ClearStarted, in.StartedAt,
+		in.ClearFinished, in.FinishedAt,
+		in.Status, in.ProgressUnit, in.ProgressValue)
+	if err != nil {
+		return nil, translateSessionErr(err)
+	}
+	if tag.RowsAffected() == 0 {
+		return nil, ErrNotFound
+	}
+	return r.FindByID(ctx, id)
+}
+
 // Finish closes a session, which is the common write: someone marks a book done
 // and the session that was open becomes the record of when.
 func (r *ReadingSessionRepo) Finish(ctx context.Context, id uuid.UUID, finishedAt *string, status string) (*models.ReadingSession, error) {

--- a/internal/repository/schema_tiers_live_test.go
+++ b/internal/repository/schema_tiers_live_test.go
@@ -1234,3 +1234,102 @@ func TestLibraryMembersCollapsesASecondRole(t *testing.T) {
 			reportedPerms, heldPerms)
 	}
 }
+
+// TestSessionUpdateChangesOnlyWhatWasSent covers the reason clearing is a
+// separate flag. A client correcting a start date must not blank the finish
+// date it did not mention, and removing a mistyped date must be possible at
+// all, which one nullable field cannot express.
+func TestSessionUpdateChangesOnlyWhatWasSent(t *testing.T) {
+	pool, ctx := tiersPool(t)
+	repo := NewReadingSessionRepo(pool)
+
+	var userID, bookID uuid.UUID
+	if err := pool.QueryRow(ctx, `SELECT id FROM users LIMIT 1`).Scan(&userID); err != nil {
+		t.Skipf("no users: %v", err)
+	}
+	if err := pool.QueryRow(ctx, `SELECT id FROM books LIMIT 1`).Scan(&bookID); err != nil {
+		t.Skipf("no books: %v", err)
+	}
+
+	started, finished := "2026-01-02T00:00:00Z", "2026-02-03T00:00:00Z"
+	s, err := repo.Create(ctx, CreateSessionInput{
+		UserID: userID, BookID: bookID,
+		StartedAt: &started, FinishedAt: &finished, Status: "finished",
+	})
+	if err != nil {
+		t.Fatalf("creating a session: %v", err)
+	}
+	defer func() { _ = repo.Delete(ctx, s.ID) }()
+
+	// Correcting the start date leaves the finish date alone.
+	newStart := "2026-01-05T00:00:00Z"
+	got, err := repo.Update(ctx, s.ID, UpdateSessionInput{StartedAt: &newStart})
+	if err != nil {
+		t.Fatalf("updating the start date: %v", err)
+	}
+	// Compared in UTC: the value is stored as an instant, and formatting it in
+	// the machine's zone turns midnight UTC into the previous evening.
+	if got.StartedAt == nil || got.StartedAt.UTC().Format("2006-01-02") != "2026-01-05" {
+		t.Errorf("started_at = %v, want the corrected date", got.StartedAt)
+	}
+	if got.FinishedAt == nil {
+		t.Error("correcting the start date cleared the finish date")
+	}
+	if got.Status != "finished" {
+		t.Errorf("status = %q, want it untouched", got.Status)
+	}
+
+	// Clearing is a separate request, and it has to actually clear.
+	got, err = repo.Update(ctx, s.ID, UpdateSessionInput{ClearFinished: true})
+	if err != nil {
+		t.Fatalf("clearing the finish date: %v", err)
+	}
+	if got.FinishedAt != nil {
+		t.Errorf("finished_at = %v after an explicit clear, want nil", got.FinishedAt)
+	}
+	if got.StartedAt == nil {
+		t.Error("clearing the finish date also cleared the start date")
+	}
+}
+
+// TestSessionUpdateKeepsPageProgressHonest covers the rule holding after an
+// edit rather than only at create time. A page number is meaningless without
+// knowing which printing it counts, so clearing the edition on a session that
+// counts pages has to be refused.
+func TestSessionUpdateKeepsPageProgressHonest(t *testing.T) {
+	pool, ctx := tiersPool(t)
+	repo := NewReadingSessionRepo(pool)
+
+	var userID, bookID, editionID uuid.UUID
+	err := pool.QueryRow(ctx,
+		`SELECT be.book_id, be.id FROM book_editions be LIMIT 1`).Scan(&bookID, &editionID)
+	if err != nil {
+		t.Skipf("no editions: %v", err)
+	}
+	if err := pool.QueryRow(ctx, `SELECT id FROM users LIMIT 1`).Scan(&userID); err != nil {
+		t.Skipf("no users: %v", err)
+	}
+
+	pages := 200.0
+	s, err := repo.Create(ctx, CreateSessionInput{
+		UserID: userID, BookID: bookID, EditionID: &editionID,
+		Status: "reading", ProgressUnit: "page", ProgressValue: &pages,
+	})
+	if err != nil {
+		t.Fatalf("creating a page-progress session: %v", err)
+	}
+	defer func() { _ = repo.Delete(ctx, s.ID) }()
+
+	if _, err := repo.Update(ctx, s.ID, UpdateSessionInput{ClearEdition: true}); !errors.Is(err, ErrPageNeedsEdition) {
+		t.Errorf("clearing the edition on a page-counting session returned %v, want ErrPageNeedsEdition", err)
+	}
+
+	// The session is unchanged after the refusal.
+	after, err := repo.FindByID(ctx, s.ID)
+	if err != nil {
+		t.Fatalf("re-reading: %v", err)
+	}
+	if after.EditionID == nil {
+		t.Error("the refused update cleared the edition anyway")
+	}
+}


### PR DESCRIPTION
The endpoint map promised this and only DELETE was built, so a mistyped finish date could be removed but not fixed. Web needs it, since reading dates live in `reading_sessions` now.

- Clearing is a separate flag, because "not mentioned" and "remove it" cannot share one nullable field.
- Delete's hand-rolled ownership check is now shared with update.