### PR TITLE
A curly apostrophe sorts where a straight one does

### DIFF
--- a/internal/db/migrations/000039_sort_folds_typography.down.sql
+++ b/internal/db/migrations/000039_sort_folds_typography.down.sql
@@ -1,0 +1,23 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Copyright (C) 2026 FireBall1725 (Adaléa)
+
+-- Back to the definition from the initial schema, which sorts a curly
+-- apostrophe apart from a straight one.
+CREATE OR REPLACE FUNCTION sort_title(t TEXT)
+RETURNS TEXT
+LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$
+  SELECT trim(
+    regexp_replace(
+      regexp_replace(
+        trim(t),
+        E'^(unos|unas|eine|the|les|una|une|des|los|las|gli|het|een|das|der|die|dem|den|det|ein|ett|uma|um|os|as|le|la|lo|el|un|de|na|az|yr|il|et|en|y|an|o|a)\s+',
+        '',
+        'i'
+      ),
+      E'^l''',
+      '',
+      'i'
+    )
+  );
+$$;

--- a/internal/db/migrations/000039_sort_folds_typography.up.sql
+++ b/internal/db/migrations/000039_sort_folds_typography.up.sql
@@ -1,0 +1,45 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Copyright (C) 2026 FireBall1725 (Adaléa)
+
+-- A curly apostrophe sorted somewhere a straight one did not.
+--
+-- Three volumes of one run came back 1, 3, 2, because volume two was catalogued
+-- as "Can’t Fear Your Own World" with U+2019 while its siblings used U+0027.
+-- The two characters are the same apostrophe to a reader and forty-eight code
+-- points apart to a sort, so every straight-quoted title in a run groups ahead
+-- of every curly-quoted one and the numbering falls apart in between.
+--
+-- Providers are where this comes from and they are not consistent with
+-- themselves: the same series arrives with both, depending on which record was
+-- typed by whom. Normalising the stored title would be the other fix and is
+-- wrong, because the title is what the publisher printed and a catalogue should
+-- keep it. So the folding belongs in the sort key, which exists precisely to be
+-- the reading of a title rather than the title.
+--
+-- Dashes and double quotes go the same way for the same reason. They are less
+-- common in titles and split a sort identically when they turn up.
+CREATE OR REPLACE FUNCTION sort_title(t TEXT)
+RETURNS TEXT
+LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$
+  SELECT trim(
+    regexp_replace(
+      regexp_replace(
+        trim(
+          -- Typographic punctuation folded to ASCII before anything else, so
+          -- the article strip below sees L’Assommoir the same way it already
+          -- sees L'Assommoir.
+          translate(t,
+            U&'\2018\2019\201C\201D\2013\2014\2212',
+            '''''""---')
+        ),
+        E'^(unos|unas|eine|the|les|una|une|des|los|las|gli|het|een|das|der|die|dem|den|det|ein|ett|uma|um|os|as|le|la|lo|el|un|de|na|az|yr|il|et|en|y|an|o|a)\s+',
+        '',
+        'i'
+      ),
+      E'^l''',
+      '',
+      'i'
+    )
+  );
+$$;

--- a/internal/repository/schema_tiers_live_test.go
+++ b/internal/repository/schema_tiers_live_test.go
@@ -3955,3 +3955,62 @@ func TestAJobKindDoesNotRunTwiceAtOnce(t *testing.T) {
 		t.Error("a completed job reports as running")
 	}
 }
+
+// A curly apostrophe sorts where a straight one does.
+//
+// Three volumes of one run came back 1, 3, 2 because volume two was catalogued
+// with U+2019 and its siblings with U+0027. The characters are the same
+// apostrophe to a reader and forty-eight code points apart to a sort, so every
+// straight-quoted title in a run groups ahead of every curly-quoted one and the
+// numbering falls apart in between.
+//
+// Providers are not consistent with themselves about this, so it is not a
+// matter of picking a good one.
+func TestTypographicPunctuationSortsWithItsPlainForm(t *testing.T) {
+	pool, ctx := tiersPool(t)
+
+	cases := []struct{ curly, plain string }{
+		{"Can’t Fear Your Own World", "Can't Fear Your Own World"},
+		{"L’Assommoir", "L'Assommoir"},
+		{"A – Dash", "A - Dash"},
+		{"“Quoted”", "\"Quoted\""},
+	}
+	for _, c := range cases {
+		var a, b string
+		if err := pool.QueryRow(ctx,
+			`SELECT natural_sort_key($1), natural_sort_key($2)`, c.curly, c.plain).Scan(&a, &b); err != nil {
+			t.Fatalf("keying %q: %v", c.curly, err)
+		}
+		if a != b {
+			t.Errorf("%q keys to %q but %q keys to %q; they must sort together",
+				c.curly, a, c.plain, b)
+		}
+	}
+
+	// The whole point: a run numbered 1 to 3 with one odd apostrophe reads in
+	// order rather than 1, 3, 2.
+	rows, err := pool.Query(ctx, `
+		SELECT t FROM unnest(ARRAY[
+			'Bleach: Can''t Fear Your Own World #1',
+			'Bleach: Can`+"’"+`t Fear Your Own World #2',
+			'Bleach: Can''t Fear Your Own World #3'
+		]) AS t ORDER BY natural_sort_key(t)`)
+	if err != nil {
+		t.Fatalf("ordering: %v", err)
+	}
+	defer rows.Close()
+	var got []string
+	for rows.Next() {
+		var t2 string
+		if err := rows.Scan(&t2); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		got = append(got, t2[len(t2)-2:])
+	}
+	want := []string{"#1", "#2", "#3"}
+	for i := range want {
+		if i >= len(got) || got[i] != want[i] {
+			t.Fatalf("the run sorted %v, want %v", got, want)
+		}
+	}
+}


### PR DESCRIPTION
Three volumes of one run listed as 1, 3, 2, because volume two was catalogued with U+2019 while its siblings used U+0027. The two are the same apostrophe to a reader and forty-eight code points apart to a sort, so every straight-quoted title in a run groups ahead of every curly-quoted one.

Providers are not consistent with themselves about this. Normalising the stored title would be the other fix and is wrong, because the title is what the publisher printed; the folding belongs in `sort_title`, which exists to be the reading of a title rather than the title. Dashes and typographic double quotes fold too, and `L’Assommoir` now hits the article rule that only ever matched `L'Assommoir`.