### PR TITLE
List the lists that hold a book

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -3002,6 +3002,87 @@ const docTemplate = `{
                 }
             }
         },
+        "/books/{book_id}/lists": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Which of the caller's lists a book is on. Manual lists only: a smart list's membership is whatever its filter matches right now, and answering for one would mean running every stored filter to draw a label.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "me"
+                ],
+                "summary": "List my lists that hold a book",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Book UUID",
+                        "name": "book_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "items": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "color": {
+                                                "type": "string"
+                                            },
+                                            "icon": {
+                                                "type": "string"
+                                            },
+                                            "id": {
+                                                "type": "string"
+                                            },
+                                            "name": {
+                                                "type": "string"
+                                            },
+                                            "visibility": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/books/{book_id}/me": {
             "get": {
                 "security": [

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -2996,6 +2996,87 @@
                 }
             }
         },
+        "/books/{book_id}/lists": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Which of the caller's lists a book is on. Manual lists only: a smart list's membership is whatever its filter matches right now, and answering for one would mean running every stored filter to draw a label.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "me"
+                ],
+                "summary": "List my lists that hold a book",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Book UUID",
+                        "name": "book_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "items": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "color": {
+                                                "type": "string"
+                                            },
+                                            "icon": {
+                                                "type": "string"
+                                            },
+                                            "id": {
+                                                "type": "string"
+                                            },
+                                            "name": {
+                                                "type": "string"
+                                            },
+                                            "visibility": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/books/{book_id}/me": {
             "get": {
                 "security": [

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -3424,6 +3424,59 @@ paths:
       summary: Re-enrich metadata for a single book
       tags:
       - books
+  /books/{book_id}/lists:
+    get:
+      description: 'Which of the caller''s lists a book is on. Manual lists only:
+        a smart list''s membership is whatever its filter matches right now, and answering
+        for one would mean running every stored filter to draw a label.'
+      parameters:
+      - description: Book UUID
+        in: path
+        name: book_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            properties:
+              items:
+                items:
+                  properties:
+                    color:
+                      type: string
+                    icon:
+                      type: string
+                    id:
+                      type: string
+                    name:
+                      type: string
+                    visibility:
+                      type: string
+                  type: object
+                type: array
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: List my lists that hold a book
+      tags:
+      - me
   /books/{book_id}/me:
     delete:
       description: Soft-deletes the caller's opinion. The review and notes history

--- a/internal/api/handlers/lists.go
+++ b/internal/api/handlers/lists.go
@@ -54,6 +54,32 @@ func (h *ListHandler) ListMyLists(w http.ResponseWriter, r *http.Request) {
 	respond.JSON(w, http.StatusOK, map[string]any{"items": lists})
 }
 
+// ListsHoldingBook godoc
+//
+// @Summary     List my lists that hold a book
+// @Description Which of the caller's lists a book is on. Manual lists only: a smart list's membership is whatever its filter matches right now, and answering for one would mean running every stored filter to draw a label.
+// @Tags        me
+// @Produce     json
+// @Security    BearerAuth
+// @Param       book_id  path  string  true  "Book UUID"
+// @Success     200  {object}  object{items=[]object{id=string,name=string,icon=string,color=string,visibility=string}}
+// @Failure     400  {object}  object{error=string}
+// @Failure     401  {object}  object{error=string}
+// @Router      /books/{book_id}/lists [get]
+func (h *ListHandler) ListsHoldingBook(w http.ResponseWriter, r *http.Request) {
+	bookID, ok := bookIDOf(r)
+	if !ok {
+		respond.Error(w, http.StatusBadRequest, "invalid book id")
+		return
+	}
+	items, err := h.lists.ContainingBook(r.Context(), callerOf(r), bookID)
+	if err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
+	respond.JSON(w, http.StatusOK, map[string]any{"items": items})
+}
+
 type listBody struct {
 	Name            string          `json:"name"`
 	Description     string          `json:"description"`

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -236,6 +236,7 @@ func NewRouter(ctx context.Context, db *pgxpool.Pool, cfg *config.Config, riverC
 
 	// Lists are what shelves and saved views became.
 	mux.Handle("GET /api/v1/me/lists", requireAuth(http.HandlerFunc(listHandler.ListMyLists)))
+	mux.Handle("GET /api/v1/books/{book_id}/lists", requireAuth(http.HandlerFunc(listHandler.ListsHoldingBook)))
 	mux.Handle("POST /api/v1/me/lists", requireAuth(http.HandlerFunc(listHandler.CreateList)))
 	mux.Handle("PATCH /api/v1/me/lists/{list_id}", requireAuth(http.HandlerFunc(listHandler.UpdateList)))
 	mux.Handle("DELETE /api/v1/me/lists/{list_id}", requireAuth(http.HandlerFunc(listHandler.DeleteList)))

--- a/internal/repository/lists.go
+++ b/internal/repository/lists.go
@@ -405,6 +405,47 @@ func (r *ListRepo) RemoveBook(ctx context.Context, listID, bookID uuid.UUID) err
 	return nil
 }
 
+// ContainingBook returns the caller's lists that hold a book.
+//
+// The reverse of BookIDs, and the one a book page asks: "which of my lists is
+// this on". Manual lists only, because a smart list's membership is whatever
+// its filter matches right now and answering for one would mean running every
+// stored filter to draw a label.
+//
+// Scoped to the caller's own lists plus anything shared into a library they can
+// reach, the same visibility rule the filter and the facet follow.
+func (r *ListRepo) ContainingBook(ctx context.Context, userID, bookID uuid.UUID) ([]*models.List, error) {
+	q := `
+		SELECT ` + listColumns + `
+		  FROM lists l
+		  JOIN list_books lb ON lb.list_id = l.id AND lb.book_id = $2
+		 WHERE l.kind = 'manual'
+		   AND (l.owner_user_id = $1
+		        OR (l.visibility = 'library' AND EXISTS (
+		              SELECT 1 FROM user_permissions up
+		               WHERE up.user_id = $1
+		                 AND (up.library_id IS NULL OR up.library_id = l.shared_library_id))))
+		 ORDER BY l.display_order, l.name`
+
+	rows, err := r.db.Query(ctx, q, userID, bookID)
+	if err != nil {
+		return nil, fmt.Errorf("listing the lists holding a book: %w", err)
+	}
+	defer rows.Close()
+
+	// Initialised rather than nil: a nil slice marshals to null and the React
+	// client crashes where it expects an array.
+	out := make([]*models.List, 0)
+	for rows.Next() {
+		l, err := scanList(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scanning list: %w", err)
+		}
+		out = append(out, l)
+	}
+	return out, rows.Err()
+}
+
 // BookIDs returns a manual list's contents in order. A smart list's contents
 // come from running its filter, which is the caller's job.
 func (r *ListRepo) BookIDs(ctx context.Context, listID uuid.UUID) ([]uuid.UUID, error) {

--- a/internal/repository/schema_tiers_live_test.go
+++ b/internal/repository/schema_tiers_live_test.go
@@ -1612,3 +1612,85 @@ func TestLegacySyncIDsStillResolve(t *testing.T) {
 		t.Errorf("an unknown id returned %q, want not_found", status)
 	}
 }
+
+// TestListsHoldingBookRespectsVisibility covers the reverse lookup a book page
+// asks. It reads across every list in the table, so the visibility rule matters
+// as much here as it does in the filter.
+func TestListsHoldingBookRespectsVisibility(t *testing.T) {
+	pool, ctx := tiersPool(t)
+	repo := NewListRepo(pool)
+
+	var owner, stranger, bookID uuid.UUID
+	rows, err := pool.Query(ctx, `SELECT id FROM users LIMIT 2`)
+	if err != nil {
+		t.Skipf("no users: %v", err)
+	}
+	var ids []uuid.UUID
+	for rows.Next() {
+		var id uuid.UUID
+		if err := rows.Scan(&id); err != nil {
+			t.Fatalf("scanning: %v", err)
+		}
+		ids = append(ids, id)
+	}
+	rows.Close()
+	if len(ids) < 2 {
+		t.Skip("need two users")
+	}
+	owner, stranger = ids[0], ids[1]
+	if err := pool.QueryRow(ctx, `SELECT id FROM books LIMIT 1`).Scan(&bookID); err != nil {
+		t.Skipf("no books: %v", err)
+	}
+
+	manual, err := repo.Create(ctx, CreateListInput{
+		OwnerUserID: owner, Name: "test holding list", Kind: "manual", Visibility: "private",
+	})
+	if err != nil {
+		t.Fatalf("creating a manual list: %v", err)
+	}
+	defer func() { _ = repo.Delete(ctx, manual.ID) }()
+	if err := repo.AddBook(ctx, manual.ID, bookID, 0); err != nil {
+		t.Fatalf("adding the book: %v", err)
+	}
+
+	// A smart list is deliberately absent even when its filter would match:
+	// answering for one would mean running every stored filter to draw a label.
+	smart, err := repo.Create(ctx, CreateListInput{
+		OwnerUserID: owner, Name: "test holding smart", Kind: "smart",
+		Filter: []byte(`{"query":""}`),
+	})
+	if err != nil {
+		t.Fatalf("creating a smart list: %v", err)
+	}
+	defer func() { _ = repo.Delete(ctx, smart.ID) }()
+
+	mine, err := repo.ContainingBook(ctx, owner, bookID)
+	if err != nil {
+		t.Fatalf("reading as the owner: %v", err)
+	}
+	var sawManual, sawSmart bool
+	for _, l := range mine {
+		if l.ID == manual.ID {
+			sawManual = true
+		}
+		if l.ID == smart.ID {
+			sawSmart = true
+		}
+	}
+	if !sawManual {
+		t.Error("the owner cannot see their own list holding the book")
+	}
+	if sawSmart {
+		t.Error("a smart list was reported as holding a book; its membership is a filter, not a set")
+	}
+
+	theirs, err := repo.ContainingBook(ctx, stranger, bookID)
+	if err != nil {
+		t.Fatalf("reading as a stranger: %v", err)
+	}
+	for _, l := range theirs {
+		if l.ID == manual.ID {
+			t.Error("a stranger can see someone else's private list holding a book")
+		}
+	}
+}


### PR DESCRIPTION
The reverse of a list's contents, and what a book page asks. iOS needs it to show a book's lists including private ones, which `/me/shelves` cannot see.

- Manual lists only: a smart list's membership is a filter, not a set.
- Same visibility rule as the filter and the facet.