### PR TITLE
Return the reading date that was sent, whatever zone the server runs in

### DIFF
--- a/internal/api/handlers/editions.go
+++ b/internal/api/handlers/editions.go
@@ -481,15 +481,29 @@ func interactionBody(i *models.UserBookInteraction) map[string]any {
 	} else {
 		body["rating"] = nil
 	}
-	if i.DateStarted != nil {
-		body["date_started"] = i.DateStarted.Format("2006-01-02")
-	} else {
-		body["date_started"] = nil
-	}
-	if i.DateFinished != nil {
-		body["date_finished"] = i.DateFinished.Format("2006-01-02")
-	} else {
-		body["date_finished"] = nil
-	}
+	body["date_started"] = readingDate(i.DateStarted)
+	body["date_finished"] = readingDate(i.DateFinished)
 	return body
+}
+
+// readingDate flattens a reading session's timestamp to the day it was written
+// as, in UTC.
+//
+// These two are dates wearing a timestamp: the client sends YYYY-MM-DD, the
+// handler parses it to midnight UTC, and `reading_sessions` stores it in a
+// `timestamptz` because the same column also carries real instants for
+// progress tracking. Formatting it back in the server's local zone moves it:
+// midnight UTC read as anything west of Greenwich is the previous day, so a
+// book finished on the first of January came back finished on the thirty-first
+// of December. The deployment images mount /etc/localtime, so this is every
+// self-hosted instance outside UTC and none of the CI that tests it.
+//
+// Every other date the API returns is a real DATE column and needs no such
+// care; these two are the exception, which is why it is spelled out here
+// rather than applied everywhere.
+func readingDate(t *time.Time) any {
+	if t == nil {
+		return nil
+	}
+	return t.UTC().Format("2006-01-02")
 }

--- a/internal/api/handlers/reading_date_test.go
+++ b/internal/api/handlers/reading_date_test.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725
+
+package handlers
+
+import (
+	"testing"
+	"time"
+)
+
+// Regression test for a bug found 2026-08-27 while checking librarium-api#65:
+// every reading date came back a day early on any server not running in UTC.
+//
+// `date_started` and `date_finished` are dates wearing a timestamp. The client
+// sends YYYY-MM-DD, the handler parses it to midnight UTC, and the column is a
+// `timestamptz` because the same table carries real instants for progress. The
+// render then formatted it in whatever zone the connection returned, so
+// midnight UTC read west of Greenwich is the previous day: a book finished on
+// 1 January came back finished on 31 December.
+//
+// The deployment compose files mount /etc/localtime, so this is every
+// self-hosted instance outside UTC — and none of the CI that tests it, which
+// is why it survived.
+func TestReadingDateIsTheDayItWasWrittenAs(t *testing.T) {
+	day := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	t.Run("in UTC", func(t *testing.T) {
+		if got := readingDate(&day); got != "2026-01-01" {
+			t.Errorf("got %v, want 2026-01-01", got)
+		}
+	})
+
+	t.Run("read back west of Greenwich", func(t *testing.T) {
+		// What pgx hands back when the server runs in, say, Toronto: the same
+		// instant, carrying a zone four hours behind. Formatting it there is
+		// what produced 2025-12-31.
+		toronto := time.FixedZone("EST", -5*60*60)
+		shifted := day.In(toronto)
+		if got := readingDate(&shifted); got != "2026-01-01" {
+			t.Errorf("got %v, want 2026-01-01", got)
+		}
+	})
+
+	t.Run("read back east of Greenwich", func(t *testing.T) {
+		// The other direction rounds the wrong way just as easily.
+		sydney := time.FixedZone("AEDT", 11*60*60)
+		shifted := day.In(sydney)
+		if got := readingDate(&shifted); got != "2026-01-01" {
+			t.Errorf("got %v, want 2026-01-01", got)
+		}
+	})
+
+	t.Run("no date stays absent", func(t *testing.T) {
+		// nil rather than an empty string: the client tells "never started"
+		// apart from "started, date unknown" by the null.
+		if got := readingDate(nil); got != nil {
+			t.Errorf("got %v, want nil", got)
+		}
+	})
+}


### PR DESCRIPTION
Every reading date came back a day early on any server not running in UTC. Reproduced against a running instance: send `2026-01-01`, get `2025-12-31`; `2026-06-15` becomes `2026-06-14`, and so on.

`date_started` and `date_finished` are dates wearing a timestamp. The handler parses `YYYY-MM-DD` to midnight UTC, `reading_sessions` stores it in a `timestamptz` because the same table carries real instants for progress tracking, and the render then formatted it in whatever zone the connection returned. Midnight UTC read west of Greenwich is the previous day.

Every other date the API returns is a real `DATE` column, which is why loans and publish dates are unaffected. These two are the only exception, so the fix is spelled out at that one site rather than applied everywhere.

The deployment compose files mount `/etc/localtime`, so this hits every self-hosted instance outside UTC and none of the CI that tests it. That is why it survived: the tests run in UTC, where the bug does not exist.

Found while checking #65. Verified against the running API before and after: three dates round-trip exactly now.
