### PR TITLE
Reference the OpenAPI spec relatively so the docs work behind a proxy

### DIFF
--- a/internal/api/handlers/docs.go
+++ b/internal/api/handlers/docs.go
@@ -51,9 +51,14 @@ func ServeScalarUI(w http.ResponseWriter, r *http.Request) {
     </style>
   </head>
   <body>
+    <!-- Relative, so the page works wherever the API is mounted. This route is
+         /api/docs, so a relative reference resolves against /api/ and gives
+         /api/openapi.json at the root and /<prefix>/api/openapi.json behind a
+         reverse proxy. An absolute path asks the host root, which is the one
+         place the spec is not when the API is served under a prefix. -->
     <script
       id="api-reference"
-      data-url="/api/openapi.json"
+      data-url="openapi.json"
       data-configuration='{"theme":"purple"}'></script>
     <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
   </body>

--- a/internal/api/handlers/docs_test.go
+++ b/internal/api/handlers/docs_test.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725 (Adaléa)
+
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// The docs page has to work wherever the API is mounted.
+//
+// Nothing else in this service cares: every path it hands a client is
+// root-relative and the client resolves it against its own base, so an API
+// behind a reverse proxy at /librarium-api needs no configuration. The docs
+// page was the exception, because it is the one thing here a browser loads
+// directly, and a browser resolves an absolute path against the origin rather
+// than against wherever the page lives.
+func TestDocsReferencesTheSpecRelatively(t *testing.T) {
+	rec := httptest.NewRecorder()
+	ServeScalarUI(rec, httptest.NewRequest(http.MethodGet, "/api/docs", nil))
+
+	body := rec.Body.String()
+	if !strings.Contains(body, `data-url="openapi.json"`) {
+		t.Errorf("docs page does not reference the spec relatively")
+	}
+	// The shape that breaks: from /librarium-api/api/docs a browser asks the
+	// host root for /api/openapi.json, which is the one place it is not.
+	if strings.Contains(body, `data-url="/api/openapi.json"`) {
+		t.Errorf("docs page references the spec by an absolute path")
+	}
+}


### PR DESCRIPTION
Every path this service hands a client is root-relative, and the client resolves it against its own base, so an API served under a prefix already works with no configuration, which is why librarium-web needed the base-path machinery and this repo did not.

The docs page was the one exception. It is the only thing here a browser loads directly, and a browser resolves an absolute path against the origin: from `/librarium-api/api/docs` it asked the host root for `/api/openapi.json` and rendered empty.

Relative resolves against `/api/` from `/api/docs`, which gives the right URL at the root and under any prefix.

Verified against the running service both ways. At the root the spec answers 200. Behind an nginx proxy at `/librarium-api`, the docs page and the spec both answer 200, and the path the old absolute reference would have requested answers 404, which is the bug.
