### PR TITLE
Revert the golang 1.27-alpine build image bump

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Pinned to the BUILD platform: without this, buildx runs the arm64 leg under
 # QEMU emulation. Go cross-compiles natively.
-FROM --platform=$BUILDPLATFORM golang:1.27-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download


### PR DESCRIPTION
Merged by mistake rather than by decision: a bare `gh pr merge 80` run from this repo's directory hit this PR instead of the web one with the same number.

- Nothing was wrong with it. CI was green and `main` stayed green after it, so this is about the choice not having been made, not about a breakage.
- Back on `golang:1.26-alpine`; the image builds on it.