### PR TITLE
Stop dropping reading progress the iOS client sends

### DIFF
--- a/internal/api/handlers/reading_state.go
+++ b/internal/api/handlers/reading_state.go
@@ -88,6 +88,11 @@ func (h *ReadingStateHandler) GetMyBook(w http.ResponseWriter, r *http.Request) 
 // rated and never moves through containment.
 func readingStateBody(ub *models.UserBook) map[string]any {
 	return map[string]any{
+		// The row id, which sync addresses ops by. Absent from the default
+		// answer below, because a book nobody has said anything about has no
+		// row yet and inventing an id would have clients queue edits against
+		// one that does not exist.
+		"id":          ub.ID,
 		"book_id":     ub.BookID,
 		"read_status": ub.ReadStatus,
 		"rating":      ub.Rating,

--- a/internal/db/migrations/000031_session_progress_updated_at.down.sql
+++ b/internal/db/migrations/000031_session_progress_updated_at.down.sql
@@ -1,0 +1,5 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Copyright (C) 2026 FireBall1725
+
+DROP INDEX IF EXISTS reading_sessions_user_book_open_idx;
+ALTER TABLE reading_sessions DROP COLUMN IF EXISTS progress_updated_at;

--- a/internal/db/migrations/000031_session_progress_updated_at.up.sql
+++ b/internal/db/migrations/000031_session_progress_updated_at.up.sql
@@ -1,0 +1,25 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Copyright (C) 2026 FireBall1725
+
+-- progress_updated_at: when the progress on this pass last changed.
+--
+-- Sync is per-field last-writer-wins, so every field it carries needs its own
+-- timestamp to compare against. Progress moved from the old interactions row
+-- (which had one) to reading_sessions (which did not), so the sync path had
+-- nothing to compare and rejected the field outright.
+--
+-- Rejecting was worse than it looked. The iOS client treats a rejected op as
+-- acknowledged and deletes it, so a reader who set their page count watched it
+-- save locally and never leave the device. That is silent data loss, and it is
+-- the shipping client, not a hypothetical one.
+--
+-- Nullable, with no backfill: a session nobody has recorded progress against
+-- has no such moment, and inventing created_at would claim progress was set
+-- when the session was opened.
+ALTER TABLE reading_sessions ADD COLUMN IF NOT EXISTS progress_updated_at TIMESTAMPTZ;
+
+-- The sync read finds the pass a book's progress belongs to. One open session
+-- per book is the common case; the index keeps it a lookup rather than a scan.
+CREATE INDEX IF NOT EXISTS reading_sessions_user_book_open_idx
+    ON reading_sessions (user_id, book_id, created_at DESC)
+ WHERE finished_at IS NULL;

--- a/internal/db/migrations/000032_legacy_interaction_ids.down.sql
+++ b/internal/db/migrations/000032_legacy_interaction_ids.down.sql
@@ -1,0 +1,4 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Copyright (C) 2026 FireBall1725 (Adaléa)
+
+DROP TABLE IF EXISTS legacy_interaction_ids;

--- a/internal/db/migrations/000032_legacy_interaction_ids.up.sql
+++ b/internal/db/migrations/000032_legacy_interaction_ids.up.sql
@@ -1,0 +1,40 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Copyright (C) 2026 FireBall1725 (Adaléa)
+
+-- A forwarding address for interaction ids clients are still holding.
+--
+-- 000027 gave user_books a surrogate id for sync and generated fresh UUIDs for
+-- it. Its own comment said clients presenting an old id would get not_found,
+-- re-read from /sync/changes, and lose nothing but a round trip.
+--
+-- That is not what the shipping iOS client does. It treats not_found as
+-- acknowledged and deletes the op, alongside applied and discarded_stale. So
+-- every edit queued offline before an upgrade would be aimed at an id that no
+-- longer resolves and thrown away: a rating set on a plane, a book marked read
+-- in a basement, gone on reconnect with nothing said.
+--
+-- The old ids cannot simply be reused, because several per-edition rows can
+-- collapse into one per-work row and only one of them could win. A forwarding
+-- table keeps every one of them resolvable.
+CREATE TABLE IF NOT EXISTS legacy_interaction_ids (
+    legacy_id    UUID PRIMARY KEY,
+    user_book_id UUID NOT NULL
+);
+
+-- Only meaningful where the old table still exists, which is every install that
+-- upgraded rather than started fresh. Contract drops it with the rest.
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM information_schema.tables
+                WHERE table_schema = current_schema() AND table_name = 'user_book_interactions') THEN
+        INSERT INTO legacy_interaction_ids (legacy_id, user_book_id)
+        SELECT ubi.id, ub.id
+          FROM user_book_interactions ubi
+          JOIN book_editions be ON be.id = ubi.book_edition_id
+          JOIN user_books ub ON ub.user_id = ubi.user_id AND ub.book_id = be.book_id
+        ON CONFLICT (legacy_id) DO NOTHING;
+    END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS legacy_interaction_ids_target_idx
+    ON legacy_interaction_ids (user_book_id);

--- a/internal/models/user_book.go
+++ b/internal/models/user_book.go
@@ -19,6 +19,11 @@ import (
 // forbade outright. Borrowing a book, rating it, and buying it later becomes a
 // thing the schema can express.
 type UserBook struct {
+	// ID is the surrogate key sync addresses ops by. The natural key is
+	// (user_id, book_id); this exists because the sync protocol hands clients
+	// an opaque id and takes it back, and changing that shape would put a
+	// schema change on the App Store's release schedule.
+	ID     uuid.UUID `json:"id"`
 	UserID uuid.UUID `json:"user_id"`
 	BookID uuid.UUID `json:"book_id"`
 

--- a/internal/repository/editions.go
+++ b/internal/repository/editions.go
@@ -296,7 +296,7 @@ func (r *EditionRepo) bookOfEdition(ctx context.Context, editionID uuid.UUID) (u
 // pass through the book, not the verdict on it.
 func (r *EditionRepo) readInteraction(ctx context.Context, userID, editionID, bookID uuid.UUID) (*models.UserBookInteraction, error) {
 	const q = `
-		SELECT ub.user_id, ub.read_status, ub.rating, COALESCE(ub.notes,''), COALESCE(ub.review,''),
+		SELECT ub.id, ub.user_id, ub.read_status, ub.rating, COALESCE(ub.notes,''), COALESCE(ub.review,''),
 		       ub.is_favorite, ub.created_at, ub.updated_at,
 		       (SELECT min(rs.started_at) FROM reading_sessions rs
 		         WHERE rs.user_id = ub.user_id AND rs.book_id = ub.book_id),
@@ -310,8 +310,12 @@ func (r *EditionRepo) readInteraction(ctx context.Context, userID, editionID, bo
 
 	var i models.UserBookInteraction
 	var sessions int
+	// The id is load-bearing rather than decoration: the sync outbox addresses
+	// ops by it, so returning the zero UUID here would have every offline edit
+	// aimed at a row that does not exist, acknowledged as not_found, and
+	// dropped by the client.
 	err := r.db.QueryRow(ctx, q, userID, bookID).Scan(
-		&i.UserID, &i.ReadStatus, &i.Rating, &i.Notes, &i.Review,
+		&i.ID, &i.UserID, &i.ReadStatus, &i.Rating, &i.Notes, &i.Review,
 		&i.IsFavorite, &i.CreatedAt, &i.UpdatedAt,
 		&i.DateStarted, &i.DateFinished, &sessions)
 	if errors.Is(err, pgx.ErrNoRows) {

--- a/internal/repository/schema_tiers_live_test.go
+++ b/internal/repository/schema_tiers_live_test.go
@@ -1500,3 +1500,43 @@ func TestSyncProgressRoundTrips(t *testing.T) {
 		t.Error("progress was stored but never sent back, so another device would never see it")
 	}
 }
+
+// TestInteractionCarriesItsRowID guards a field that looks like decoration and
+// is not.
+//
+// The iOS outbox addresses every offline edit by interaction.id. This read
+// briefly returned the zero UUID, which parses as a perfectly good UUID on the
+// client, so edits were aimed at a row that does not exist, acknowledged as
+// not_found, and deleted. The old routes still serve clients in the field, so
+// the id has to be real there and not only on the new ones.
+func TestInteractionCarriesItsRowID(t *testing.T) {
+	pool, ctx := tiersPool(t)
+	repo := NewEditionRepo(pool)
+
+	var userID, editionID, wantID uuid.UUID
+	err := pool.QueryRow(ctx,
+		`SELECT ub.user_id, be.id, ub.id
+		   FROM user_books ub
+		   JOIN book_editions be ON be.book_id = ub.book_id
+		  WHERE ub.deleted_at IS NULL
+		  LIMIT 1`).Scan(&userID, &editionID, &wantID)
+	if err != nil {
+		t.Skipf("no opinion on a book with an edition: %v", err)
+	}
+
+	got, err := repo.GetInteraction(ctx, userID, editionID)
+	if err != nil {
+		t.Fatalf("reading the interaction: %v", err)
+	}
+	if got.ID == uuid.Nil {
+		t.Fatal("interaction came back with the zero id; every outbox op addressed to it would be dropped")
+	}
+	if got.ID != wantID {
+		t.Errorf("id = %s, want the user_books row id %s", got.ID, wantID)
+	}
+	// Still the edition that was asked for, since old clients key their local
+	// store on it.
+	if got.BookEditionID != editionID {
+		t.Errorf("book_edition_id = %s, want the edition requested %s", got.BookEditionID, editionID)
+	}
+}

--- a/internal/repository/schema_tiers_live_test.go
+++ b/internal/repository/schema_tiers_live_test.go
@@ -1540,3 +1540,75 @@ func TestInteractionCarriesItsRowID(t *testing.T) {
 		t.Errorf("book_edition_id = %s, want the edition requested %s", got.BookEditionID, editionID)
 	}
 }
+
+// TestLegacySyncIDsStillResolve covers the upgrade path for a client that was
+// offline across it.
+//
+// 000027 minted fresh surrogate ids for user_books, so an id cached before the
+// upgrade addresses nothing. Its comment said the client would get not_found
+// and re-read, losing only a round trip. The shipping iOS client instead treats
+// not_found as acknowledged and deletes the op, so every edit queued offline
+// before the upgrade would be thrown away on reconnect.
+func TestLegacySyncIDsStillResolve(t *testing.T) {
+	pool, ctx := tiersPool(t)
+	repo := NewSyncRepo(pool)
+
+	var legacyID, userBookID, userID uuid.UUID
+	err := pool.QueryRow(ctx,
+		`SELECT l.legacy_id, l.user_book_id, ub.user_id
+		   FROM legacy_interaction_ids l
+		   JOIN user_books ub ON ub.id = l.user_book_id
+		  WHERE ub.deleted_at IS NULL
+		  LIMIT 1`).Scan(&legacyID, &userBookID, &userID)
+	if err != nil {
+		t.Skipf("no forwarded ids: %v", err)
+	}
+	if legacyID == userBookID {
+		t.Skip("this install kept its ids, so there is nothing to forward")
+	}
+
+	// An op addressed the old way has to land, not be answered not_found.
+	before := time.Now()
+	status, err := repo.ApplyUserBookInteractionOp(ctx, userID, responses.SyncApplyOp{
+		EntityType: "user_book_interaction",
+		EntityID:   legacyID,
+		Field:      "is_favorite",
+		Value:      true,
+		UpdatedAt:  before,
+	})
+	if err != nil {
+		t.Fatalf("applying through a legacy id: %v", err)
+	}
+	if status != SyncApplyStatusApplied {
+		t.Fatalf("a legacy id returned %q, want applied; not_found is what the client throws away", status)
+	}
+
+	var fav bool
+	if err := pool.QueryRow(ctx,
+		`SELECT is_favorite FROM user_books WHERE id = $1`, userBookID).Scan(&fav); err != nil {
+		t.Fatalf("re-reading: %v", err)
+	}
+	if !fav {
+		t.Error("the op was acknowledged but changed nothing")
+	}
+	// Put it back rather than leaving a favourite nobody set.
+	_, _ = pool.Exec(ctx,
+		`UPDATE user_books SET is_favorite = false, is_favorite_updated_at = NULL WHERE id = $1`,
+		userBookID)
+
+	// An id belonging to nobody still misses, so forwarding has not become a
+	// way to write to another person's row.
+	status, err = repo.ApplyUserBookInteractionOp(ctx, userID, responses.SyncApplyOp{
+		EntityType: "user_book_interaction",
+		EntityID:   uuid.New(),
+		Field:      "is_favorite",
+		Value:      true,
+		UpdatedAt:  before,
+	})
+	if err != nil {
+		t.Fatalf("applying an unknown id: %v", err)
+	}
+	if status != SyncApplyStatusNotFound {
+		t.Errorf("an unknown id returned %q, want not_found", status)
+	}
+}

--- a/internal/repository/schema_tiers_live_test.go
+++ b/internal/repository/schema_tiers_live_test.go
@@ -7,10 +7,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"github.com/fireball1725/librarium-api/internal/api/responses"
 	"github.com/fireball1725/librarium-api/internal/models"
 	"os"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -1403,5 +1405,98 @@ func TestListFilterRefusesSomebodyElsesList(t *testing.T) {
 	}
 	if got := count(stranger); got != 0 {
 		t.Errorf("a stranger filtering on someone else's private list sees %d books, want 0", got)
+	}
+}
+
+// TestSyncProgressRoundTrips covers a regression that lost real data.
+//
+// Progress moved from the interactions row to reading_sessions, and the sync
+// path briefly rejected the field on the reasoning that a client told invalid
+// would stop sending it. The shipping iOS client does the opposite: it treats
+// invalid as acknowledged and deletes the op, so a reader who set their page
+// count saw it save locally and never leave the device.
+func TestSyncProgressRoundTrips(t *testing.T) {
+	pool, ctx := tiersPool(t)
+	sync := NewSyncRepo(pool)
+
+	// A book with an edition, since a page number needs a printing to count in.
+	var userID, bookID uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`SELECT ub.user_id, ub.book_id FROM user_books ub
+		  WHERE ub.deleted_at IS NULL
+		    AND EXISTS (SELECT 1 FROM book_editions be WHERE be.book_id = ub.book_id)
+		  LIMIT 1`).Scan(&userID, &bookID); err != nil {
+		t.Skipf("no opinion on a book with an edition: %v", err)
+	}
+	var entityID uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`SELECT id FROM user_books WHERE user_id = $1 AND book_id = $2`,
+		userID, bookID).Scan(&entityID); err != nil {
+		t.Fatalf("finding the row: %v", err)
+	}
+
+	defer func() {
+		_, _ = pool.Exec(ctx,
+			`DELETE FROM reading_sessions WHERE user_id = $1 AND book_id = $2 AND progress_updated_at IS NOT NULL`,
+			userID, bookID)
+	}()
+	if _, err := pool.Exec(ctx,
+		`DELETE FROM reading_sessions WHERE user_id = $1 AND book_id = $2`, userID, bookID); err != nil {
+		t.Fatalf("clearing sessions: %v", err)
+	}
+
+	at := time.Now().Add(-time.Hour)
+	op := responses.SyncApplyOp{
+		EntityType: "user_book_interaction",
+		EntityID:   entityID,
+		Field:      "progress",
+		Value:      map[string]any{"pages_read": float64(120)},
+		UpdatedAt:  at,
+	}
+	status, err := sync.ApplyUserBookInteractionOp(ctx, userID, op)
+	if err != nil {
+		t.Fatalf("applying progress: %v", err)
+	}
+	if status != SyncApplyStatusApplied {
+		t.Fatalf("progress returned %q, want applied; invalid is what silently dropped it", status)
+	}
+
+	var unit string
+	var value float64
+	if err := pool.QueryRow(ctx,
+		`SELECT progress_unit, progress_value FROM reading_sessions
+		  WHERE user_id = $1 AND book_id = $2 AND finished_at IS NULL
+		  ORDER BY created_at DESC LIMIT 1`, userID, bookID).Scan(&unit, &value); err != nil {
+		t.Fatalf("progress was accepted but stored nowhere: %v", err)
+	}
+	if unit != "page" || value != 120 {
+		t.Errorf("stored %s=%v, want page=120", unit, value)
+	}
+
+	// An older op must not overwrite a newer value, the same rule every other
+	// synced field follows.
+	older := op
+	older.UpdatedAt = at.Add(-time.Hour)
+	older.Value = map[string]any{"pages_read": float64(5)}
+	if status, err := sync.ApplyUserBookInteractionOp(ctx, userID, older); err != nil {
+		t.Fatalf("applying an older op: %v", err)
+	} else if status != SyncApplyStatusDiscardedStale {
+		t.Errorf("an older progress op returned %q, want discarded_stale", status)
+	}
+
+	// And it comes back down, or a second device never learns it.
+	ops, err := sync.UserBookInteractionChanges(ctx, userID, at.Add(-2*time.Hour), 500)
+	if err != nil {
+		t.Fatalf("reading changes: %v", err)
+	}
+	// The feed is one op per changed field, so progress is its own row.
+	found := false
+	for _, o := range ops {
+		if o.EntityID == entityID && o.Field == "progress" && o.Value != nil {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("progress was stored but never sent back, so another device would never see it")
 	}
 }

--- a/internal/repository/sync.go
+++ b/internal/repository/sync.go
@@ -43,22 +43,38 @@ func NewSyncRepo(db *pgxpool.Pool) *SyncRepo {
 // that row (the row is gone; per-field state is moot).
 func (r *SyncRepo) UserBookInteractionChanges(ctx context.Context, userID uuid.UUID, since time.Time, limit int) ([]responses.SyncOp, error) {
 	const q = `
-		SELECT id,
-		       rating, rating_updated_at,
-		       read_status, read_status_updated_at,
-		       NULL::jsonb AS progress, NULL::timestamptz AS progress_updated_at,
-		       is_favorite, is_favorite_updated_at,
-		       updated_at, deleted_at
-		  FROM user_books
-		 WHERE user_id = $1
+		SELECT ub.id,
+		       ub.rating, ub.rating_updated_at,
+		       ub.read_status, ub.read_status_updated_at,
+		       -- Progress lives on the pass, not the verdict, so it is read
+		       -- from the caller's newest open session for this book. Sent
+		       -- back in the shape the client writes, so a device that did
+		       -- not set it still learns it.
+		       (SELECT jsonb_build_object('pages_read', rs.progress_value)
+		          FROM reading_sessions rs
+		         WHERE rs.user_id = ub.user_id AND rs.book_id = ub.book_id
+		           AND rs.finished_at IS NULL AND rs.progress_unit = 'page'
+		         ORDER BY rs.created_at DESC LIMIT 1) AS progress,
+		       (SELECT rs.progress_updated_at
+		          FROM reading_sessions rs
+		         WHERE rs.user_id = ub.user_id AND rs.book_id = ub.book_id
+		           AND rs.finished_at IS NULL
+		         ORDER BY rs.created_at DESC LIMIT 1) AS progress_updated_at,
+		       ub.is_favorite, ub.is_favorite_updated_at,
+		       ub.updated_at, ub.deleted_at
+		  FROM user_books ub
+		 WHERE ub.user_id = $1
 		   AND (
-		           updated_at             > $2
-		        OR rating_updated_at      > $2
-		        OR read_status_updated_at > $2
-		        OR is_favorite_updated_at > $2
-		        OR deleted_at             > $2
+		           ub.updated_at             > $2
+		        OR ub.rating_updated_at      > $2
+		        OR ub.read_status_updated_at > $2
+		        OR ub.is_favorite_updated_at > $2
+		        OR ub.deleted_at             > $2
+		        OR EXISTS (SELECT 1 FROM reading_sessions rs
+		                    WHERE rs.user_id = ub.user_id AND rs.book_id = ub.book_id
+		                      AND rs.progress_updated_at > $2)
 		       )
-		 ORDER BY updated_at ASC
+		 ORDER BY ub.updated_at ASC
 		 LIMIT $3`
 	rows, err := r.db.Query(ctx, q, userID, since, limit)
 	if err != nil {
@@ -201,16 +217,16 @@ func (r *SyncRepo) ApplyUserBookInteractionOp(ctx context.Context, userID uuid.U
 	case "progress":
 		// Progress moved to reading_sessions, where it is a unit and a value
 		// describing one pass through a book rather than an unvalidated blob on
-		// the verdict. It has no per-field timestamp there, so it cannot take
-		// part in per-field last-writer-wins, and pretending otherwise would
-		// mean inventing a timestamp to compare against.
+		// the verdict. The op still addresses the opinion row, so this resolves
+		// the pass it belongs to rather than asking the client to know about
+		// sessions.
 		//
-		// Rejected rather than silently accepted: a client that is told invalid
-		// stops sending it, where one told applied would keep pushing a value
-		// that goes nowhere. No collection seen so far has ever had a non-null
-		// progress, so this drops nothing real. Progress syncs again when the
-		// protocol gains a sessions entity.
-		return SyncApplyStatusInvalid, nil
+		// This briefly returned invalid instead, on the reasoning that a client
+		// told invalid would stop sending the field. The shipping iOS client
+		// does the opposite: it treats invalid as acknowledged and deletes the
+		// op, so a reader who set their page count saw it save locally and
+		// never leave the device.
+		return r.applyProgress(ctx, userID, op.EntityID, op.UpdatedAt, op.Value)
 	default:
 		return SyncApplyStatusInvalid, nil
 	}
@@ -220,6 +236,145 @@ func (r *SyncRepo) ApplyUserBookInteractionOp(ctx context.Context, userID uuid.U
 // server's timestamp for the field is older than the op's, or if the
 // field has never been touched. Skipped writes are reported as
 // discarded_stale unless the row doesn't exist at all (not_found).
+// applyProgress records how far through a book the caller is.
+//
+// The op addresses a user_books row, because that is what the sync protocol
+// has always addressed and old clients cannot be asked to know otherwise. The
+// pass it belongs to is resolved here: the caller's newest unfinished session
+// for that book, or a new one if they have none open.
+//
+// The unit is pages, which is what the client sends, and pages need an edition
+// because page 200 of a paperback is not page 200 of the omnibus. The client
+// counted against whichever printing it was showing, so the book's first
+// edition by position is the closest honest answer available server-side.
+func (r *SyncRepo) applyProgress(ctx context.Context, userID, entityID uuid.UUID, opTS time.Time, value any) (string, error) {
+	var bookID uuid.UUID
+	err := r.db.QueryRow(ctx,
+		`SELECT book_id FROM user_books WHERE id = $1 AND user_id = $2 AND deleted_at IS NULL`,
+		entityID, userID).Scan(&bookID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return r.classifyUBIMiss(ctx, userID, entityID)
+	}
+	if err != nil {
+		return "", fmt.Errorf("apply progress: finding the book: %w", err)
+	}
+
+	pages, ok := pagesReadFrom(value)
+	if !ok {
+		// A shape nobody writes. Rejected rather than stored, since a value the
+		// server cannot read is one no reader will ever see again.
+		return SyncApplyStatusInvalid, nil
+	}
+
+	// Update the open session if this op is newer than what it already holds,
+	// which is the same last-writer-wins rule every other field follows.
+	const update = `
+		UPDATE reading_sessions
+		   SET progress_unit       = CASE WHEN $3::numeric IS NULL THEN NULL ELSE 'page' END,
+		       progress_value      = $3,
+		       progress_updated_at = $4
+		 WHERE id = (SELECT id FROM reading_sessions
+		              WHERE user_id = $1 AND book_id = $2 AND finished_at IS NULL
+		              ORDER BY created_at DESC LIMIT 1)
+		   AND (progress_updated_at IS NULL OR progress_updated_at < $4)
+		   AND ($3::numeric IS NULL OR edition_id IS NOT NULL)
+		 RETURNING id`
+	var sessionID uuid.UUID
+	err = r.db.QueryRow(ctx, update, userID, bookID, pages, opTS).Scan(&sessionID)
+	if err == nil {
+		return SyncApplyStatusApplied, nil
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return "", fmt.Errorf("apply progress: %w", err)
+	}
+
+	// Nothing updated: either the caller has no open session, or the one they
+	// have already holds something newer, or it has no edition to count pages
+	// against. Only the first is worth acting on.
+	var openID uuid.UUID
+	var openTS *time.Time
+	err = r.db.QueryRow(ctx,
+		`SELECT id, progress_updated_at FROM reading_sessions
+		  WHERE user_id = $1 AND book_id = $2 AND finished_at IS NULL
+		  ORDER BY created_at DESC LIMIT 1`, userID, bookID).Scan(&openID, &openTS)
+	switch {
+	case err == nil && openTS != nil && !openTS.Before(opTS):
+		return SyncApplyStatusDiscardedStale, nil
+	case err == nil:
+		// An open session that the update skipped for want of an edition.
+		if pages == nil {
+			return SyncApplyStatusApplied, nil
+		}
+		if _, err := r.db.Exec(ctx,
+			`UPDATE reading_sessions SET edition_id = (
+			     SELECT id FROM book_editions WHERE book_id = $2
+			      ORDER BY position, created_at, id LIMIT 1)
+			  WHERE id = $1 AND edition_id IS NULL`, openID, bookID); err != nil {
+			return "", fmt.Errorf("apply progress: attaching an edition: %w", err)
+		}
+		if err := r.db.QueryRow(ctx, update, userID, bookID, pages, opTS).Scan(&sessionID); err != nil {
+			// No edition exists to count pages against, so there is nowhere
+			// honest to put a page number.
+			return SyncApplyStatusInvalid, nil
+		}
+		return SyncApplyStatusApplied, nil
+	case !errors.Is(err, pgx.ErrNoRows):
+		return "", fmt.Errorf("apply progress: reading the open session: %w", err)
+	}
+
+	// No open pass. Clearing progress on one that does not exist is already
+	// true, so it needs no row.
+	if pages == nil {
+		return SyncApplyStatusApplied, nil
+	}
+	const insert = `
+		INSERT INTO reading_sessions (user_id, book_id, edition_id, started_at, status,
+		                              progress_unit, progress_value, progress_updated_at)
+		SELECT $1, $2,
+		       (SELECT id FROM book_editions WHERE book_id = $2
+		         ORDER BY position, created_at, id LIMIT 1),
+		       $4, 'reading', 'page', $3, $4
+		 WHERE EXISTS (SELECT 1 FROM book_editions WHERE book_id = $2)`
+	tag, err := r.db.Exec(ctx, insert, userID, bookID, pages, opTS)
+	if err != nil {
+		return "", fmt.Errorf("apply progress: opening a session: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return SyncApplyStatusInvalid, nil
+	}
+	return SyncApplyStatusApplied, nil
+}
+
+// pagesReadFrom pulls the page count out of the progress blob the client sends.
+//
+// The wire shape is {pages_read?, percent?, position?} and the client only ever
+// writes pages_read; null clears it. Anything else is a shape nobody writes.
+func pagesReadFrom(value any) (*float64, bool) {
+	if value == nil {
+		return nil, true
+	}
+	obj, ok := value.(map[string]any)
+	if !ok {
+		return nil, false
+	}
+	raw, present := obj["pages_read"]
+	if !present || raw == nil {
+		return nil, true
+	}
+	switch v := raw.(type) {
+	case float64:
+		if v < 0 {
+			return nil, false
+		}
+		return &v, true
+	case int:
+		f := float64(v)
+		return &f, true
+	default:
+		return nil, false
+	}
+}
+
 func (r *SyncRepo) applyUBIField(ctx context.Context, userID, entityID uuid.UUID, opTS time.Time, valueCol, tsCol string, value interface{}) (string, error) {
 	q := fmt.Sprintf(`
 		UPDATE user_books

--- a/internal/repository/sync.go
+++ b/internal/repository/sync.go
@@ -184,6 +184,15 @@ func (r *SyncRepo) ApplyUserBookInteractionOp(ctx context.Context, userID uuid.U
 	if op.EntityType != "user_book_interaction" {
 		return SyncApplyStatusInvalid, nil
 	}
+	// An id from before the surrogate key existed still has to resolve. The
+	// client deletes an op it is told not_found, so failing to forward it is
+	// not a retry, it is the edit being thrown away.
+	entityID, err := r.resolveEntityID(ctx, userID, op.EntityID)
+	if err != nil {
+		return "", err
+	}
+	op.EntityID = entityID
+
 	if op.Deleted {
 		return r.applyUBITombstone(ctx, userID, op.EntityID, op.UpdatedAt)
 	}
@@ -420,6 +429,31 @@ func (r *SyncRepo) applyUBITombstone(ctx context.Context, userID, entityID uuid.
 // classifyUBIMiss runs after an apply UPDATE returned 0 rows. It
 // distinguishes "row doesn't exist (or wrong owner)" from "row exists
 // but the LWW comparison rejected the write."
+// resolveEntityID maps an id the client is holding onto the row it addresses.
+//
+// Current ids pass straight through. One minted before 000027 is looked up in
+// the forwarding table, which is why that table exists: several per-edition
+// rows could collapse into one per-work row, so the old ids could not simply be
+// reused and every one of them still has to resolve.
+//
+// An id that matches nothing is returned unchanged, so the miss is classified
+// downstream the way it always was.
+func (r *SyncRepo) resolveEntityID(ctx context.Context, userID, entityID uuid.UUID) (uuid.UUID, error) {
+	const q = `
+		SELECT CASE
+		         WHEN EXISTS (SELECT 1 FROM user_books WHERE id = $1 AND user_id = $2) THEN $1
+		         ELSE COALESCE((SELECT l.user_book_id
+		                          FROM legacy_interaction_ids l
+		                          JOIN user_books ub ON ub.id = l.user_book_id AND ub.user_id = $2
+		                         WHERE l.legacy_id = $1), $1)
+		       END`
+	var resolved uuid.UUID
+	if err := r.db.QueryRow(ctx, q, entityID, userID).Scan(&resolved); err != nil {
+		return uuid.Nil, fmt.Errorf("resolving entity id: %w", err)
+	}
+	return resolved, nil
+}
+
 func (r *SyncRepo) classifyUBIMiss(ctx context.Context, userID, entityID uuid.UUID) (string, error) {
 	const q = `SELECT EXISTS(SELECT 1 FROM user_books WHERE id = $1 AND user_id = $2)`
 	var exists bool

--- a/internal/repository/user_books.go
+++ b/internal/repository/user_books.go
@@ -37,14 +37,14 @@ func NewUserBookRepo(db *pgxpool.Pool) *UserBookRepo {
 }
 
 const userBookColumns = `
-	user_id, book_id, read_status, rating, is_favorite, review, notes, wants,
+	id, user_id, book_id, read_status, rating, is_favorite, review, notes, wants,
 	read_status_updated_at, rating_updated_at, is_favorite_updated_at,
 	created_at, updated_at, deleted_at`
 
 func scanUserBook(row pgx.Row) (*models.UserBook, error) {
 	var u models.UserBook
 	err := row.Scan(
-		&u.UserID, &u.BookID, &u.ReadStatus, &u.Rating, &u.IsFavorite,
+		&u.ID, &u.UserID, &u.BookID, &u.ReadStatus, &u.Rating, &u.IsFavorite,
 		&u.Review, &u.Notes, &u.Wants,
 		&u.ReadStatusUpdatedAt, &u.RatingUpdatedAt, &u.IsFavoriteUpdatedAt,
 		&u.CreatedAt, &u.UpdatedAt, &u.DeletedAt,


### PR DESCRIPTION
Progress moved to `reading_sessions` and the sync path rejected the field, on the reasoning that a client told invalid would stop sending it. The shipping iOS client does the opposite: it treats invalid as acknowledged and deletes the op, so a page count saved locally and never left the device.

- Resolves the pass the op belongs to rather than asking old clients to know about sessions.
- Progress reads back out too, so a second device learns it; that needs `progress_updated_at` (000031) for last-writer-wins.