### PR TITLE
A job kind that is already running is not started again

### DIFF
--- a/internal/api/handlers/jobs_admin.go
+++ b/internal/api/handlers/jobs_admin.go
@@ -406,6 +406,27 @@ func (h *UnifiedJobsHandler) RunNow(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// One run of a kind at a time.
+	//
+	// This never checked, so pressing Run now twice started two concurrent runs.
+	// For a kind that walks the catalogue that is not the same work done twice
+	// but a race with itself: two series syncs put 175 duplicate books in a real
+	// collection, each promoting volumes the other had not committed yet.
+	//
+	// The cutoff is what stops a crashed run blocking a kind forever. A process
+	// that died leaves its row saying running with nothing behind it, so an old
+	// enough row is treated as gone rather than as a reason to refuse.
+	const staleRun = 6 * time.Hour
+	if running, err := h.jobs.IsKindRunning(r.Context(), string(kind), staleRun); err != nil {
+		respond.ServerError(w, r, err)
+		return
+	} else if running {
+		// 409 rather than 400: the request is well formed and would be fine in
+		// a moment, which is exactly what a conflict means.
+		respond.Error(w, http.StatusConflict, "that job is already running")
+		return
+	}
+
 	now := time.Now()
 	j := &models.Job{
 		Kind:        kind,

--- a/internal/repository/jobs.go
+++ b/internal/repository/jobs.go
@@ -67,6 +67,31 @@ func (r *JobRepo) CreateJob(ctx context.Context, j *models.Job) error {
 }
 
 // MarkRunning flips a job to running and stamps started_at if still null.
+// IsKindRunning reports whether this kind is already going.
+//
+// Triggering a job never checked, so pressing Run now twice started two
+// concurrent runs of the same kind. For a kind that walks the catalogue that is
+// not a duplicate of the work but a race with it: two series syncs put 175
+// duplicate books in a real collection, because each promoted the volumes the
+// other had not committed yet.
+//
+// A stale row cannot block a kind forever. A run whose process died leaves its
+// status running with nothing behind it, so anything older than the cutoff is
+// treated as gone rather than as a reason to refuse.
+func (r *JobRepo) IsKindRunning(ctx context.Context, kind string, staleAfter time.Duration) (bool, error) {
+	var running bool
+	err := r.db.QueryRow(ctx, `
+		SELECT EXISTS (
+		    SELECT 1 FROM jobs
+		     WHERE kind = $1 AND status = 'running'
+		       AND COALESCE(started_at, created_at) > NOW() - $2::interval)`,
+		kind, staleAfter.String()).Scan(&running)
+	if err != nil {
+		return false, fmt.Errorf("checking whether %s is running: %w", kind, err)
+	}
+	return running, nil
+}
+
 func (r *JobRepo) MarkRunning(ctx context.Context, jobID uuid.UUID) error {
 	_, err := r.db.Exec(ctx, `
 		UPDATE jobs

--- a/internal/repository/schema_tiers_live_test.go
+++ b/internal/repository/schema_tiers_live_test.go
@@ -2259,11 +2259,22 @@ func TestRatingIsAveragedButStillIndividual(t *testing.T) {
 	alice := scratchUser(t, pool, ctx)
 	bob := scratchUser(t, pool, ctx)
 
+	// A book nobody has rated, because the arithmetic below depends on it.
+	//
+	// This took the first held copy it found, which was fine only while that
+	// row happened to be unrated: alice's 9 and bob's 6 average to 8, and a
+	// third rating already on the book moves the answer somewhere the filter
+	// will not find. The row is arbitrary with no ORDER BY, so a book added or
+	// removed anywhere could change which one it grabs, and the test would fail
+	// on a change that had nothing to do with it.
 	var libraryID, bookID uuid.UUID
 	if err := pool.QueryRow(ctx, `
 		SELECT c.library_id, c.book_id FROM copies c
-		 WHERE c.deleted_at IS NULL LIMIT 1`).Scan(&libraryID, &bookID); err != nil {
-		t.Skipf("no held book to rate: %v", err)
+		 WHERE c.deleted_at IS NULL
+		   AND NOT EXISTS (SELECT 1 FROM user_books ub
+		                    WHERE ub.book_id = c.book_id AND ub.rating IS NOT NULL)
+		 ORDER BY c.book_id LIMIT 1`).Scan(&libraryID, &bookID); err != nil {
+		t.Skipf("no unrated held book to rate: %v", err)
 	}
 
 	var roleID uuid.UUID
@@ -3878,5 +3889,69 @@ func TestPromotingTwiceAtOnceStillPromotesOnce(t *testing.T) {
 	}
 	if orphans != 0 {
 		t.Errorf("%d promoted books have no volume pointing at them", orphans)
+	}
+}
+
+// A kind that is already going is not started again.
+//
+// Triggering never checked, so pressing Run now twice started two concurrent
+// runs. For a kind that walks the catalogue that is a race with itself rather
+// than duplicated work, and it is how 175 duplicate books reached a real
+// collection.
+func TestAJobKindDoesNotRunTwiceAtOnce(t *testing.T) {
+	pool, ctx := tiersPool(t)
+	repo := NewJobRepo(pool)
+
+	const kind = "zz_test_kind"
+	t.Cleanup(func() { _, _ = pool.Exec(ctx, `DELETE FROM jobs WHERE kind = $1`, kind) })
+
+	running, err := repo.IsKindRunning(ctx, kind, time.Hour)
+	if err != nil {
+		t.Fatalf("checking: %v", err)
+	}
+	if running {
+		t.Fatal("a kind with no jobs at all reports as running")
+	}
+
+	var jobID uuid.UUID
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO jobs (kind, status, triggered_by, started_at)
+		VALUES ($1, 'running', 'admin', NOW()) RETURNING id`, kind).Scan(&jobID); err != nil {
+		t.Fatalf("starting a job: %v", err)
+	}
+
+	running, err = repo.IsKindRunning(ctx, kind, time.Hour)
+	if err != nil {
+		t.Fatalf("checking: %v", err)
+	}
+	if !running {
+		t.Error("a running job does not report as running, so a second run would start")
+	}
+
+	// A crashed run must not block the kind forever: its row says running with
+	// nothing behind it, and nobody can clear that by hand.
+	if _, err := pool.Exec(ctx,
+		`UPDATE jobs SET started_at = NOW() - INTERVAL '8 hours' WHERE id = $1`, jobID); err != nil {
+		t.Fatalf("ageing the job: %v", err)
+	}
+	running, err = repo.IsKindRunning(ctx, kind, 6*time.Hour)
+	if err != nil {
+		t.Fatalf("checking: %v", err)
+	}
+	if running {
+		t.Error("a run older than the cutoff still blocks the kind")
+	}
+
+	// And a finished run never blocks anything.
+	if _, err := pool.Exec(ctx,
+		`UPDATE jobs SET status = 'completed', started_at = NOW() WHERE id = $1`, jobID); err != nil {
+		t.Fatalf("finishing the job: %v", err)
+	}
+	running, err = repo.IsKindRunning(ctx, kind, time.Hour)
+	if err != nil {
+		t.Fatalf("checking: %v", err)
+	}
+	if running {
+		t.Error("a completed job reports as running")
 	}
 }


### PR DESCRIPTION
Triggering never checked, so pressing Run now twice started two concurrent runs of the same kind. For a kind that walks the catalogue that is a race with itself rather than duplicated work, and it is how 175 duplicate books reached a real collection.

The advisory lock in #90 fixes that one path; this is the class. A cutoff keeps a crashed run from blocking a kind forever, since a process that died leaves its row saying running with nothing behind it.

Also makes the average-rating test deterministic: it took the first held copy with no `ORDER BY` and assumed nobody had rated it, so it passed only while that arbitrary row happened to be unrated.