### PR TITLE
Filter and count by any list the caller can see

### DIFF
--- a/internal/repository/book_facets.go
+++ b/internal/repository/book_facets.go
@@ -221,6 +221,18 @@ func (r *BookRepo) Facets(
 		return strings.Join(parts, " AND ")
 	}
 
+	// Which lists this caller may be counted against: their own, plus anything
+	// shared into a library in scope. Spliced in by concatenation rather than as
+	// another %s, because the argument list below is positional and adding a
+	// slot in the middle renumbers everything after it.
+	//
+	// A nil caller matches no owner, so an unauthenticated read still sees the
+	// library-shared lists and nothing private, which is what it saw before
+	// shelves and saved views became one thing.
+	listVisible := fmt.Sprintf(
+		`(l4.owner_user_id = %s OR (l4.visibility = 'library' AND l4.shared_library_id = ANY($1)))`,
+		arg(callerID))
+
 	q := fmt.Sprintf(`
 WITH scope AS (
     SELECT DISTINCT b.id, b.media_type_id, lb.ownership
@@ -263,11 +275,11 @@ FROM f JOIN book_tags bt ON bt.book_id = f.id AND bt.deleted_at IS NULL
        JOIN tags t ON t.id = bt.tag_id AND t.deleted_at IS NULL
 WHERE %s GROUP BY t.name
 UNION ALL
-SELECT 'shelf', sh.id::text, sh.name, COUNT(DISTINCT f.id)
-FROM f JOIN library_shelf_books bsh ON bsh.book_id = f.id
-       JOIN library_shelves sh ON sh.id = bsh.shelf_id
-WHERE sh.library_id = ANY($1) AND %s
-GROUP BY sh.id, sh.name
+SELECT 'shelf', l4.id::text, l4.name, COUNT(DISTINCT f.id)
+FROM f JOIN list_books lb4 ON lb4.book_id = f.id
+       JOIN lists l4 ON l4.id = lb4.list_id
+WHERE `+listVisible+` AND %s
+GROUP BY l4.id, l4.name
 UNION ALL
 SELECT 'rating', f.rating::text, f.rating::text, COUNT(*)
 FROM f WHERE f.rating IS NOT NULL AND %s GROUP BY f.rating

--- a/internal/repository/books.go
+++ b/internal/repository/books.go
@@ -485,7 +485,7 @@ type ListBooksOpts struct {
 	Letter     string           // single char: 'a'-'z' matches LIKE 'letter%'
 	TagFilter  string           // filter to books that have a tag with this exact name (case-insensitive)
 	SeriesIDs  []uuid.UUID      // filter to books in any of these series; how a collapsed series group is opened
-	ShelfIDs   []uuid.UUID      // filter to books on any of these shelves
+	ShelfIDs   []uuid.UUID      // filter to books on any of these lists (shelves are lists)
 	TypeFilter string           // filter by media type display name (case-insensitive), e.g. "Novel"
 	IsRegex    bool             // if true, use b.title ~* $query instead of ILIKE
 	Groups     []ConditionGroup // from query language parser; groups are ANDed together
@@ -561,16 +561,31 @@ func (r *BookRepo) buildBookFilter(libraryIDs []uuid.UUID, opts ListBooksOpts) b
 		argIdx++
 	}
 
-	// A shelf is a hand-picked set rather than a property of the book, but it
-	// narrows the list the same way a tag does, so it lives with the rest of
+	// A list is a hand-picked set rather than a property of the book, but it
+	// narrows the results the same way a tag does, so it lives with the rest of
 	// the conditions and the facet counts pick it up for free.
+	//
+	// Reads list_books rather than the shelf-shaped view over it. A shelf is a
+	// list shared with a library, so the view only sees those; filtering
+	// through it would silently return nothing for a private list, which is the
+	// ordinary case now that saved views and shelves are one thing.
+	//
+	// The visibility arm is load-bearing rather than defensive: list ids reach
+	// this from a query string, so without it anyone could read the contents of
+	// somebody else's list by guessing at one.
 	if len(opts.ShelfIDs) > 0 {
 		conditions = append(conditions, fmt.Sprintf(`EXISTS (
-            SELECT 1 FROM library_shelf_books bsh
-            WHERE bsh.book_id = b.id AND bsh.shelf_id = ANY($%d)
-        )`, argIdx))
-		args = append(args, opts.ShelfIDs)
-		argIdx++
+            SELECT 1 FROM list_books lb2
+            JOIN lists l2 ON l2.id = lb2.list_id
+            WHERE lb2.book_id = b.id AND lb2.list_id = ANY($%d)
+              AND (l2.owner_user_id = $%d
+                   OR (l2.visibility = 'library' AND EXISTS (
+                         SELECT 1 FROM user_permissions up2
+                          WHERE up2.user_id = $%d
+                            AND (up2.library_id IS NULL OR up2.library_id = l2.shared_library_id))))
+        )`, argIdx, argIdx+1, argIdx+1))
+		args = append(args, opts.ShelfIDs, opts.CallerID)
+		argIdx += 2
 	}
 
 	if opts.TagFilter != "" {

--- a/internal/repository/schema_tiers_live_test.go
+++ b/internal/repository/schema_tiers_live_test.go
@@ -1038,11 +1038,17 @@ func TestShelfWritesLandInLists(t *testing.T) {
 	}
 
 	shelfID := uuid.New()
+	// Registered before Create, not after. Create inserts and then reads back,
+	// so a failure in the read leaves the row behind, and a cleanup that only
+	// runs on success leaks it into the sidebar of whoever owns this database.
+	defer func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM lists WHERE id = $1`, shelfID)
+	}()
+
 	shelf, err := repo.Create(ctx, shelfID, libraryID, "test shelf", "desc", "#fff", "star", 3, userID)
 	if err != nil {
 		t.Fatalf("creating a shelf: %v", err)
 	}
-	defer func() { _ = repo.Delete(ctx, shelfID) }()
 	if shelf.Name != "test shelf" {
 		t.Errorf("shelf name = %q, want the one written", shelf.Name)
 	}
@@ -1331,5 +1337,71 @@ func TestSessionUpdateKeepsPageProgressHonest(t *testing.T) {
 	}
 	if after.EditionID == nil {
 		t.Error("the refused update cleared the edition anyway")
+	}
+}
+
+// TestListFilterRefusesSomebodyElsesList is the reason the filter carries a
+// visibility arm. List ids arrive from a query string, so filtering on one
+// without checking who owns it would let anyone read the contents of a private
+// list by guessing at an id.
+func TestListFilterRefusesSomebodyElsesList(t *testing.T) {
+	pool, ctx := tiersPool(t)
+	lists := NewListRepo(pool)
+	books := NewBookRepo(pool)
+
+	var owner, stranger, bookID uuid.UUID
+	rows, err := pool.Query(ctx, `SELECT id FROM users LIMIT 2`)
+	if err != nil {
+		t.Skipf("no users: %v", err)
+	}
+	var ids []uuid.UUID
+	for rows.Next() {
+		var id uuid.UUID
+		if err := rows.Scan(&id); err != nil {
+			t.Fatalf("scanning: %v", err)
+		}
+		ids = append(ids, id)
+	}
+	rows.Close()
+	if len(ids) < 2 {
+		t.Skip("need two users to test one hiding a list from the other")
+	}
+	owner, stranger = ids[0], ids[1]
+	// Picked from copies rather than books: the filter runs inside a
+	// library-scoped list, so a book nothing holds would return zero for both
+	// callers and the test would pass without testing anything.
+	var libraryID uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`SELECT book_id, library_id FROM copies WHERE deleted_at IS NULL LIMIT 1`).
+		Scan(&bookID, &libraryID); err != nil {
+		t.Skipf("no copies: %v", err)
+	}
+
+	l, err := lists.Create(ctx, CreateListInput{
+		OwnerUserID: owner, Name: "test private list", Kind: "manual", Visibility: "private",
+	})
+	if err != nil {
+		t.Fatalf("creating: %v", err)
+	}
+	defer func() { _ = lists.Delete(ctx, l.ID) }()
+	if err := lists.AddBook(ctx, l.ID, bookID, 0); err != nil {
+		t.Fatalf("adding a book: %v", err)
+	}
+
+	count := func(caller uuid.UUID) int {
+		_, total, err := books.List(ctx, libraryID, ListBooksOpts{
+			CallerID: caller, ShelfIDs: []uuid.UUID{l.ID}, PerPage: 50,
+		})
+		if err != nil {
+			t.Fatalf("listing as %s: %v", caller, err)
+		}
+		return total
+	}
+
+	if got := count(owner); got != 1 {
+		t.Errorf("the owner sees %d books in their own list, want 1", got)
+	}
+	if got := count(stranger); got != 0 {
+		t.Errorf("a stranger filtering on someone else's private list sees %d books, want 0", got)
 	}
 }


### PR DESCRIPTION
Shelves and saved views are one concept now, and most lists are private, so filtering on one returned nothing and it had no count in the rail. Both the filter and the facet now read `lists` directly.

- The visibility arm is load-bearing: list ids arrive from a query string, so without it a guessed id would read someone else's list.