### PR TITLE
Lists that stay deleted, filter by author, and sit where each person put them

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -13260,6 +13260,72 @@ const docTemplate = `{
                 }
             }
         },
+        "/me/lists/order": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Records where the caller wants each view, including views shared\nwith them. Order belongs to a rail rather than to a view, so\nthis changes nothing for anyone else. Send every id, in order.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "me"
+                ],
+                "summary": "Arrange my own view rail",
+                "parameters": [
+                    {
+                        "description": "Every visible list id, in the order wanted",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "ids": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/me/lists/{list_id}": {
             "delete": {
                 "security": [

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -3640,8 +3640,13 @@ const docTemplate = `{
                         "type": "string",
                         "description": "Search query (min 2 chars)",
                         "name": "q",
-                        "in": "query",
-                        "required": true
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Comma-separated contributor ids to resolve by name",
+                        "name": "ids",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -3634,8 +3634,13 @@
                         "type": "string",
                         "description": "Search query (min 2 chars)",
                         "name": "q",
-                        "in": "query",
-                        "required": true
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Comma-separated contributor ids to resolve by name",
+                        "name": "ids",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -13254,6 +13254,72 @@
                 }
             }
         },
+        "/me/lists/order": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Records where the caller wants each view, including views shared\nwith them. Order belongs to a rail rather than to a view, so\nthis changes nothing for anyone else. Send every id, in order.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "me"
+                ],
+                "summary": "Arrange my own view rail",
+                "parameters": [
+                    {
+                        "description": "Every visible list id, in the order wanted",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "ids": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/me/lists/{list_id}": {
             "delete": {
                 "security": [

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -3838,7 +3838,10 @@ paths:
       - description: Search query (min 2 chars)
         in: query
         name: q
-        required: true
+        type: string
+      - description: Comma-separated contributor ids to resolve by name
+        in: query
+        name: ids
         type: string
       produces:
       - application/json

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -10257,6 +10257,50 @@ paths:
       summary: Put a book in one of my lists
       tags:
       - me
+  /me/lists/order:
+    put:
+      consumes:
+      - application/json
+      description: |-
+        Records where the caller wants each view, including views shared
+        with them. Order belongs to a rail rather than to a view, so
+        this changes nothing for anyone else. Send every id, in order.
+      parameters:
+      - description: Every visible list id, in the order wanted
+        in: body
+        name: body
+        required: true
+        schema:
+          properties:
+            ids:
+              items:
+                type: string
+              type: array
+          type: object
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Arrange my own view rail
+      tags:
+      - me
   /me/loans:
     get:
       description: |-

--- a/internal/api/handlers/books.go
+++ b/internal/api/handlers/books.go
@@ -67,11 +67,33 @@ func (h *BookHandler) ListMediaTypes(w http.ResponseWriter, r *http.Request) {
 // @Tags        books
 // @Produce     json
 // @Security    BearerAuth
-// @Param       q    query     string  true  "Search query (min 2 chars)"
+// @Param       q    query     string  false  "Search query (min 2 chars)"
+// @Param       ids  query     string  false  "Comma-separated contributor ids to resolve by name"
 // @Success     200  {array}   github_com_fireball1725_librarium-api_internal_api_responses.ContributorItem
 // @Failure     401  {object}  object{error=string}
 // @Router      /contributors [get]
 func (h *BookHandler) SearchContributors(w http.ResponseWriter, r *http.Request) {
+	// `ids` answers the other direction: a filter shared as a link carries the
+	// contributor id, and the client needs the name back to say whose books it
+	// is showing.
+	if raw := r.URL.Query().Get("ids"); raw != "" {
+		var ids []uuid.UUID
+		for _, part := range strings.Split(raw, ",") {
+			id, err := uuid.Parse(strings.TrimSpace(part))
+			if err != nil {
+				continue
+			}
+			ids = append(ids, id)
+		}
+		contributors, err := h.svc.ContributorsByIDs(r.Context(), ids)
+		if err != nil {
+			respond.ServerError(w, r, err)
+			return
+		}
+		respond.JSON(w, http.StatusOK, contributorItems(contributors))
+		return
+	}
+
 	q := r.URL.Query().Get("q")
 	if len(q) < 2 {
 		respond.JSON(w, http.StatusOK, []any{})
@@ -82,11 +104,15 @@ func (h *BookHandler) SearchContributors(w http.ResponseWriter, r *http.Request)
 		respond.ServerError(w, r, err)
 		return
 	}
-	out := make([]map[string]any, 0, len(contributors))
-	for _, c := range contributors {
+	respond.JSON(w, http.StatusOK, contributorItems(contributors))
+}
+
+func contributorItems(cs []*models.Contributor) []map[string]any {
+	out := make([]map[string]any, 0, len(cs))
+	for _, c := range cs {
 		out = append(out, map[string]any{"id": c.ID, "name": c.Name})
 	}
-	respond.JSON(w, http.StatusOK, out)
+	return out
 }
 
 // CreateContributor godoc

--- a/internal/api/handlers/books_across.go
+++ b/internal/api/handlers/books_across.go
@@ -275,6 +275,13 @@ func parseFacetSelection(r *http.Request) repository.FacetSelection {
 			sel.Libraries = append(sel.Libraries, id)
 		}
 	}
+	// By id, because naming an author is a different question from searching
+	// for their name: "Tite" the person is not a book with Tite in its title.
+	for _, s := range split("contributor") {
+		if id, err := uuid.Parse(s); err == nil {
+			sel.Contributors = append(sel.Contributors, id)
+		}
+	}
 	for _, s := range split("rating") {
 		if n, err := strconv.Atoi(s); err == nil && n >= 0 && n <= 5 {
 			sel.Ratings = append(sel.Ratings, int32(n))

--- a/internal/api/handlers/lists.go
+++ b/internal/api/handlers/lists.go
@@ -140,6 +140,47 @@ func (h *ListHandler) CreateList(w http.ResponseWriter, r *http.Request) {
 	respond.JSON(w, http.StatusCreated, list)
 }
 
+// SetListOrder godoc
+//
+// @Summary     Arrange my own view rail
+// @Description Records where the caller wants each view, including views shared
+// @Description with them. Order belongs to a rail rather than to a view, so
+// @Description this changes nothing for anyone else. Send every id, in order.
+// @Tags        me
+// @Accept      json
+// @Produce     json
+// @Security    BearerAuth
+// @Param       body  body  object{ids=[]string}  true  "Every visible list id, in the order wanted"
+// @Success     204
+// @Failure     400  {object}  object{error=string}
+// @Failure     401  {object}  object{error=string}
+// @Router      /me/lists/order [put]
+func (h *ListHandler) SetListOrder(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		IDs []string `json:"ids"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		respond.Error(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	ids := make([]uuid.UUID, 0, len(body.IDs))
+	for _, raw := range body.IDs {
+		id, err := uuid.Parse(raw)
+		if err != nil {
+			respond.Error(w, http.StatusBadRequest, "invalid list id")
+			return
+		}
+		ids = append(ids, id)
+	}
+
+	if err := h.lists.SetOrder(r.Context(), callerOf(r), ids); err != nil {
+		respond.ServerError(w, r, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
 // DeleteList godoc
 //
 // @Summary     Delete one of my lists

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -238,6 +238,7 @@ func NewRouter(ctx context.Context, db *pgxpool.Pool, cfg *config.Config, riverC
 	mux.Handle("GET /api/v1/me/lists", requireAuth(http.HandlerFunc(listHandler.ListMyLists)))
 	mux.Handle("GET /api/v1/books/{book_id}/lists", requireAuth(http.HandlerFunc(listHandler.ListsHoldingBook)))
 	mux.Handle("POST /api/v1/me/lists", requireAuth(http.HandlerFunc(listHandler.CreateList)))
+	mux.Handle("PUT /api/v1/me/lists/order", requireAuth(http.HandlerFunc(listHandler.SetListOrder)))
 	mux.Handle("PATCH /api/v1/me/lists/{list_id}", requireAuth(http.HandlerFunc(listHandler.UpdateList)))
 	mux.Handle("DELETE /api/v1/me/lists/{list_id}", requireAuth(http.HandlerFunc(listHandler.DeleteList)))
 	mux.Handle("POST /api/v1/me/lists/{list_id}/books/{book_id}", requireAuth(http.HandlerFunc(listHandler.AddBookToList)))

--- a/internal/db/migrations/000033_lists_seeded_once.down.sql
+++ b/internal/db/migrations/000033_lists_seeded_once.down.sql
@@ -1,0 +1,4 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Copyright (C) 2026 FireBall1725 (Adaléa)
+
+ALTER TABLE users DROP COLUMN IF EXISTS lists_seeded_at;

--- a/internal/db/migrations/000033_lists_seeded_once.up.sql
+++ b/internal/db/migrations/000033_lists_seeded_once.up.sql
@@ -1,0 +1,28 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Copyright (C) 2026 FireBall1725 (Adaléa)
+
+-- lists_seeded_at: when this person was given the example lists.
+--
+-- The lists shipped with the product were re-inserted on every read, because
+-- "has this user been seeded" had no honest answer without somewhere to record
+-- it. That made them undeletable in practice: removing one worked, and the next
+-- page load put it straight back.
+--
+-- They are examples, not fixtures. A reader should be able to rename Five stars,
+-- point it somewhere else, or throw it away and have that stick. Recording the
+-- moment they were handed over is what lets seeding happen once and then leave
+-- them alone.
+--
+-- Nullable: NULL means never seeded, which is exactly what an account created
+-- before this migration should look like, so anyone who has not yet been given
+-- the examples still gets them.
+ALTER TABLE users ADD COLUMN IF NOT EXISTS lists_seeded_at TIMESTAMPTZ;
+
+-- Anyone who already holds a built-in has plainly been seeded. Without this
+-- every existing account would be seeded a second time, resurrecting the exact
+-- rows they may have just deleted.
+UPDATE users u
+   SET lists_seeded_at = NOW()
+ WHERE u.lists_seeded_at IS NULL
+   AND EXISTS (SELECT 1 FROM lists l
+                WHERE l.owner_user_id = u.id AND l.builtin_key IS NOT NULL);

--- a/internal/db/migrations/000034_list_order_overrides.down.sql
+++ b/internal/db/migrations/000034_list_order_overrides.down.sql
@@ -1,0 +1,4 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Copyright (C) 2026 FireBall1725 (Adaléa)
+
+DROP TABLE IF EXISTS list_order_overrides;

--- a/internal/db/migrations/000034_list_order_overrides.up.sql
+++ b/internal/db/migrations/000034_list_order_overrides.up.sql
@@ -1,0 +1,32 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Copyright (C) 2026 FireBall1725 (Adaléa)
+
+-- Where each person put each view in their own sidebar.
+--
+-- lists.display_order is one number on one row, so it could only ever describe
+-- one arrangement. That was fine while every view belonged to the person
+-- looking at it, and stopped being fine the moment a view shared into a library
+-- appeared in someone else's rail: dragging it either moved it for everybody or
+-- failed, and it failed. The reorder is a PATCH on the list, the list is
+-- guarded by ownership, and the client swallowed the 404, so the row sprang
+-- back on the next load with nothing said.
+--
+-- Order is a property of a sidebar, not of a view. This table says so.
+CREATE TABLE IF NOT EXISTS list_order_overrides (
+    user_id       UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    list_id       UUID NOT NULL REFERENCES lists(id) ON DELETE CASCADE,
+    display_order INTEGER NOT NULL,
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (user_id, list_id)
+);
+
+-- The read is "every view this person can see, in their order", so the index
+-- covers the join and the sort together.
+CREATE INDEX IF NOT EXISTS list_order_overrides_user_idx
+    ON list_order_overrides (user_id, display_order);
+
+-- Nothing is backfilled on purpose. An absent row means "wherever the owner put
+-- it", which is the right starting point for a view someone has just been given
+-- and the right answer for every existing account, none of which has expressed
+-- an opinion yet. lists.display_order keeps its meaning as that seed rather
+-- than becoming dead weight.

--- a/internal/repository/book_facets.go
+++ b/internal/repository/book_facets.go
@@ -55,7 +55,18 @@ type FacetSelection struct {
 	// Shelves are hand-picked sets rather than a property of a book, but they
 	// narrow the list exactly like a tag does, so they are a facet dimension.
 	Shelves []uuid.UUID
-	Ratings []int32
+	// Contributors narrows to books someone worked on, by id.
+	//
+	// Not counted as a facet dimension: a collection has hundreds of them and a
+	// rail listing every author is a scrolling wall rather than a filter. It is
+	// a filter you reach by naming someone, which is what the search box is
+	// for.
+	//
+	// By id rather than by name, because the text search already matches
+	// contributor names loosely and that is a different question: "Tite" the
+	// author is not the same as a book with Tite in its title.
+	Contributors []uuid.UUID
+	Ratings      []int32
 	// Favourites filters on the starred flag. A slice rather than a *bool so
 	// it behaves like every other dimension: empty means not filtering.
 	Favourites []bool
@@ -126,6 +137,17 @@ func (r *BookRepo) Facets(
 		textWhere = fmt.Sprintf(`AND (b.title ILIKE %[1]s OR EXISTS (
             SELECT 1 FROM book_contributors bc JOIN contributors c ON c.id = bc.contributor_id
             WHERE bc.book_id = b.id AND c.name ILIKE %[1]s))`, p)
+	}
+
+	// Naming an author narrows every dimension, for the same reason the text
+	// search does: it is a filter rather than a counted dimension, so no
+	// dimension owns it and none may count around it. Leaving it out is how the
+	// rail ends up promising more than the page delivers.
+	if len(sel.Contributors) > 0 {
+		p := arg(sel.Contributors)
+		textWhere += fmt.Sprintf(` AND EXISTS (
+            SELECT 1 FROM book_contributors bc_f
+             WHERE bc_f.book_id = b.id AND bc_f.contributor_id = ANY(%s))`, p)
 	}
 
 	// Drilling into a series narrows every dimension, for the same reason the

--- a/internal/repository/book_facets.go
+++ b/internal/repository/book_facets.go
@@ -131,12 +131,24 @@ func (r *BookRepo) Facets(
 
 	// Text search is not a facet, so it narrows every dimension including the
 	// one being counted, and belongs in the base scope.
+	//
+	// Matched term by term, because that is what the list does: the list runs
+	// the query through the parser, which makes one condition per word, so
+	// "bleach tite" asks for both. Matching the whole phrase in one ILIKE here
+	// found nothing, and the rail reported zero of everything beside a list
+	// showing 82 books. A count that disagrees with its own rows is the tell.
+	//
+	// Operators (type:Manga, quotes, or, not) are still only understood by the
+	// list. They reach the facet query as ordinary words, so a rail beside one
+	// undercounts rather than overcounts, which is the safe direction.
 	textWhere := ""
-	if query != "" {
-		p := arg("%" + query + "%")
-		textWhere = fmt.Sprintf(`AND (b.title ILIKE %[1]s OR EXISTS (
-            SELECT 1 FROM book_contributors bc JOIN contributors c ON c.id = bc.contributor_id
-            WHERE bc.book_id = b.id AND c.name ILIKE %[1]s))`, p)
+	for _, term := range strings.Fields(query) {
+		// Three consecutive placeholders, all the same term: titleContainsSQL
+		// reads the term once for the plain match, once normalised, and once
+		// against contributor names.
+		base := len(args) + 1
+		args = append(args, term, term, term)
+		textWhere += " AND " + titleContainsSQL(base, asciiNormSpace)
 	}
 
 	// Naming an author narrows every dimension, for the same reason the text

--- a/internal/repository/books.go
+++ b/internal/repository/books.go
@@ -825,6 +825,17 @@ func (r *BookRepo) buildBookFilter(libraryIDs []uuid.UUID, opts ListBooksOpts) b
 		argIdx++
 	}
 
+	// Books someone worked on. EXISTS rather than a join, because a book with
+	// an author and an illustrator would otherwise appear once per credit.
+	if len(sel.Contributors) > 0 {
+		conditions = append(conditions, fmt.Sprintf(`EXISTS (
+            SELECT 1 FROM book_contributors bc3
+            WHERE bc3.book_id = b.id AND bc3.contributor_id = ANY($%d)
+        )`, argIdx))
+		args = append(args, sel.Contributors)
+		argIdx++
+	}
+
 	// Reading state is one row per work, so these are direct lookups. They were
 	// correlated subqueries collapsing per-edition rows, because joining
 	// editions would multiply a work with three printings into three rows and

--- a/internal/repository/contributors.go
+++ b/internal/repository/contributors.go
@@ -105,6 +105,35 @@ func (r *ContributorRepo) Search(ctx context.Context, query string, limit int) (
 	return out, rows.Err()
 }
 
+// ByIDs returns the named contributors, for turning ids that arrived in a URL
+// back into names. A filter shared as a link carries the id, so without this
+// the chip standing for it would have nothing to say.
+func (r *ContributorRepo) ByIDs(ctx context.Context, ids []uuid.UUID) ([]*models.Contributor, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	q := `SELECT ` + contributorCols + `
+		FROM contributors c
+		WHERE c.id = ANY($1)
+		ORDER BY c.name`
+
+	rows, err := r.db.Query(ctx, q, ids)
+	if err != nil {
+		return nil, fmt.Errorf("loading contributors: %w", err)
+	}
+	defer rows.Close()
+
+	var out []*models.Contributor
+	for rows.Next() {
+		c, err := scanFullContributor(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}
+
 // ListForLibrary returns all contributors who have at least one book in the given
 // library, ordered by name. BookCount is set to the number of distinct books in
 // that library for each contributor.

--- a/internal/repository/lists.go
+++ b/internal/repository/lists.go
@@ -90,12 +90,34 @@ func NewListRepo(db *pgxpool.Pool) *ListRepo {
 	return &ListRepo{db: db}
 }
 
-const listColumns = `
+// listColumns selects a list, with orderExpr standing in for the position it
+// occupies in the rail being built. Ownership does not decide that any more:
+// a view shared into a library sits wherever its reader dragged it, which is a
+// different number for each of them, so the query asking for a particular
+// person's rail supplies their own expression.
+func listColumns(orderExpr string) string {
+	return `
 	l.id, l.owner_user_id, l.name, l.description, l.icon, l.color,
-	l.kind, l.filter, l.filter_version, l.layout, l.display_order,
+	l.kind, l.filter, l.filter_version, l.layout, ` + orderExpr + `,
 	l.visibility, l.shared_library_id, COALESCE(l.share_token, ''),
 	(SELECT count(*) FROM list_books lb WHERE lb.list_id = l.id),
 	COALESCE(l.builtin_key, ''), l.created_at, l.updated_at`
+}
+
+// ownOrder is the list's own position, for reads that are not building one
+// person's rail: a lookup by id, a public share, the lists holding a book.
+const ownOrder = "l.display_order"
+
+// railOrder is where the caller put it, falling back to where its owner did.
+// An absent override is not "position zero", it is "no opinion yet", which is
+// what everyone starts with and what someone newly given a shared view should
+// see until they move it.
+const railOrder = "COALESCE(o.display_order, l.display_order)"
+
+// railOrderJoin binds railOrder to a caller. Kept beside it so the two cannot
+// drift apart: railOrder without this join is a query that will not compile.
+const railOrderJoin = `LEFT JOIN list_order_overrides o
+	                          ON o.list_id = l.id AND o.user_id = $1`
 
 func scanList(row pgx.Row) (*models.List, error) {
 	var l models.List
@@ -121,13 +143,14 @@ func scanList(row pgx.Row) (*models.List, error) {
 // show only the books its viewer could already see, and that rule is easy to
 // forget one call site at a time.
 func (r *ListRepo) ListForUser(ctx context.Context, userID uuid.UUID) ([]*models.List, error) {
-	q := `SELECT ` + listColumns + `
+	q := `SELECT ` + listColumns(railOrder) + `
 	        FROM lists l
+	        ` + railOrderJoin + `
 	       WHERE l.owner_user_id = $1
 	          OR (l.visibility = 'library'
 	              AND EXISTS (SELECT 1 FROM user_roles ur
 	                           WHERE ur.user_id = $1 AND ur.library_id = l.shared_library_id))
-	       ORDER BY l.display_order, l.name`
+	       ORDER BY ` + railOrder + `, l.name`
 
 	rows, err := r.db.Query(ctx, q, userID)
 	if err != nil {
@@ -147,7 +170,7 @@ func (r *ListRepo) ListForUser(ctx context.Context, userID uuid.UUID) ([]*models
 }
 
 func (r *ListRepo) FindByID(ctx context.Context, id uuid.UUID) (*models.List, error) {
-	q := `SELECT ` + listColumns + ` FROM lists l WHERE l.id = $1`
+	q := `SELECT ` + listColumns(ownOrder) + ` FROM lists l WHERE l.id = $1`
 	l, err := scanList(r.db.QueryRow(ctx, q, id))
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, ErrNotFound
@@ -161,7 +184,7 @@ func (r *ListRepo) FindByID(ctx context.Context, id uuid.UUID) (*models.List, er
 // FindByShareToken resolves a public link. Only public lists resolve: a token
 // left over from a list that has since been made private is not a way in.
 func (r *ListRepo) FindByShareToken(ctx context.Context, token string) (*models.List, error) {
-	q := `SELECT ` + listColumns + ` FROM lists l
+	q := `SELECT ` + listColumns(ownOrder) + ` FROM lists l
 	       WHERE l.share_token = $1 AND l.visibility = 'public'`
 
 	l, err := scanList(r.db.QueryRow(ctx, q, token))
@@ -392,6 +415,43 @@ func (r *ListRepo) Delete(ctx context.Context, id uuid.UUID) error {
 	return nil
 }
 
+// SetOrder records where this person wants each view in their own rail.
+//
+// Takes the whole rail rather than one move, because a drag renumbers every row
+// after it and sending them one at a time leaves the rail in a half-applied
+// order if any request fails. It also replaces the old shape, which PATCHed
+// display_order on the list itself: that is a column the caller may not own, so
+// dragging a shared view 404ed and the client swallowed it.
+//
+// Ids the caller cannot see are ignored rather than refused. The rail is built
+// from what they can see, so an id outside it is a stale client, and failing
+// the whole reorder over one dead row would strand the rest.
+func (r *ListRepo) SetOrder(ctx context.Context, userID uuid.UUID, ids []uuid.UUID) error {
+	if len(ids) == 0 {
+		return nil
+	}
+
+	// WITH ORDINALITY carries the caller's ordering into the insert, so
+	// position comes from where the id sits in the array rather than from a
+	// round trip per row.
+	q := `
+		INSERT INTO list_order_overrides (user_id, list_id, display_order)
+		SELECT $1, v.id, v.ord - 1
+		  FROM unnest($2::uuid[]) WITH ORDINALITY AS v(id, ord)
+		  JOIN lists l ON l.id = v.id
+		 WHERE l.owner_user_id = $1
+		    OR (l.visibility = 'library'
+		        AND EXISTS (SELECT 1 FROM user_roles ur
+		                     WHERE ur.user_id = $1 AND ur.library_id = l.shared_library_id))
+		    ON CONFLICT (user_id, list_id)
+		    DO UPDATE SET display_order = EXCLUDED.display_order, updated_at = NOW()`
+
+	if _, err := r.db.Exec(ctx, q, userID, ids); err != nil {
+		return fmt.Errorf("saving list order: %w", err)
+	}
+	return nil
+}
+
 // AddBook puts a work in a manual list.
 func (r *ListRepo) AddBook(ctx context.Context, listID, bookID uuid.UUID, position float64) error {
 	kind, err := r.kindOf(ctx, listID)
@@ -442,7 +502,7 @@ func (r *ListRepo) RemoveBook(ctx context.Context, listID, bookID uuid.UUID) err
 // reach, the same visibility rule the filter and the facet follow.
 func (r *ListRepo) ContainingBook(ctx context.Context, userID, bookID uuid.UUID) ([]*models.List, error) {
 	q := `
-		SELECT ` + listColumns + `
+		SELECT ` + listColumns(ownOrder) + `
 		  FROM lists l
 		  JOIN list_books lb ON lb.list_id = l.id AND lb.book_id = $2
 		 WHERE l.kind = 'manual'

--- a/internal/repository/lists.go
+++ b/internal/repository/lists.go
@@ -57,6 +57,9 @@ type BuiltinList struct {
 }
 
 var BuiltinLists = []BuiltinList{
+	// Not an example: it is what the books page opens on, so it is hidden from
+	// the rail and cannot be deleted. Everything below it is a suggestion the
+	// reader is free to rename, retarget or throw away.
 	{Key: "default", Name: "Default", Query: "", Layout: "list", DisplayOrder: 0, Hidden: true, Permanent: true},
 	{Key: "reading", Name: "Reading now", Query: "status=reading", Layout: "grid", Icon: "next", DisplayOrder: 1},
 	{Key: "unread", Name: "Up next", Query: "status=unread", Layout: "grid", DisplayOrder: 2},
@@ -236,8 +239,13 @@ func (r *ListRepo) Create(ctx context.Context, in CreateListInput) (*models.List
 	q := `
 		INSERT INTO lists (owner_user_id, name, description, icon, color, kind,
 		                   filter, filter_version, layout, visibility,
-		                   shared_library_id, share_token)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+		                   shared_library_id, share_token, display_order)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12,
+		        -- Last, not first. Order is something a reader arranges by hand
+		        -- now, so a new list appearing at the top would reshuffle a rail
+		        -- they had already put in the order they wanted.
+		        COALESCE((SELECT max(display_order) + 1 FROM lists
+		                   WHERE owner_user_id = $1), 0))
 		RETURNING id`
 
 	var id uuid.UUID
@@ -251,15 +259,33 @@ func (r *ListRepo) Create(ctx context.Context, in CreateListInput) (*models.List
 	return r.FindByID(ctx, id)
 }
 
-// SeedBuiltIns gives a user the lists this release ships with.
+// SeedBuiltIns gives a person the example lists, once.
 //
-// Safe to call on every read, which is the point: "has this user been seeded"
-// has no honest answer once deleting a built-in is allowed, so there is no flag
-// to check and the insert carries its own idempotency through
-// lists_builtin_key_idx. A built-in a user deleted stays deleted only until the
-// next seed, and that is a real limitation worth naming rather than a bug: the
-// alternative is a tombstone table for something nobody has asked to do yet.
+// Examples, not fixtures. Whoever gets them owns them: rename Five stars, point
+// it at something else, or throw it away, and that sticks. So this runs exactly
+// once per account and never touches those rows again.
+//
+// It used to run on every read, which made them undeletable in practice:
+// removing one worked and the next page load put it back. users.lists_seeded_at
+// is what makes "has this person been seeded" answerable, and the claim below
+// is what makes concurrent first reads insert one set rather than two.
 func (r *ListRepo) SeedBuiltIns(ctx context.Context, userID uuid.UUID) error {
+	// Claim the seed before writing anything. Two requests arriving together on
+	// a first load would otherwise both find NULL and both insert; only one
+	// UPDATE can move the column off NULL, and the loser does nothing.
+	const claim = `
+		UPDATE users SET lists_seeded_at = NOW()
+		 WHERE id = $1 AND lists_seeded_at IS NULL
+		 RETURNING id`
+	var claimed uuid.UUID
+	err := r.db.QueryRow(ctx, claim, userID).Scan(&claimed)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil // Already seeded. Their lists are their own now.
+	}
+	if err != nil {
+		return fmt.Errorf("claiming the list seed: %w", err)
+	}
+
 	for _, b := range BuiltinLists {
 		filter, err := json.Marshal(map[string]string{"query": b.Query})
 		if err != nil {

--- a/internal/repository/schema_tiers_live_test.go
+++ b/internal/repository/schema_tiers_live_test.go
@@ -1694,3 +1694,111 @@ func TestListsHoldingBookRespectsVisibility(t *testing.T) {
 		}
 	}
 }
+
+// TestExampleListsAreSeededOnceAndStayDeleted covers what makes them examples
+// rather than fixtures.
+//
+// They used to be re-inserted on every read, so deleting one worked and the
+// next page load put it straight back. A reader who threw away Five stars had
+// to watch it return.
+func TestExampleListsAreSeededOnceAndStayDeleted(t *testing.T) {
+	pool, ctx := tiersPool(t)
+	repo := NewListRepo(pool)
+
+	var userID uuid.UUID
+	if err := pool.QueryRow(ctx, `SELECT id FROM users LIMIT 1`).Scan(&userID); err != nil {
+		t.Skipf("no users: %v", err)
+	}
+
+	// Start from never-seeded, and put the account back afterwards.
+	var was *time.Time
+	if err := pool.QueryRow(ctx,
+		`SELECT lists_seeded_at FROM users WHERE id = $1`, userID).Scan(&was); err != nil {
+		t.Fatalf("reading the seed marker: %v", err)
+	}
+	defer func() {
+		_, _ = pool.Exec(ctx, `UPDATE users SET lists_seeded_at = $2 WHERE id = $1`, userID, was)
+	}()
+	if _, err := pool.Exec(ctx,
+		`UPDATE users SET lists_seeded_at = NULL WHERE id = $1`, userID); err != nil {
+		t.Fatalf("clearing the marker: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`DELETE FROM lists WHERE owner_user_id = $1 AND builtin_key IS NOT NULL`, userID); err != nil {
+		t.Fatalf("clearing examples: %v", err)
+	}
+
+	count := func() int {
+		var n int
+		if err := pool.QueryRow(ctx,
+			`SELECT count(*) FROM lists WHERE owner_user_id = $1 AND builtin_key IS NOT NULL`,
+			userID).Scan(&n); err != nil {
+			t.Fatalf("counting: %v", err)
+		}
+		return n
+	}
+
+	if err := repo.SeedBuiltIns(ctx, userID); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+	seeded := count()
+	if seeded != len(BuiltinLists) {
+		t.Fatalf("seeded %d, want %d", seeded, len(BuiltinLists))
+	}
+
+	// Throw one away, the way a reader would.
+	var fiveStars uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`SELECT id FROM lists WHERE owner_user_id = $1 AND builtin_key = 'five-stars'`,
+		userID).Scan(&fiveStars); err != nil {
+		t.Fatalf("finding five-stars: %v", err)
+	}
+	if err := repo.Delete(ctx, fiveStars); err != nil {
+		t.Fatalf("deleting an example: %v", err)
+	}
+
+	// Every later read seeds again. It must not come back.
+	for i := 0; i < 3; i++ {
+		if err := repo.SeedBuiltIns(ctx, userID); err != nil {
+			t.Fatalf("re-seeding: %v", err)
+		}
+	}
+	if got := count(); got != seeded-1 {
+		t.Errorf("after deleting one example and %d reads there are %d, want %d: it came back",
+			3, got, seeded-1)
+	}
+
+	// The default is machinery, not an example: the books page has to open on
+	// something, so it is still refused.
+	var dflt uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`SELECT id FROM lists WHERE owner_user_id = $1 AND builtin_key = 'default'`,
+		userID).Scan(&dflt); err != nil {
+		t.Fatalf("finding the default: %v", err)
+	}
+	if err := repo.Delete(ctx, dflt); !errors.Is(err, ErrListPermanent) {
+		t.Errorf("deleting the default returned %v, want ErrListPermanent", err)
+	}
+
+	// An example can be renamed and retargeted, because it belongs to whoever
+	// was given it.
+	var reading uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`SELECT id FROM lists WHERE owner_user_id = $1 AND builtin_key = 'reading'`,
+		userID).Scan(&reading); err != nil {
+		t.Fatalf("finding reading: %v", err)
+	}
+	name := "On the go"
+	if _, err := repo.Update(ctx, reading, UpdateListInput{
+		Name: &name, Filter: []byte(`{"query":"status=reading&fav=true"}`),
+	}); err != nil {
+		t.Fatalf("editing an example: %v", err)
+	}
+	after, err := repo.FindByID(ctx, reading)
+	if err != nil {
+		t.Fatalf("re-reading: %v", err)
+	}
+	if after.Name != name {
+		t.Errorf("name = %q, want the rename to stick", after.Name)
+	}
+}

--- a/internal/repository/schema_tiers_live_test.go
+++ b/internal/repository/schema_tiers_live_test.go
@@ -1782,3 +1782,69 @@ func TestExampleListsAreSeededOnceAndStayDeleted(t *testing.T) {
 		t.Errorf("name = %q, want the rename to stick", after.Name)
 	}
 }
+
+// TestContributorFilterIsNotATextSearch covers the difference the search box
+// depends on: naming an author is a different question from searching for their
+// name. "Tite" the person is not a book with Tite in its title.
+func TestContributorFilterIsNotATextSearch(t *testing.T) {
+	pool, ctx := tiersPool(t)
+	books := NewBookRepo(pool)
+
+	var contributorID, libraryID uuid.UUID
+	var name string
+	err := pool.QueryRow(ctx, `
+		SELECT c.id, c.name, cp.library_id
+		  FROM contributors c
+		  JOIN book_contributors bc ON bc.contributor_id = c.id
+		  JOIN copies cp ON cp.book_id = bc.book_id AND cp.deleted_at IS NULL
+		 GROUP BY c.id, c.name, cp.library_id
+		HAVING count(*) > 1
+		 LIMIT 1`).Scan(&contributorID, &name, &libraryID)
+	if err != nil {
+		t.Skipf("no contributor with more than one held book: %v", err)
+	}
+
+	_, total, err := books.List(ctx, libraryID, ListBooksOpts{
+		PerPage:   200,
+		Selection: FacetSelection{Contributors: []uuid.UUID{contributorID}},
+	})
+	if err != nil {
+		t.Fatalf("filtering by contributor: %v", err)
+	}
+	if total == 0 {
+		t.Fatalf("%s has books but the filter matched none", name)
+	}
+
+	// Every row really is theirs, which a name match could not promise.
+	rows, _, err := books.List(ctx, libraryID, ListBooksOpts{
+		PerPage:   200,
+		Selection: FacetSelection{Contributors: []uuid.UUID{contributorID}},
+	})
+	if err != nil {
+		t.Fatalf("re-reading: %v", err)
+	}
+	for _, b := range rows {
+		var linked bool
+		if err := pool.QueryRow(ctx,
+			`SELECT EXISTS(SELECT 1 FROM book_contributors
+			                WHERE book_id = $1 AND contributor_id = $2)`,
+			b.ID, contributorID).Scan(&linked); err != nil {
+			t.Fatalf("checking the credit: %v", err)
+		}
+		if !linked {
+			t.Errorf("%q came back for a contributor who is not credited on it", b.Title)
+		}
+	}
+
+	// An id nobody holds matches nothing, rather than everything.
+	_, none, err := books.List(ctx, libraryID, ListBooksOpts{
+		PerPage:   10,
+		Selection: FacetSelection{Contributors: []uuid.UUID{uuid.New()}},
+	})
+	if err != nil {
+		t.Fatalf("filtering by an unknown contributor: %v", err)
+	}
+	if none != 0 {
+		t.Errorf("an unknown contributor matched %d books, want 0", none)
+	}
+}

--- a/internal/repository/schema_tiers_live_test.go
+++ b/internal/repository/schema_tiers_live_test.go
@@ -25,6 +25,27 @@ import (
 //
 // Set LIBRARIUM_TEST_DSN to a database that has run migration 000025.
 
+// scratchUser makes an account this test owns, removed when it finishes.
+//
+// Live tests run against a restored copy of a real collection, so a test that
+// writes has to own what it writes to. Picking whichever account
+// `SELECT id FROM users LIMIT 1` returns and deleting its rows destroys
+// somebody's actual data, which is not hypothetical: it happened.
+func scratchUser(t *testing.T, pool *pgxpool.Pool, ctx context.Context) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	tag := id.String()[:8]
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO users (id, username, email, display_name, password_hash, is_active)
+		 VALUES ($1, $2, $3, 'Scratch', '', true)`,
+		id, "scratch-"+tag, "scratch-"+tag+"@example.invalid"); err != nil {
+		t.Skipf("cannot create a scratch user: %v", err)
+	}
+	// Everything owned by a user cascades, so this takes the fixture with it.
+	t.Cleanup(func() { _, _ = pool.Exec(ctx, `DELETE FROM users WHERE id = $1`, id) })
+	return id
+}
+
 func tiersPool(t *testing.T) (*pgxpool.Pool, context.Context) {
 	t.Helper()
 	dsn := os.Getenv("LIBRARIUM_TEST_DSN")
@@ -894,21 +915,8 @@ func TestBuiltInListsSeedOnceAndResistDeletion(t *testing.T) {
 	pool, ctx := tiersPool(t)
 	repo := NewListRepo(pool)
 
-	var userID uuid.UUID
-	if err := pool.QueryRow(ctx, `SELECT id FROM users LIMIT 1`).Scan(&userID); err != nil {
-		t.Skipf("no users: %v", err)
-	}
-	defer func() {
-		_, _ = pool.Exec(ctx,
-			`DELETE FROM lists WHERE owner_user_id = $1 AND builtin_key IS NOT NULL`, userID)
-	}()
-	// Start from a known state rather than assuming this user has none: the
-	// seed is idempotent, so a previous run leaving rows behind must not change
-	// what this measures.
-	if _, err := pool.Exec(ctx,
-		`DELETE FROM lists WHERE owner_user_id = $1 AND builtin_key IS NOT NULL`, userID); err != nil {
-		t.Fatalf("clearing built-ins: %v", err)
-	}
+	// Its own account, so "start from none" needs no deleting.
+	userID := scratchUser(t, pool, ctx)
 
 	if err := repo.SeedBuiltIns(ctx, userID); err != nil {
 		t.Fatalf("seeding: %v", err)
@@ -1419,30 +1427,23 @@ func TestSyncProgressRoundTrips(t *testing.T) {
 	pool, ctx := tiersPool(t)
 	sync := NewSyncRepo(pool)
 
-	// A book with an edition, since a page number needs a printing to count in.
-	var userID, bookID uuid.UUID
+	// A scratch reader with an opinion of a real book, rather than a real
+	// reader whose sessions this would have to clear first. Clearing them is
+	// what an earlier version did, and reading history is not test scaffolding.
+	userID := scratchUser(t, pool, ctx)
+
+	// The book only has to have an edition, since a page number needs a
+	// printing to count in.
+	var bookID uuid.UUID
 	if err := pool.QueryRow(ctx,
-		`SELECT ub.user_id, ub.book_id FROM user_books ub
-		  WHERE ub.deleted_at IS NULL
-		    AND EXISTS (SELECT 1 FROM book_editions be WHERE be.book_id = ub.book_id)
-		  LIMIT 1`).Scan(&userID, &bookID); err != nil {
-		t.Skipf("no opinion on a book with an edition: %v", err)
+		`SELECT be.book_id FROM book_editions be LIMIT 1`).Scan(&bookID); err != nil {
+		t.Skipf("no editions: %v", err)
 	}
 	var entityID uuid.UUID
 	if err := pool.QueryRow(ctx,
-		`SELECT id FROM user_books WHERE user_id = $1 AND book_id = $2`,
-		userID, bookID).Scan(&entityID); err != nil {
-		t.Fatalf("finding the row: %v", err)
-	}
-
-	defer func() {
-		_, _ = pool.Exec(ctx,
-			`DELETE FROM reading_sessions WHERE user_id = $1 AND book_id = $2 AND progress_updated_at IS NOT NULL`,
-			userID, bookID)
-	}()
-	if _, err := pool.Exec(ctx,
-		`DELETE FROM reading_sessions WHERE user_id = $1 AND book_id = $2`, userID, bookID); err != nil {
-		t.Fatalf("clearing sessions: %v", err)
+		`INSERT INTO user_books (user_id, book_id, read_status)
+		 VALUES ($1, $2, 'reading') RETURNING id`, userID, bookID).Scan(&entityID); err != nil {
+		t.Fatalf("creating an opinion: %v", err)
 	}
 
 	at := time.Now().Add(-time.Hour)
@@ -1705,28 +1706,7 @@ func TestExampleListsAreSeededOnceAndStayDeleted(t *testing.T) {
 	pool, ctx := tiersPool(t)
 	repo := NewListRepo(pool)
 
-	var userID uuid.UUID
-	if err := pool.QueryRow(ctx, `SELECT id FROM users LIMIT 1`).Scan(&userID); err != nil {
-		t.Skipf("no users: %v", err)
-	}
-
-	// Start from never-seeded, and put the account back afterwards.
-	var was *time.Time
-	if err := pool.QueryRow(ctx,
-		`SELECT lists_seeded_at FROM users WHERE id = $1`, userID).Scan(&was); err != nil {
-		t.Fatalf("reading the seed marker: %v", err)
-	}
-	defer func() {
-		_, _ = pool.Exec(ctx, `UPDATE users SET lists_seeded_at = $2 WHERE id = $1`, userID, was)
-	}()
-	if _, err := pool.Exec(ctx,
-		`UPDATE users SET lists_seeded_at = NULL WHERE id = $1`, userID); err != nil {
-		t.Fatalf("clearing the marker: %v", err)
-	}
-	if _, err := pool.Exec(ctx,
-		`DELETE FROM lists WHERE owner_user_id = $1 AND builtin_key IS NOT NULL`, userID); err != nil {
-		t.Fatalf("clearing examples: %v", err)
-	}
+	userID := scratchUser(t, pool, ctx)
 
 	count := func() int {
 		var n int

--- a/internal/repository/schema_tiers_live_test.go
+++ b/internal/repository/schema_tiers_live_test.go
@@ -36,10 +36,14 @@ func scratchUser(t *testing.T, pool *pgxpool.Pool, ctx context.Context) uuid.UUI
 	id := uuid.New()
 	tag := id.String()[:8]
 	if _, err := pool.Exec(ctx,
-		`INSERT INTO users (id, username, email, display_name, password_hash, is_active)
-		 VALUES ($1, $2, $3, 'Scratch', '', true)`,
+		`INSERT INTO users (id, username, email, display_name, is_active)
+		 VALUES ($1, $2, $3, 'Scratch', true)`,
 		id, "scratch-"+tag, "scratch-"+tag+"@example.invalid"); err != nil {
-		t.Skipf("cannot create a scratch user: %v", err)
+		// Fatal rather than skipped. This named a password_hash column that
+		// does not exist, so every test built on a scratch user skipped itself
+		// and reported PASS. A skip is for "not configured to run here"; a
+		// query that does not match the schema is a broken test.
+		t.Fatalf("creating a scratch user: %v", err)
 	}
 	// Everything owned by a user cascades, so this takes the fixture with it.
 	t.Cleanup(func() { _, _ = pool.Exec(ctx, `DELETE FROM users WHERE id = $1`, id) })
@@ -1902,5 +1906,91 @@ func TestFacetsAgreeWithTheListOnAMultiWordSearch(t *testing.T) {
 	}
 	if counted != total {
 		t.Errorf("the rail counted %d for %q, the list returned %d", counted, query, total)
+	}
+}
+
+// Order belongs to a sidebar, not to a view. Two people looking at the same
+// shared view put it in different places, and neither move is visible to the
+// other. Before list_order_overrides there was one number on the row, so the
+// second person's drag either moved it for the first or, because the reorder
+// was a PATCH guarded by ownership, failed and was swallowed.
+func TestRailOrderIsPerPerson(t *testing.T) {
+	pool, ctx := tiersPool(t)
+	lists := NewListRepo(pool)
+
+	owner := scratchUser(t, pool, ctx)
+	reader := scratchUser(t, pool, ctx)
+
+	var libraryID uuid.UUID
+	if err := pool.QueryRow(ctx, `SELECT id FROM libraries LIMIT 1`).Scan(&libraryID); err != nil {
+		t.Skipf("no library to share into: %v", err)
+	}
+	// The reader has to hold a role on the library or the shared view is not
+	// theirs to see, let alone to arrange.
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO user_roles (user_id, library_id, role_id, scope)
+		 SELECT $1, $2, r.id, r.scope FROM roles r
+		  WHERE r.name = 'library_viewer'`,
+		reader, libraryID); err != nil {
+		t.Fatalf("granting the reader a role: %v", err)
+	}
+
+	shared, err := lists.Create(ctx, CreateListInput{
+		OwnerUserID: owner, Name: "Shared run", Kind: "smart",
+		Filter: []byte(`{"query":"tag=manga"}`), Layout: "list",
+		Visibility: "library", SharedLibraryID: &libraryID,
+	})
+	if err != nil {
+		t.Fatalf("creating a shared view: %v", err)
+	}
+	mine, err := lists.Create(ctx, CreateListInput{
+		OwnerUserID: reader, Name: "Mine", Kind: "smart",
+		Filter: []byte(`{"query":""}`), Layout: "list", Visibility: "private",
+	})
+	if err != nil {
+		t.Fatalf("creating the reader's own view: %v", err)
+	}
+
+	// The reader puts the shared one first. It is not theirs, which is exactly
+	// the move that used to fail.
+	if err := lists.SetOrder(ctx, reader, []uuid.UUID{shared.ID, mine.ID}); err != nil {
+		t.Fatalf("arranging the reader's rail: %v", err)
+	}
+
+	order := func(who uuid.UUID) []string {
+		ls, err := lists.ListForUser(ctx, who)
+		if err != nil {
+			t.Fatalf("reading a rail: %v", err)
+		}
+		var names []string
+		for _, l := range ls {
+			if l.ID == shared.ID || l.ID == mine.ID {
+				names = append(names, l.Name)
+			}
+		}
+		return names
+	}
+
+	if got := order(reader); len(got) != 2 || got[0] != "Shared run" {
+		t.Errorf("the reader's rail is %v, want Shared run first", got)
+	}
+
+	// The owner never asked for anything, so their rail is untouched: the
+	// reader's drag is invisible to them.
+	var ownerHasOpinion bool
+	if err := pool.QueryRow(ctx,
+		`SELECT EXISTS(SELECT 1 FROM list_order_overrides
+		                WHERE user_id = $1 AND list_id = $2)`,
+		owner, shared.ID).Scan(&ownerHasOpinion); err != nil {
+		t.Fatalf("checking the owner's rail: %v", err)
+	}
+	if ownerHasOpinion {
+		t.Error("the reader's drag wrote a position into the owner's rail")
+	}
+
+	// An id the caller cannot see is ignored rather than refused, so one stale
+	// row does not strand the rest of the reorder.
+	if err := lists.SetOrder(ctx, reader, []uuid.UUID{uuid.New(), mine.ID}); err != nil {
+		t.Errorf("an unknown id failed the whole reorder: %v", err)
 	}
 }

--- a/internal/repository/schema_tiers_live_test.go
+++ b/internal/repository/schema_tiers_live_test.go
@@ -1848,3 +1848,59 @@ func TestContributorFilterIsNotATextSearch(t *testing.T) {
 		t.Errorf("an unknown contributor matched %d books, want 0", none)
 	}
 }
+
+// The rail and the rows have to answer the same question. The list runs a text
+// query through the parser, which makes one condition per word; the facet query
+// used to match the whole phrase in one ILIKE, so any two-word search reported
+// zero of everything beside a list showing books.
+func TestFacetsAgreeWithTheListOnAMultiWordSearch(t *testing.T) {
+	pool, ctx := tiersPool(t)
+	books := NewBookRepo(pool)
+
+	// Two words that are known to co-occur: a title word and a word from a
+	// contributor's name on the same book. Read from the data rather than
+	// hardcoded, so the test travels with whatever collection it is run against.
+	var titleWord, nameWord string
+	var libraryID uuid.UUID
+	err := pool.QueryRow(ctx, `
+		SELECT split_part(b.title, ' ', 1),
+		       split_part(c.name, ' ', 1),
+		       cp.library_id
+		  FROM books b
+		  JOIN book_contributors bc ON bc.book_id = b.id
+		  JOIN contributors c ON c.id = bc.contributor_id
+		  JOIN copies cp ON cp.book_id = b.id AND cp.deleted_at IS NULL
+		 WHERE length(split_part(b.title, ' ', 1)) > 3
+		   AND length(split_part(c.name, ' ', 1)) > 3
+		 LIMIT 1`).Scan(&titleWord, &nameWord, &libraryID)
+	if err != nil {
+		t.Skipf("no book with a multi-word title and a credited contributor: %v", err)
+	}
+
+	query := titleWord + " " + nameWord
+	// What internal/search produces for two bare words. Built by hand because
+	// that package imports this one, so the test cannot call the parser.
+	groups := []ConditionGroup{{Mode: "and", Conditions: []FilterCondition{
+		{Field: "title", Op: "contains", Value: titleWord},
+		{Field: "title", Op: "contains", Value: nameWord},
+	}}}
+	_, total, err := books.List(ctx, libraryID, ListBooksOpts{PerPage: 1, Groups: groups})
+	if err != nil {
+		t.Fatalf("listing for %q: %v", query, err)
+	}
+	if total == 0 {
+		t.Fatalf("%q matched nothing, so there is nothing to compare", query)
+	}
+
+	facets, err := books.Facets(ctx, []uuid.UUID{libraryID}, FacetSelection{}, query, nil, uuid.Nil)
+	if err != nil {
+		t.Fatalf("counting facets for %q: %v", query, err)
+	}
+	var counted int
+	for _, v := range facets.Library {
+		counted += v.Count
+	}
+	if counted != total {
+		t.Errorf("the rail counted %d for %q, the list returned %d", counted, query, total)
+	}
+}

--- a/internal/service/book.go
+++ b/internal/service/book.go
@@ -58,6 +58,10 @@ func (s *BookService) SearchContributors(ctx context.Context, query string) ([]*
 	return s.contributors.Search(ctx, query, 10)
 }
 
+func (s *BookService) ContributorsByIDs(ctx context.Context, ids []uuid.UUID) ([]*models.Contributor, error) {
+	return s.contributors.ByIDs(ctx, ids)
+}
+
 func (s *BookService) CreateContributor(ctx context.Context, name string) (*models.Contributor, error) {
 	if name == "" {
 		return nil, fmt.Errorf("name is required")


### PR DESCRIPTION
- The shipped lists were re-inserted on every read, so deleting one worked and the next page load put it straight back. `users.lists_seeded_at` makes "has this person been seeded" answerable, and the seed claims it with an UPDATE first so two concurrent first loads insert one set rather than two.
- `list_order_overrides` moves rail order onto the reader. One column on one row could only describe one arrangement, so dragging a list shared into a library either moved it for everybody or, since the reorder was a PATCH guarded by ownership, 404ed. `PUT /me/lists/order` writes the whole rail against the caller.
- Books filter by contributor id rather than by name match, and facet counts now agree with the list beside them on a multi-word search: the list parses the query into one condition per word, the facet query matched the whole phrase, so any two-word search reported zero of everything.