### PR TITLE
Recover from a failed migration without anyone editing the database by hand

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ internal/
   service/               business logic. Handlers call these; workers call these
   repository/            SQL. One file per aggregate, hand-written queries
   models/                domain structs shared across layers
-  db/migrations/         numbered golang-migrate pairs, 22 and counting
+  db/migrations/         numbered golang-migrate pairs, 39 and counting
   jobs/                  the unified job framework: kind registry and cron scheduler
   workers/               River workers for import, enrichment, AI suggestions
   providers/             book metadata sources: Open Library, Google Books, ISBNdb,
@@ -107,6 +107,12 @@ than adding a container dependency to the default `go test` path.
 - **Never edit a shipped migration.** Add a new numbered pair in
   `internal/db/migrations/`. Both `.up.sql` and `.down.sql`, and the down has to
   actually reverse the up.
+- **A migration has to roll back in full.** golang-migrate sends each file as
+  one simple query and Postgres runs that in an implicit transaction, which is
+  what lets `Migrate` retry a failed migration instead of leaving a dirty flag
+  for someone to clear by hand. `CREATE INDEX CONCURRENTLY`, `VACUUM` and
+  explicit `BEGIN`/`COMMIT` break that, and `TestEveryMigrationIsAtomic` fails
+  if one appears.
 - **Never hand-edit the version.** `internal/version/version.go` reports
   `0.0.0-dev` and the release workflow injects the real `YY.M.R` via ldflags.
   A version bump in a feature diff will be asked out of the PR.

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -70,8 +70,10 @@ func main() {
 		switch os.Args[1] {
 		case "preflight":
 			os.Exit(runPreflight(os.Args[2:]))
+		case "repair":
+			os.Exit(runRepair(os.Args[2:]))
 		default:
-			fmt.Fprintf(os.Stderr, "unknown command %q (known commands: preflight)\n", os.Args[1])
+			fmt.Fprintf(os.Stderr, "unknown command %q (known commands: preflight, repair)\n", os.Args[1])
 			os.Exit(2)
 		}
 	}

--- a/cmd/api/repair.go
+++ b/cmd/api/repair.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725
+
+package main
+
+import (
+	"bufio"
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/fireball1725/librarium-api/internal/config"
+	"github.com/fireball1725/librarium-api/internal/db"
+)
+
+// runRepair checks whether schema_migrations is telling the truth and, if it is
+// not, puts it right. It returns the process exit code.
+//
+// Migrate rewinds its own failures, so a database this build has always managed
+// cannot need this. It is here for databases that were repaired by hand before
+// that shipped: setting the version to the migration that just failed, rather
+// than the one before it, marks a migration as applied when it rolled back, and
+// nothing in the schema disagrees loudly enough to notice until a later
+// migration reaches for a table that was never created.
+//
+// It reads first and prints what it found. Applying needs a yes, because the
+// evidence is what the schema contains rather than a record of what ran:
+//
+//	docker compose run --rm api repair
+func runRepair(args []string) int {
+	fs := flag.NewFlagSet("repair", flag.ContinueOnError)
+	dsn := fs.String("database-url", "", "Postgres connection string (defaults to DATABASE_URL)")
+	yes := fs.Bool("yes", false, "apply the repair without asking, for non-interactive use")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	url := *dsn
+	if url == "" {
+		url = config.Load().DatabaseURL
+	}
+	if url == "" {
+		_, _ = fmt.Fprintln(os.Stderr, "repair: no database URL; pass --database-url or set DATABASE_URL")
+		return 2
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	pool, err := db.Connect(ctx, url)
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "repair: connecting: %v\n", err)
+		return 1
+	}
+	defer pool.Close()
+
+	plan, err := db.AnalyseRepair(ctx, pool)
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "repair: %v\n", err)
+		return 1
+	}
+	plan.Report(os.Stdout)
+
+	if !plan.NeedsRepair() {
+		return 0
+	}
+	if !plan.Confident {
+		return 1
+	}
+
+	if !*yes && !confirm(os.Stdin, os.Stdout) {
+		_, _ = fmt.Fprintln(os.Stdout, "Nothing written.")
+		return 1
+	}
+
+	if err := db.ApplyRepair(url, plan); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "repair: %v\n", err)
+		return 1
+	}
+
+	_, _ = fmt.Fprintln(os.Stdout, "\nDone. Start the server and the outstanding migrations will run.")
+	return 0
+}
+
+// confirm asks before writing. A pipe with no --yes is a no rather than a
+// silent yes, because the whole point of this command is that someone looked.
+func confirm(in *os.File, out *os.File) bool {
+	info, err := in.Stat()
+	if err != nil || info.Mode()&os.ModeCharDevice == 0 {
+		_, _ = fmt.Fprintln(out, "\nRe-run with --yes to apply this, once the plan above looks right.")
+		return false
+	}
+
+	_, _ = fmt.Fprint(out, "\nApply it? [y/N] ")
+	answer, err := bufio.NewReader(in).ReadString('\n')
+	if err != nil {
+		return false
+	}
+	answer = strings.ToLower(strings.TrimSpace(answer))
+	return answer == "y" || answer == "yes"
+}

--- a/deploy/docker-compose/README.md
+++ b/deploy/docker-compose/README.md
@@ -77,7 +77,17 @@ docker compose up -d
 
 Compose will replace the api and web containers and leave the db untouched. Database migrations run automatically on API startup.
 
-If something breaks after an upgrade, roll back by pinning the previous tag and re-running `docker compose up -d`. (This only works cleanly within the same schema version — check the CHANGELOG for migration-related notes before upgrading across larger jumps.)
+Rolling back is pinning the previous tag and re-running `docker compose up -d`, but only within the same schema version. Migrations run forward, and an older image refuses to start against a database a newer one has already migrated. Check the CHANGELOG for migration notes before a larger jump, and take a dump first.
+
+### Before a large upgrade
+
+Migrations run at boot, so one that refuses is a server that will not start. `preflight` asks the same questions ahead of time, against the new image, and changes nothing:
+
+```bash
+docker compose run --rm api preflight
+```
+
+Lines marked `!` have to be resolved before upgrading. The rest are counts you can check against the result afterwards.
 
 ## Data persistence
 
@@ -153,4 +163,22 @@ docker compose down -v
 
 **Images won't pull (`denied` or `unauthorized`).** The GHCR images are public, so this is almost always a stale Docker login. `docker logout ghcr.io` and try again.
 
-**Migration fails on startup, API crash-loops.** Open an issue with the full `librarium-api` log output. Migrations are applied in order and never edited after release, so a failure usually means a partially-applied migration from a previous crash. Recovery instructions will depend on where it stopped.
+### Migration failures
+
+Read the last `migration failed` line first. It names the migration, the line it stopped on, and what Postgres said.
+
+**A migration failed.** The API puts the version back on its way out, so the next start retries from the schema it began with and prints the same error until the cause is fixed. Nothing needs clearing by hand.
+
+**"it was migrated by a newer release than the one now running".** This database has been through a newer image than the tag now in `.env`. Put `API_TAG` back to the version that last ran, or restore a dump taken before that upgrade.
+
+**"Run `librarium-api repair`".** The version in `schema_migrations` names a migration that never ran, which is what a row edited by hand looks like. `repair` checks which migrations left their tables behind and prints what it found before changing anything:
+
+```bash
+docker compose run --rm api repair
+```
+
+Take a dump first. It asks before writing, and refuses outright when the evidence does not settle the question.
+
+Do not edit `schema_migrations` yourself. Setting the version to the migration that just failed marks it as applied, and the next start resumes at the one after it, which then fails on tables its predecessor never created.
+
+If the cause is not something you can fix in your own data, open an issue with the full `librarium-api` log output.

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/google/uuid v1.6.0
+	github.com/jackc/pgerrcode v0.0.0-20240316143900-6e2875d9b438
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/riverqueue/river v0.44.0
 	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.44.0
@@ -35,7 +36,6 @@ require (
 	github.com/go-openapi/spec v0.20.4 // indirect
 	github.com/go-openapi/swag v0.19.15 // indirect
 	github.com/invopop/jsonschema v0.14.0 // indirect
-	github.com/jackc/pgerrcode v0.0.0-20240316143900-6e2875d9b438 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -9,12 +9,16 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"regexp"
 	"strings"
 	"time"
 
 	"github.com/golang-migrate/migrate/v4"
+	"github.com/golang-migrate/migrate/v4/database"
 	_ "github.com/golang-migrate/migrate/v4/database/pgx/v5"
 	"github.com/golang-migrate/migrate/v4/source/iofs"
+	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -45,16 +49,41 @@ func Connect(ctx context.Context, databaseURL string) (*pgxpool.Pool, error) {
 }
 
 // Migrate runs all pending up migrations embedded in the binary.
+//
+// Anything that fails here stops the server, so the states that used to need
+// someone with psql are handled here instead:
+//
+//   - A migration that failed leaves schema_migrations dirty. golang-migrate's
+//     pgx driver sends each file to the server as one simple query, and Postgres
+//     wraps a multi-statement simple query in an implicit transaction, so a
+//     failed migration rolled back in full and the schema is exactly as it was.
+//     Rewinding the version so the file runs again is therefore safe, and doing
+//     it here means the next boot shows the error that actually caused the
+//     failure rather than a dirty flag. That matters because the intuitive way
+//     to clear a dirty flag is to clear the flag, and clearing it in place marks
+//     the failed migration as applied: the next boot resumes at the migration
+//     after it, which then fails on tables its predecessor never created.
+//
+//   - A database migrated by a newer build than the one now running. Left to
+//     golang-migrate that surfaces as a missing file for a version it has never
+//     heard of, which sends people looking for a packaging bug.
+//
+// What is not handled here is a version that was already set by hand before
+// this build shipped. Deciding that needs evidence from the schema and a person
+// who can say yes, so it lives in the repair subcommand.
 func Migrate(databaseURL string) error {
+	head, err := headVersion()
+	if err != nil {
+		return err
+	}
+
 	source, err := iofs.New(migrationsFS, "migrations")
 	if err != nil {
 		return fmt.Errorf("creating migration source: %w", err)
 	}
 
 	// golang-migrate's pgx/v5 driver expects the pgx5:// scheme.
-	migrateURL := toPgx5URL(databaseURL)
-
-	m, err := migrate.NewWithSourceInstance("iofs", source, migrateURL)
+	m, err := migrate.NewWithSourceInstance("iofs", source, toPgx5URL(databaseURL))
 	if err != nil {
 		return fmt.Errorf("creating migrator: %w", err)
 	}
@@ -68,31 +97,12 @@ func Migrate(databaseURL string) error {
 		}
 	}()
 
-	if err := m.Up(); err != nil && !errors.Is(err, migrate.ErrNoChange) {
-		// A dirty version means a migration started and did not finish. This
-		// used to auto-recover by calling Force(dirtyVersion) and retrying Up(),
-		// which is wrong in a way that hides itself: Force marks that version
-		// APPLIED, so the retry resumes at the next one and the failed migration
-		// never runs. golang-migrate wraps each file in a transaction, so its
-		// changes were rolled back — the schema then claims work that is not
-		// there. Survivable when a migration only adds a column; not survivable
-		// when one moves data.
-		//
-		// So: refuse to start, and make the operator decide. Recovery is either
-		// restoring the backup taken before the upgrade, or forcing to the
-		// version BEFORE the failed one so it runs again, and the difference
-		// depends on whether the file is idempotent. Neither is a choice a boot
-		// sequence should make on someone's behalf.
-		var dirtyErr migrate.ErrDirty
-		if errors.As(err, &dirtyErr) {
-			return fmt.Errorf(
-				"database is in a dirty migration state at version %d: migration %d started and did not complete, "+
-					"so the schema may not match what schema_migrations reports. Refusing to continue. "+
-					"Restore the backup taken before the upgrade, or if you are certain migration %d applied nothing, "+
-					"force the version to %d and restart to retry it",
-				dirtyErr.Version, dirtyErr.Version, dirtyErr.Version, dirtyErr.Version-1)
-		}
-		return fmt.Errorf("running migrations: %w", err)
+	if err := refuseIfAhead(m, head); err != nil {
+		return err
+	}
+
+	if err := runUp(m); err != nil {
+		return err
 	}
 
 	version, dirty, err := m.Version()
@@ -102,6 +112,223 @@ func Migrate(databaseURL string) error {
 	slog.Info("migrations up to date", "version", version, "dirty", dirty)
 
 	return nil
+}
+
+// refuseIfAhead stops a build from running against a database that a later one
+// has already migrated. Nothing here can fix that, but saying so beats the
+// error golang-migrate would give, which names a file rather than the image.
+func refuseIfAhead(m *migrate.Migrate, head int) error {
+	version, _, err := m.Version()
+	if errors.Is(err, migrate.ErrNilVersion) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("reading migration version: %w", err)
+	}
+	if int(version) <= head {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"this database is at migration version %d and this build ships %d: it was migrated by a newer "+
+			"release than the one now running. Start the image that last migrated it, or restore a backup "+
+			"taken before that upgrade", version, head)
+}
+
+// runUp applies everything pending, recovering from a run that was interrupted
+// and rewinding its own failure so the next attempt starts from a clean state.
+func runUp(m *migrate.Migrate) error {
+	err := m.Up()
+
+	// Dirty on entry means a previous process started a migration and was
+	// killed before it could finish or tidy up. The file rolled back with its
+	// transaction, so let it run again.
+	var dirty migrate.ErrDirty
+	if errors.As(err, &dirty) {
+		if rerr := rewind(m, dirty.Version, "was interrupted"); rerr != nil {
+			return rerr
+		}
+		err = m.Up()
+	}
+
+	if err == nil || errors.Is(err, migrate.ErrNoChange) {
+		return nil
+	}
+
+	// The migration that just failed left the version dirty. Put it back before
+	// returning, so what anyone sees on the next boot is the error below.
+	failed := unknownVersion
+	if version, isDirty, verr := m.Version(); verr == nil && isDirty {
+		failed = int(version)
+		if rerr := rewind(m, failed, "failed"); rerr != nil {
+			return errors.Join(explainFailure(failed, err), rerr)
+		}
+	}
+
+	return explainFailure(failed, err)
+}
+
+// unknownVersion is used when a failure cannot be pinned to a migration.
+const unknownVersion = -1
+
+// migrationFailure keeps the original error reachable while presenting
+// something a person can read. golang-migrate renders a failure by printing the
+// entire migration file, which for the schema-tiers migration is 900 lines of
+// SQL wrapped in one JSON log field, and the sentence that matters is the last
+// one.
+type migrationFailure struct {
+	msg string
+	err error
+}
+
+func (e migrationFailure) Error() string { return e.msg }
+func (e migrationFailure) Unwrap() error { return e.err }
+
+// explainFailure turns a migration error into the four things worth knowing:
+// which migration, which line, what Postgres said, and whether the cause is a
+// version that claims a migration which never ran.
+func explainFailure(version int, err error) error {
+	var dbErr database.Error
+	pgErr, ok := asPgError(err, &dbErr)
+	if !ok {
+		return fmt.Errorf("running migrations: %w", err)
+	}
+
+	name := "unknown"
+	if source, found, srcErr := migrationByVersion(version); srcErr == nil && found {
+		name = source.Name
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "migration %d (%s) failed", version, name)
+	if dbErr.Line > 0 {
+		fmt.Fprintf(&b, " at line %d", dbErr.Line)
+	}
+	fmt.Fprintf(&b, ": %s (SQLSTATE %s)", pgErr.Message, pgErr.Code)
+
+	if stmt := sourceLine(dbErr.Query, dbErr.Line); stmt != "" {
+		fmt.Fprintf(&b, "\n    %s", stmt)
+	}
+	if pgErr.Detail != "" {
+		fmt.Fprintf(&b, "\n%s", pgErr.Detail)
+	}
+	if pgErr.Hint != "" {
+		fmt.Fprintf(&b, "\n%s", pgErr.Hint)
+	}
+	if hint := missingObjectHint(pgErr); hint != "" {
+		fmt.Fprintf(&b, "\n\n%s", hint)
+	}
+
+	return migrationFailure{msg: b.String(), err: err}
+}
+
+// asPgError digs the Postgres error out of golang-migrate's wrapper, which does
+// not implement Unwrap.
+func asPgError(err error, dbErr *database.Error) (*pgconn.PgError, bool) {
+	if !errors.As(err, dbErr) {
+		return nil, false
+	}
+	pgErr, ok := dbErr.OrigErr.(*pgconn.PgError)
+	return pgErr, ok
+}
+
+// sourceLine pulls one line out of the migration body, so the report shows the
+// statement that failed rather than the file that contained it.
+func sourceLine(query []byte, line uint) string {
+	if line == 0 {
+		return ""
+	}
+	lines := strings.Split(string(query), "\n")
+	if int(line) > len(lines) {
+		return ""
+	}
+	return strings.TrimSpace(lines[line-1])
+}
+
+// rewind sets the version back to the one before an unfinished migration, so
+// that migration runs again. It refuses when the file could have left something
+// behind, because then the schema and the version disagree in a way only a
+// person with the backup can settle.
+func rewind(m *migrate.Migrate, version int, why string) error {
+	source, ok, err := migrationByVersion(version)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf(
+			"migration %d %s but is not in this build, so it cannot be retried: start the image that "+
+				"last migrated this database", version, why)
+	}
+
+	if reasons := atomicityBlockers(source.SQL); len(reasons) > 0 {
+		return fmt.Errorf(
+			"migration %d (%s) %s and cannot be retried automatically because %s. Part of it may have "+
+				"applied, so the schema may not match what schema_migrations reports. Restore the backup "+
+				"taken before the upgrade", version, source.Name, why, strings.Join(reasons, "; "))
+	}
+
+	target := version - 1
+	if target < 1 {
+		target = NoVersion
+	}
+	if err := m.Force(target); err != nil {
+		return fmt.Errorf("rewinding schema_migrations from %d to %s: %w", version, versionLabel(target), err)
+	}
+
+	slog.Warn("rolled back an unfinished migration; it runs again on the next start",
+		"migration", version, "name", source.Name, "reason", why, "version_set_to", versionLabel(target))
+	return nil
+}
+
+// quotedName pulls the first quoted identifier out of a Postgres error message.
+// The message text is translated when lc_messages is set; the identifier inside
+// it is not.
+var quotedName = regexp.MustCompile(`"([^"]+)"`)
+
+// missingObjectHint adds the one thing Postgres cannot know: which migration
+// was supposed to create the object that is missing. A database whose version
+// was set by hand always fails this way, on a later migration reaching for
+// something its predecessor never created.
+func missingObjectHint(pgErr *pgconn.PgError) string {
+	switch pgErr.Code {
+	case pgerrcode.UndefinedTable, pgerrcode.UndefinedColumn,
+		pgerrcode.UndefinedFunction, pgerrcode.UndefinedObject:
+	default:
+		return ""
+	}
+
+	match := quotedName.FindStringSubmatch(pgErr.Message)
+	if match == nil {
+		return ""
+	}
+	creator, found, err := migrationThatCreates(match[1])
+	if err != nil || !found {
+		return ""
+	}
+
+	return fmt.Sprintf(
+		"%q is created by migration %d (%s), which schema_migrations reports as already applied. "+
+			"A version that was set by hand looks exactly like this. Run `librarium-api repair` to see "+
+			"which migrations actually ran.", match[1], creator.Version, creator.Name)
+}
+
+// migrationThatCreates finds the earliest migration that creates a named object.
+func migrationThatCreates(name string) (migrationSource, bool, error) {
+	ups, err := upMigrations()
+	if err != nil {
+		return migrationSource{}, false, err
+	}
+	for _, source := range ups {
+		for _, p := range probes(source.SQL) {
+			if p.kind != probeColumn && p.target == name {
+				return source, true, nil
+			}
+			if p.kind == probeColumn && p.column == name {
+				return source, true, nil
+			}
+		}
+	}
+	return migrationSource{}, false, nil
 }
 
 // toPgx5URL converts a postgres:// or postgresql:// URL to the pgx5:// scheme

--- a/internal/db/migrate_test.go
+++ b/internal/db/migrate_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -16,8 +15,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 )
-
-var migrationName = regexp.MustCompile(`^(\d{6})_([a-z0-9_]+)\.(up|down)\.sql$`)
 
 // TestMigrationFilesAreWellFormed needs no database, so it runs everywhere and
 // catches the mistakes that are cheap to make and expensive to discover on a
@@ -95,7 +92,14 @@ func TestMigrationFilesAreWellFormed(t *testing.T) {
 // Point LIBRARIUM_MIGRATE_TEST_DSN at any Postgres the test may create and drop
 // databases on. It is deliberately not LIBRARIUM_TEST_DSN, which points at a
 // restored copy of a real collection and must not be written to.
-func TestMigrationsApplyToEmptyDatabase(t *testing.T) {
+// withScratchDatabase creates a throwaway database, hands its DSN to fn, and
+// drops it afterwards. Point LIBRARIUM_MIGRATE_TEST_DSN at any Postgres the
+// test may create and drop databases on. It is deliberately not
+// LIBRARIUM_TEST_DSN, which points at a restored copy of a real collection and
+// must not be written to.
+func withScratchDatabase(t *testing.T, fn func(dsn string)) {
+	t.Helper()
+
 	adminDSN := os.Getenv("LIBRARIUM_MIGRATE_TEST_DSN")
 	if adminDSN == "" {
 		t.Skip("set LIBRARIUM_MIGRATE_TEST_DSN to run")
@@ -127,77 +131,90 @@ func TestMigrationsApplyToEmptyDatabase(t *testing.T) {
 		t.Fatalf("building scratch DSN: %v", err)
 	}
 
-	if err := Migrate(scratchDSN); err != nil {
-		t.Fatalf("migrating an empty database: %v", err)
-	}
+	fn(scratchDSN)
+}
 
-	conn, err := pgx.Connect(ctx, scratchDSN)
-	if err != nil {
-		t.Fatalf("connecting to scratch database: %v", err)
-	}
-	defer func() { _ = conn.Close(ctx) }()
+// TestMigrationsApplyToEmptyDatabase runs the real migrator against a scratch
+// database created for this test and dropped afterwards. It exists because
+// nothing else in the repo ever executes a migration: the live tests skip
+// without a DSN and CI never sets one, so until now a migration reached a real
+// instance without having been run once.
+func TestMigrationsApplyToEmptyDatabase(t *testing.T) {
+	withScratchDatabase(t, func(scratchDSN string) {
+		ctx := context.Background()
 
-	// The head on disk is the only correct answer, so derive it rather than
-	// hardcoding a number this test would then need updating for.
-	entries, err := migrationsFS.ReadDir("migrations")
-	if err != nil {
-		t.Fatalf("reading embedded migrations: %v", err)
-	}
-	wantVersion := 0
-	for _, e := range entries {
-		if m := migrationName.FindStringSubmatch(e.Name()); m != nil && m[3] == "up" {
-			if n, _ := strconv.Atoi(m[1]); n > wantVersion {
-				wantVersion = n
+		if err := Migrate(scratchDSN); err != nil {
+			t.Fatalf("migrating an empty database: %v", err)
+		}
+
+		conn, err := pgx.Connect(ctx, scratchDSN)
+		if err != nil {
+			t.Fatalf("connecting to scratch database: %v", err)
+		}
+		defer func() { _ = conn.Close(ctx) }()
+
+		// The head on disk is the only correct answer, so derive it rather than
+		// hardcoding a number this test would then need updating for.
+		entries, err := migrationsFS.ReadDir("migrations")
+		if err != nil {
+			t.Fatalf("reading embedded migrations: %v", err)
+		}
+		wantVersion := 0
+		for _, e := range entries {
+			if m := migrationName.FindStringSubmatch(e.Name()); m != nil && m[3] == "up" {
+				if n, _ := strconv.Atoi(m[1]); n > wantVersion {
+					wantVersion = n
+				}
 			}
 		}
-	}
 
-	var version int
-	var dirty bool
-	if err := conn.QueryRow(ctx, `SELECT version, dirty FROM schema_migrations`).Scan(&version, &dirty); err != nil {
-		t.Fatalf("reading schema_migrations: %v", err)
-	}
-	if dirty {
-		t.Error("migrations finished dirty, which should now be impossible: Migrate refuses to continue past a dirty state")
-	}
-	if version != wantVersion {
-		t.Errorf("schema_migrations version = %d, want %d (the highest up migration on disk)", version, wantVersion)
-	}
+		var version int
+		var dirty bool
+		if err := conn.QueryRow(ctx, `SELECT version, dirty FROM schema_migrations`).Scan(&version, &dirty); err != nil {
+			t.Fatalf("reading schema_migrations: %v", err)
+		}
+		if dirty {
+			t.Error("migrations finished dirty, which should now be impossible: Migrate refuses to continue past a dirty state")
+		}
+		if version != wantVersion {
+			t.Errorf("schema_migrations version = %d, want %d (the highest up migration on disk)", version, wantVersion)
+		}
 
-	// A handful of invariants, chosen because each has actually been wrong at
-	// some point rather than to pad the count.
-	var roles, permissions, mediaTypes int
-	if err := conn.QueryRow(ctx, `SELECT count(*) FROM roles`).Scan(&roles); err != nil {
-		t.Fatalf("counting roles: %v", err)
-	}
-	if roles == 0 {
-		t.Error("no roles seeded; RequireLibraryPermission has nothing to resolve against")
-	}
-	if err := conn.QueryRow(ctx, `SELECT count(*) FROM permissions`).Scan(&permissions); err != nil {
-		t.Fatalf("counting permissions: %v", err)
-	}
-	if permissions == 0 {
-		t.Error("no permissions seeded")
-	}
-	if err := conn.QueryRow(ctx, `SELECT count(*) FROM media_types`).Scan(&mediaTypes); err != nil {
-		t.Fatalf("counting media types: %v", err)
-	}
-	if mediaTypes == 0 {
-		t.Error("no media types seeded; 000008 refuses to backfill floating books without one")
-	}
+		// A handful of invariants, chosen because each has actually been wrong at
+		// some point rather than to pad the count.
+		var roles, permissions, mediaTypes int
+		if err := conn.QueryRow(ctx, `SELECT count(*) FROM roles`).Scan(&roles); err != nil {
+			t.Fatalf("counting roles: %v", err)
+		}
+		if roles == 0 {
+			t.Error("no roles seeded; RequireLibraryPermission has nothing to resolve against")
+		}
+		if err := conn.QueryRow(ctx, `SELECT count(*) FROM permissions`).Scan(&permissions); err != nil {
+			t.Fatalf("counting permissions: %v", err)
+		}
+		if permissions == 0 {
+			t.Error("no permissions seeded")
+		}
+		if err := conn.QueryRow(ctx, `SELECT count(*) FROM media_types`).Scan(&mediaTypes); err != nil {
+			t.Fatalf("counting media types: %v", err)
+		}
+		if mediaTypes == 0 {
+			t.Error("no media types seeded; 000008 refuses to backfill floating books without one")
+		}
 
-	// Every permission granted to a role must exist. A typo here means a role
-	// silently grants nothing, which is the failure mode that is hardest to see
-	// from the admin UI.
-	var orphanGrants int
-	if err := conn.QueryRow(ctx, `
-		SELECT count(*) FROM role_permissions rp
-		WHERE NOT EXISTS (SELECT 1 FROM permissions p WHERE p.id = rp.permission_id)`).Scan(&orphanGrants); err != nil {
-		t.Fatalf("checking role_permissions: %v", err)
-	}
-	if orphanGrants != 0 {
-		t.Errorf("%d role_permissions rows reference a permission that does not exist", orphanGrants)
-	}
+		// Every permission granted to a role must exist. A typo here means a role
+		// silently grants nothing, which is the failure mode that is hardest to see
+		// from the admin UI.
+		var orphanGrants int
+		if err := conn.QueryRow(ctx, `
+			SELECT count(*) FROM role_permissions rp
+			WHERE NOT EXISTS (SELECT 1 FROM permissions p WHERE p.id = rp.permission_id)`).Scan(&orphanGrants); err != nil {
+			t.Fatalf("checking role_permissions: %v", err)
+		}
+		if orphanGrants != 0 {
+			t.Errorf("%d role_permissions rows reference a permission that does not exist", orphanGrants)
+		}
+	})
 }
 
 // replaceDatabase swaps the database name in a postgres DSN, keeping every

--- a/internal/db/repair.go
+++ b/internal/db/repair.go
@@ -1,0 +1,428 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725
+
+package db
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/golang-migrate/migrate/v4"
+	"github.com/golang-migrate/migrate/v4/source/iofs"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Repairing a database whose recorded version is a lie.
+//
+// schema_migrations holds one row: a version and a dirty flag. Nothing records
+// how it got there, so a version set by hand is indistinguishable from one the
+// migrator wrote. That matters because the intuitive way to clear a dirty flag
+// is to clear the flag, and doing that in place marks the migration that just
+// failed as applied. The next boot resumes at the following migration, which
+// then fails on tables its predecessor never created.
+//
+// Migrate now rewinds instead of leaving a dirty flag around to tempt anyone,
+// so new databases cannot reach that state. This exists for the ones that
+// already did.
+//
+// The evidence is the objects each migration creates. Because a migration runs
+// in one implicit transaction, a single missing object proves the whole file
+// did not apply, whatever the recorded version says. Presence proves less:
+// IF NOT EXISTS and OR REPLACE mean an object can predate the migration that
+// mentions it. So the walk moves down from the recorded version while it can
+// prove non-application, and stops at the first version it cannot, which is the
+// version to rewind to.
+
+// migrationName matches the NNNNNN_name.{up,down}.sql convention every file in
+// migrations/ follows.
+var migrationName = regexp.MustCompile(`^(\d{6})_([a-z0-9_]+)\.(up|down)\.sql$`)
+
+// migrationSource is one embedded up migration.
+type migrationSource struct {
+	Version int
+	Name    string
+	SQL     string
+}
+
+// upMigrations reads every embedded up migration, ordered by version.
+func upMigrations() ([]migrationSource, error) {
+	entries, err := migrationsFS.ReadDir("migrations")
+	if err != nil {
+		return nil, fmt.Errorf("reading embedded migrations: %w", err)
+	}
+
+	var out []migrationSource
+	for _, e := range entries {
+		m := migrationName.FindStringSubmatch(e.Name())
+		if m == nil || m[3] != "up" {
+			continue
+		}
+		version, err := strconv.Atoi(m[1])
+		if err != nil {
+			return nil, fmt.Errorf("%s: unparseable sequence number: %w", e.Name(), err)
+		}
+		body, err := migrationsFS.ReadFile("migrations/" + e.Name())
+		if err != nil {
+			return nil, fmt.Errorf("reading %s: %w", e.Name(), err)
+		}
+		out = append(out, migrationSource{Version: version, Name: m[2], SQL: string(body)})
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].Version < out[j].Version })
+	return out, nil
+}
+
+// headVersion is the highest migration this binary carries.
+func headVersion() (int, error) {
+	ups, err := upMigrations()
+	if err != nil {
+		return 0, err
+	}
+	if len(ups) == 0 {
+		return 0, fmt.Errorf("no embedded up migrations; the embed pattern is wrong")
+	}
+	return ups[len(ups)-1].Version, nil
+}
+
+// migrationByVersion returns one embedded migration.
+func migrationByVersion(version int) (migrationSource, bool, error) {
+	ups, err := upMigrations()
+	if err != nil {
+		return migrationSource{}, false, err
+	}
+	for _, m := range ups {
+		if m.Version == version {
+			return m, true, nil
+		}
+	}
+	return migrationSource{}, false, nil
+}
+
+// Verdict is what the objects on disk say about one migration.
+type Verdict int
+
+const (
+	// VerdictUnknown means the migration creates nothing we can look for, so
+	// its state cannot be settled either way. Data-only migrations land here.
+	VerdictUnknown Verdict = iota
+	// VerdictApplied means every object the migration creates is present.
+	VerdictApplied
+	// VerdictNotApplied means at least one is missing, which given atomicity
+	// means none of the file ran.
+	VerdictNotApplied
+)
+
+func (v Verdict) String() string {
+	switch v {
+	case VerdictApplied:
+		return "applied"
+	case VerdictNotApplied:
+		return "not applied"
+	default:
+		return "cannot tell"
+	}
+}
+
+// VersionReport is one migration's state, and why.
+type VersionReport struct {
+	Version int
+	Name    string
+	Verdict Verdict
+	Checked int
+	Missing []string
+	Note    string
+}
+
+// RepairPlan is what the database says, what that means, and what to do.
+type RepairPlan struct {
+	// Recorded is the version in schema_migrations, or NoVersion when the
+	// table is empty.
+	Recorded int
+	Dirty    bool
+	// Head is the highest migration this build ships.
+	Head int
+	// Reports covers the versions walked, highest first.
+	Reports []VersionReport
+	// Target is the version to write. Equal to Recorded when nothing is wrong.
+	Target int
+	// Confident is true when the walk ended on solid ground: either nothing
+	// needs changing, or it stopped at a version whose objects are all present.
+	Confident bool
+	Summary   string
+}
+
+// NoVersion marks an empty schema_migrations, matching golang-migrate's nil
+// version.
+const NoVersion = -1
+
+// NeedsRepair reports whether the plan would change anything.
+func (p RepairPlan) NeedsRepair() bool { return p.Target != p.Recorded }
+
+// AnalyseRepair works out whether the recorded version is telling the truth,
+// and what to write if it is not. It only reads.
+func AnalyseRepair(ctx context.Context, pool *pgxpool.Pool) (RepairPlan, error) {
+	head, err := headVersion()
+	if err != nil {
+		return RepairPlan{}, err
+	}
+
+	recorded, dirty, err := readRecordedVersion(ctx, pool)
+	if err != nil {
+		return RepairPlan{}, err
+	}
+
+	plan := RepairPlan{Recorded: recorded, Dirty: dirty, Head: head, Target: recorded}
+
+	switch {
+	case recorded == NoVersion:
+		plan.Confident = true
+		plan.Summary = "schema_migrations is empty, so this database has not been migrated yet. Nothing to repair."
+		return plan, nil
+
+	case recorded > head:
+		plan.Summary = fmt.Sprintf(
+			"schema_migrations is at version %d and this build ships %d. The database was migrated by a newer "+
+				"build than this one, so there is nothing to repair here: run the newer image instead.",
+			recorded, head)
+		return plan, nil
+	}
+
+	target := recorded
+	stopped := false
+	for version := recorded; version >= 1; version-- {
+		report, err := evaluateVersion(ctx, pool, version)
+		if err != nil {
+			return RepairPlan{}, err
+		}
+
+		if version == recorded && dirty {
+			report.Verdict = VerdictNotApplied
+			report.Note = "left dirty, so it was interrupted and rolled back"
+		}
+
+		plan.Reports = append(plan.Reports, report)
+
+		if report.Verdict == VerdictNotApplied {
+			target = version - 1
+			continue
+		}
+
+		stopped = true
+		plan.Confident = report.Verdict == VerdictApplied
+		break
+	}
+
+	if !stopped {
+		// Walked past migration 1 without finding anything applied, so the
+		// right answer is to start over from an empty version.
+		target = NoVersion
+		plan.Confident = true
+	}
+	if target < 1 {
+		target = NoVersion
+	}
+	plan.Target = target
+
+	switch {
+	case !plan.NeedsRepair():
+		plan.Confident = true
+		plan.Summary = fmt.Sprintf("schema_migrations is at version %d and the objects that migration creates are present. Nothing to repair.", recorded)
+	case plan.Confident:
+		plan.Summary = fmt.Sprintf(
+			"schema_migrations claims version %d, but %s. Setting the version to %s lets those migrations run.",
+			recorded, describeGap(plan), versionLabel(target))
+	default:
+		plan.Summary = fmt.Sprintf(
+			"schema_migrations claims version %d and the migrations above %s did not run, but %s creates nothing this can look for, "+
+				"so whether it ran cannot be settled from the schema. Restore the backup taken before the upgrade rather than guessing.",
+			recorded, versionLabel(target), versionLabel(target))
+	}
+
+	return plan, nil
+}
+
+// describeGap summarises the versions the walk proved had not run.
+func describeGap(p RepairPlan) string {
+	var unapplied []string
+	for _, r := range p.Reports {
+		if r.Verdict == VerdictNotApplied {
+			unapplied = append(unapplied, strconv.Itoa(r.Version))
+		}
+	}
+	sort.Strings(unapplied)
+	if len(unapplied) == 1 {
+		return "migration " + unapplied[0] + " never ran"
+	}
+	return "migrations " + strings.Join(unapplied, ", ") + " never ran"
+}
+
+func versionLabel(v int) string {
+	if v == NoVersion {
+		return "empty"
+	}
+	return strconv.Itoa(v)
+}
+
+// evaluateVersion asks the database whether one migration's objects are there.
+func evaluateVersion(ctx context.Context, pool *pgxpool.Pool, version int) (VersionReport, error) {
+	source, ok, err := migrationByVersion(version)
+	if err != nil {
+		return VersionReport{}, err
+	}
+	report := VersionReport{Version: version}
+	if !ok {
+		report.Note = "not in this build"
+		return report, nil
+	}
+	report.Name = source.Name
+
+	ps := probes(source.SQL)
+	report.Checked = len(ps)
+	if len(ps) == 0 {
+		report.Note = "creates nothing to look for"
+		return report, nil
+	}
+
+	for _, p := range ps {
+		present, err := probeExists(ctx, pool, p)
+		if err != nil {
+			return VersionReport{}, err
+		}
+		if !present {
+			report.Missing = append(report.Missing, p.String())
+		}
+	}
+
+	if len(report.Missing) > 0 {
+		report.Verdict = VerdictNotApplied
+	} else {
+		report.Verdict = VerdictApplied
+	}
+	return report, nil
+}
+
+func probeExists(ctx context.Context, pool *pgxpool.Pool, p probe) (bool, error) {
+	var exists bool
+	var err error
+
+	switch p.kind {
+	case probeColumn:
+		err = pool.QueryRow(ctx, `
+			SELECT EXISTS (
+			  SELECT 1 FROM information_schema.columns
+			   WHERE table_schema = current_schema()
+			     AND table_name = $1 AND column_name = $2)`, p.table, p.column).Scan(&exists)
+	case probeFunction:
+		err = pool.QueryRow(ctx, `
+			SELECT EXISTS (
+			  SELECT 1 FROM pg_proc p
+			    JOIN pg_namespace n ON n.oid = p.pronamespace
+			   WHERE n.nspname = current_schema() AND p.proname = $1)`, p.target).Scan(&exists)
+	default:
+		err = pool.QueryRow(ctx, `SELECT to_regclass($1) IS NOT NULL`, p.target).Scan(&exists)
+	}
+
+	if err != nil {
+		return false, fmt.Errorf("checking whether %s exists: %w", p, err)
+	}
+	return exists, nil
+}
+
+// readRecordedVersion reads schema_migrations without going through the
+// migrator, so it works when the migrator refuses to start.
+func readRecordedVersion(ctx context.Context, pool *pgxpool.Pool) (int, bool, error) {
+	var present bool
+	if err := pool.QueryRow(ctx, `SELECT to_regclass('schema_migrations') IS NOT NULL`).Scan(&present); err != nil {
+		return 0, false, fmt.Errorf("looking for schema_migrations: %w", err)
+	}
+	if !present {
+		return NoVersion, false, nil
+	}
+
+	var version int
+	var dirty bool
+	err := pool.QueryRow(ctx, `SELECT version, dirty FROM schema_migrations`).Scan(&version, &dirty)
+	if err != nil {
+		if strings.Contains(err.Error(), "no rows") {
+			return NoVersion, false, nil
+		}
+		return 0, false, fmt.Errorf("reading schema_migrations: %w", err)
+	}
+	return version, dirty, nil
+}
+
+// ApplyRepair writes the version the plan settled on. It refuses a plan that
+// would be a guess.
+func ApplyRepair(databaseURL string, plan RepairPlan) error {
+	if !plan.NeedsRepair() {
+		return nil
+	}
+	if !plan.Confident {
+		return fmt.Errorf("refusing to repair: %s", plan.Summary)
+	}
+	return forceVersion(databaseURL, plan.Target)
+}
+
+// Report renders a plan for a person reading a terminal.
+func (p RepairPlan) Report(w io.Writer) {
+	_, _ = fmt.Fprintf(w, "schema_migrations: version %s, dirty %t\n", versionLabel(p.Recorded), p.Dirty)
+	_, _ = fmt.Fprintf(w, "this build ships migrations up to %d\n\n", p.Head)
+
+	if len(p.Reports) > 0 {
+		tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+		_, _ = fmt.Fprintln(tw, "VERSION\tMIGRATION\tSTATE\tEVIDENCE")
+		for _, r := range p.Reports {
+			evidence := r.Note
+			if evidence == "" {
+				switch {
+				case len(r.Missing) > 0:
+					evidence = fmt.Sprintf("%d of %d objects missing, including %s",
+						len(r.Missing), r.Checked, r.Missing[0])
+				case r.Checked > 0:
+					evidence = fmt.Sprintf("all %d objects present", r.Checked)
+				}
+			}
+			_, _ = fmt.Fprintf(tw, "%d\t%s\t%s\t%s\n", r.Version, r.Name, r.Verdict, evidence)
+		}
+		_ = tw.Flush()
+		_, _ = fmt.Fprintln(w)
+	}
+
+	_, _ = fmt.Fprintln(w, p.Summary)
+	if p.NeedsRepair() && p.Confident {
+		_, _ = fmt.Fprintf(w, "\nAction: set schema_migrations to version %s. Migrations %d onwards then run on the next start.\n",
+			versionLabel(p.Target), p.Target+1)
+	}
+}
+
+// forceVersion writes a version into schema_migrations and clears the dirty
+// flag, which is the one thing this package does that a person would otherwise
+// do with an UPDATE.
+func forceVersion(databaseURL string, version int) error {
+	source, err := iofs.New(migrationsFS, "migrations")
+	if err != nil {
+		return fmt.Errorf("creating migration source: %w", err)
+	}
+
+	m, err := migrate.NewWithSourceInstance("iofs", source, toPgx5URL(databaseURL))
+	if err != nil {
+		return fmt.Errorf("creating migrator: %w", err)
+	}
+	defer func() {
+		if srcErr, dbErr := m.Close(); srcErr != nil || dbErr != nil {
+			slog.Error("closing migrator", "source_error", srcErr, "db_error", dbErr)
+		}
+	}()
+
+	if err := m.Force(version); err != nil {
+		return fmt.Errorf("setting schema_migrations to %s: %w", versionLabel(version), err)
+	}
+	return nil
+}

--- a/internal/db/repair_test.go
+++ b/internal/db/repair_test.go
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725
+
+package db
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/golang-migrate/migrate/v4"
+	"github.com/golang-migrate/migrate/v4/source/iofs"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// migrateTo brings a scratch database to one version, so a test can start from
+// a database that is genuinely mid-upgrade rather than one that pretends to be.
+func migrateTo(t *testing.T, dsn string, version uint) {
+	t.Helper()
+
+	source, err := iofs.New(migrationsFS, "migrations")
+	if err != nil {
+		t.Fatalf("creating migration source: %v", err)
+	}
+	m, err := migrate.NewWithSourceInstance("iofs", source, toPgx5URL(dsn))
+	if err != nil {
+		t.Fatalf("creating migrator: %v", err)
+	}
+	defer func() { _, _ = m.Close() }()
+
+	if err := m.Migrate(version); err != nil {
+		t.Fatalf("migrating to %d: %v", version, err)
+	}
+}
+
+func recordVersion(t *testing.T, dsn string, version int, dirty bool) {
+	t.Helper()
+
+	ctx := context.Background()
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connecting: %v", err)
+	}
+	defer pool.Close()
+
+	if _, err := pool.Exec(ctx,
+		`UPDATE schema_migrations SET version = $1, dirty = $2`, version, dirty); err != nil {
+		t.Fatalf("setting schema_migrations to %d/%t: %v", version, dirty, err)
+	}
+}
+
+func readVersion(t *testing.T, dsn string) (int, bool) {
+	t.Helper()
+
+	ctx := context.Background()
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connecting: %v", err)
+	}
+	defer pool.Close()
+
+	version, dirty, err := readRecordedVersion(ctx, pool)
+	if err != nil {
+		t.Fatalf("reading version: %v", err)
+	}
+	return version, dirty
+}
+
+// TestMigrateRetriesAnInterruptedMigration covers a container killed partway
+// through an upgrade. The migration rolled back with its transaction, so the
+// only thing standing between the database and a working server is a dirty
+// flag, and clearing that is not something anyone should be asked to do by
+// hand.
+func TestMigrateRetriesAnInterruptedMigration(t *testing.T) {
+	withScratchDatabase(t, func(dsn string) {
+		head, err := headVersion()
+		if err != nil {
+			t.Fatalf("reading head version: %v", err)
+		}
+
+		migrateTo(t, dsn, 24)
+		// What a kill -9 during migration 25 leaves behind.
+		recordVersion(t, dsn, 25, true)
+
+		if err := Migrate(dsn); err != nil {
+			t.Fatalf("Migrate should have recovered from a dirty version: %v", err)
+		}
+
+		version, dirty := readVersion(t, dsn)
+		if version != head || dirty {
+			t.Errorf("after recovery: version %d dirty %t, want %d false", version, dirty, head)
+		}
+	})
+}
+
+// TestRepairRecoversAHandEditedVersion is the failure a self-hoster reported on
+// 29 August 2026: migration 25 failed, the dirty flag was cleared in place
+// rather than rewound, and the next start ran migration 26 against a database
+// with none of the tables 25 creates.
+func TestRepairRecoversAHandEditedVersion(t *testing.T) {
+	withScratchDatabase(t, func(dsn string) {
+		ctx := context.Background()
+		head, err := headVersion()
+		if err != nil {
+			t.Fatalf("reading head version: %v", err)
+		}
+
+		migrateTo(t, dsn, 24)
+		// Clearing the flag without moving the version marks a migration that
+		// rolled back as applied.
+		recordVersion(t, dsn, 25, false)
+
+		// Booting now fails, and the message has to point somewhere useful.
+		err = Migrate(dsn)
+		if err == nil {
+			t.Fatal("Migrate succeeded against a database missing everything migration 25 creates")
+		}
+		for _, want := range []string{"copies", "migration 25", "repair"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("error does not mention %q: %v", want, err)
+			}
+		}
+
+		pool, err := pgxpool.New(ctx, dsn)
+		if err != nil {
+			t.Fatalf("connecting: %v", err)
+		}
+		defer pool.Close()
+
+		plan, err := AnalyseRepair(ctx, pool)
+		if err != nil {
+			t.Fatalf("analysing: %v", err)
+		}
+		if !plan.NeedsRepair() {
+			t.Fatal("repair found nothing to do")
+		}
+		if !plan.Confident {
+			t.Fatalf("repair was not confident: %s", plan.Summary)
+		}
+		if plan.Target != 24 {
+			t.Errorf("target = %d, want 24", plan.Target)
+		}
+
+		if err := ApplyRepair(dsn, plan); err != nil {
+			t.Fatalf("applying: %v", err)
+		}
+		if err := Migrate(dsn); err != nil {
+			t.Fatalf("migrating after repair: %v", err)
+		}
+
+		version, dirty := readVersion(t, dsn)
+		if version != head || dirty {
+			t.Errorf("after repair: version %d dirty %t, want %d false", version, dirty, head)
+		}
+	})
+}
+
+// TestRepairLeavesAHealthyDatabaseAlone is the case that has to stay boring:
+// running repair on a database with nothing wrong must not write anything.
+func TestRepairLeavesAHealthyDatabaseAlone(t *testing.T) {
+	withScratchDatabase(t, func(dsn string) {
+		ctx := context.Background()
+		if err := Migrate(dsn); err != nil {
+			t.Fatalf("migrating: %v", err)
+		}
+
+		pool, err := pgxpool.New(ctx, dsn)
+		if err != nil {
+			t.Fatalf("connecting: %v", err)
+		}
+		defer pool.Close()
+
+		plan, err := AnalyseRepair(ctx, pool)
+		if err != nil {
+			t.Fatalf("analysing: %v", err)
+		}
+		if plan.NeedsRepair() {
+			t.Errorf("repair wants to change a healthy database: %s", plan.Summary)
+		}
+	})
+}
+
+// TestMigrateRefusesADatabaseFromANewerBuild is the other half of the same
+// report: after the hand edit they rolled back to the release, which ships
+// fewer migrations than the version recorded.
+func TestMigrateRefusesADatabaseFromANewerBuild(t *testing.T) {
+	withScratchDatabase(t, func(dsn string) {
+		head, err := headVersion()
+		if err != nil {
+			t.Fatalf("reading head version: %v", err)
+		}
+
+		if err := Migrate(dsn); err != nil {
+			t.Fatalf("migrating: %v", err)
+		}
+		recordVersion(t, dsn, head+7, false)
+
+		err = Migrate(dsn)
+		if err == nil {
+			t.Fatal("Migrate accepted a database from a newer build")
+		}
+		if !strings.Contains(err.Error(), "newer release") {
+			t.Errorf("error should say the database came from a newer release, got: %v", err)
+		}
+		if version, _ := readVersion(t, dsn); version != head+7 {
+			t.Errorf("refusing changed the version to %d; it must not write anything", version)
+		}
+	})
+}

--- a/internal/db/sqlscan.go
+++ b/internal/db/sqlscan.go
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725
+
+package db
+
+import (
+	"regexp"
+	"strings"
+)
+
+// This file reads migration SQL as text rather than executing it, to answer two
+// questions that the repair paths depend on:
+//
+//   - Is this file atomic? golang-migrate's pgx driver sends a migration to the
+//     server as one simple query with no parameters, and Postgres wraps a
+//     multi-statement simple query in an implicit transaction. So a migration
+//     that fails rolls back in full, and rewinding schema_migrations so it runs
+//     again is safe. That holds only while nothing in the file breaks out of
+//     the transaction, which is what atomicityBlockers checks.
+//
+//   - What does this file create? If an object a migration creates is missing,
+//     the migration did not finish, whatever schema_migrations claims.
+//
+// Both matter only for text outside comments, string literals and PL/pgSQL
+// bodies, so everything here runs on the output of stripNoise.
+
+// stripNoise blanks out comments, string literals and dollar-quoted bodies,
+// keeping newlines so reported positions still make sense. Without it a BEGIN
+// inside a PL/pgSQL block reads as transaction control and every migration with
+// a DO block looks non-atomic.
+func stripNoise(sql string) string {
+	var b strings.Builder
+	b.Grow(len(sql))
+
+	keepNewlines := func(s string) {
+		for _, r := range s {
+			if r == '\n' {
+				b.WriteByte('\n')
+			} else {
+				b.WriteByte(' ')
+			}
+		}
+	}
+
+	for i := 0; i < len(sql); {
+		rest := sql[i:]
+
+		switch {
+		case strings.HasPrefix(rest, "--"):
+			end := strings.IndexByte(rest, '\n')
+			if end < 0 {
+				end = len(rest)
+			}
+			keepNewlines(rest[:end])
+			i += end
+
+		case strings.HasPrefix(rest, "/*"):
+			// Postgres block comments nest, so count depth rather than
+			// stopping at the first close.
+			depth, j := 1, 2
+			for j < len(rest) && depth > 0 {
+				switch {
+				case strings.HasPrefix(rest[j:], "/*"):
+					depth++
+					j += 2
+				case strings.HasPrefix(rest[j:], "*/"):
+					depth--
+					j += 2
+				default:
+					j++
+				}
+			}
+			keepNewlines(rest[:j])
+			i += j
+
+		case rest[0] == '\'':
+			j := 1
+			for j < len(rest) {
+				if rest[j] == '\'' {
+					if j+1 < len(rest) && rest[j+1] == '\'' {
+						j += 2
+						continue
+					}
+					j++
+					break
+				}
+				j++
+			}
+			keepNewlines(rest[:j])
+			i += j
+
+		case rest[0] == '"':
+			// Quoted identifiers are names, not noise: keep them so the object
+			// extraction below can see them.
+			j := 1
+			for j < len(rest) && rest[j] != '"' {
+				j++
+			}
+			if j < len(rest) {
+				j++
+			}
+			b.WriteString(rest[:j])
+			i += j
+
+		default:
+			if tag := dollarTag(rest); tag != "" {
+				end := strings.Index(rest[len(tag):], tag)
+				if end < 0 {
+					// Unterminated, which the server would reject anyway.
+					keepNewlines(rest)
+					i = len(sql)
+					continue
+				}
+				stop := len(tag) + end + len(tag)
+				keepNewlines(rest[:stop])
+				i += stop
+				continue
+			}
+			b.WriteByte(rest[0])
+			i++
+		}
+	}
+
+	return b.String()
+}
+
+var dollarTagPattern = regexp.MustCompile(`^\$([A-Za-z_][A-Za-z0-9_]*)?\$`)
+
+// dollarTag returns the dollar-quote delimiter starting s, or "" if s does not
+// start one. A bind placeholder like $1 is not a delimiter.
+func dollarTag(s string) string {
+	return dollarTagPattern.FindString(s)
+}
+
+// blocker is one reason a migration cannot be trusted to roll back in full.
+type blocker struct {
+	pattern *regexp.Regexp
+	reason  string
+}
+
+var blockers = []blocker{
+	{regexp.MustCompile(`(?i)\bCONCURRENTLY\b`),
+		"CREATE/DROP INDEX CONCURRENTLY cannot run inside a transaction"},
+	{regexp.MustCompile(`(?i)\bVACUUM\b`),
+		"VACUUM cannot run inside a transaction"},
+	{regexp.MustCompile(`(?i)\bREINDEX\b`),
+		"REINDEX may run outside a transaction"},
+	{regexp.MustCompile(`(?i)\bALTER\s+SYSTEM\b`),
+		"ALTER SYSTEM cannot run inside a transaction"},
+	{regexp.MustCompile(`(?i)\b(CREATE|DROP)\s+DATABASE\b`),
+		"CREATE/DROP DATABASE cannot run inside a transaction"},
+	{regexp.MustCompile(`(?i)\b(CREATE|DROP)\s+TABLESPACE\b`),
+		"CREATE/DROP TABLESPACE cannot run inside a transaction"},
+	{regexp.MustCompile(`(?i)(\A|;)\s*(BEGIN|COMMIT|ROLLBACK|START\s+TRANSACTION|SAVEPOINT)\b`),
+		"the file manages transactions itself, so a failure may leave part of it applied"},
+}
+
+// atomicityBlockers reports why a migration might not roll back cleanly. An
+// empty result means a failure leaves the schema exactly as it was, which is
+// the precondition for rewinding the version so the migration runs again.
+func atomicityBlockers(sql string) []string {
+	clean := stripNoise(sql)
+
+	var reasons []string
+	for _, b := range blockers {
+		if b.pattern.MatchString(clean) {
+			reasons = append(reasons, b.reason)
+		}
+	}
+	return reasons
+}
+
+// probeKind says how to ask the server whether an object exists.
+type probeKind int
+
+const (
+	probeRelation probeKind = iota // table, view, index or sequence
+	probeColumn
+	probeFunction
+)
+
+// probe is one object a migration creates, and so one piece of evidence about
+// whether that migration ran. Absence is the reliable direction: because a
+// migration is atomic, one missing object proves the whole file did not apply.
+// Presence is weaker, since IF NOT EXISTS and OR REPLACE mean an object may
+// predate the migration that mentions it.
+type probe struct {
+	kind   probeKind
+	target string // relation name, table.column, or function name
+	table  string // set for probeColumn
+	column string // set for probeColumn
+}
+
+func (p probe) String() string {
+	switch p.kind {
+	case probeColumn:
+		return "column " + p.table + "." + p.column
+	case probeFunction:
+		return "function " + p.target
+	default:
+		return p.target
+	}
+}
+
+var (
+	createRelation = regexp.MustCompile(
+		`(?is)\bCREATE\s+(?:OR\s+REPLACE\s+)?(?:UNIQUE\s+)?(?:MATERIALIZED\s+)?` +
+			`(?:TABLE|VIEW|INDEX|SEQUENCE)\s+(?:IF\s+NOT\s+EXISTS\s+)?("[^"]+"|[A-Za-z_][A-Za-z0-9_]*)`)
+	createTemp = regexp.MustCompile(`(?is)\bCREATE\s+(?:GLOBAL\s+|LOCAL\s+)?(?:TEMP|TEMPORARY|UNLOGGED)\s`)
+	addColumn  = regexp.MustCompile(
+		`(?is)\bALTER\s+TABLE\s+(?:IF\s+EXISTS\s+)?("[^"]+"|[A-Za-z_][A-Za-z0-9_]*)\s+` +
+			`ADD\s+COLUMN\s+(?:IF\s+NOT\s+EXISTS\s+)?("[^"]+"|[A-Za-z_][A-Za-z0-9_]*)`)
+	createFunction = regexp.MustCompile(
+		`(?is)\bCREATE\s+(?:OR\s+REPLACE\s+)?FUNCTION\s+("[^"]+"|[A-Za-z_][A-Za-z0-9_]*)`)
+)
+
+// identifier normalises a captured name the way Postgres would: quoted names
+// keep their case, bare ones fold to lower.
+func identifier(tok string) string {
+	if len(tok) >= 2 && tok[0] == '"' {
+		return tok[1 : len(tok)-1]
+	}
+	return strings.ToLower(tok)
+}
+
+// probes lists the objects a migration creates. Temporary and unlogged
+// relations are skipped: they say nothing about a migration that has finished.
+func probes(sql string) []probe {
+	clean := stripNoise(sql)
+
+	seen := map[string]bool{}
+	var out []probe
+	add := func(p probe) {
+		if key := p.String(); !seen[key] {
+			seen[key] = true
+			out = append(out, p)
+		}
+	}
+
+	for _, m := range createRelation.FindAllStringSubmatchIndex(clean, -1) {
+		if createTemp.MatchString(clean[m[0]:m[1]]) {
+			continue
+		}
+		add(probe{kind: probeRelation, target: identifier(clean[m[2]:m[3]])})
+	}
+	for _, m := range addColumn.FindAllStringSubmatch(clean, -1) {
+		add(probe{kind: probeColumn, table: identifier(m[1]), column: identifier(m[2])})
+	}
+	for _, m := range createFunction.FindAllStringSubmatch(clean, -1) {
+		add(probe{kind: probeFunction, target: identifier(m[1])})
+	}
+
+	return out
+}

--- a/internal/db/sqlscan_test.go
+++ b/internal/db/sqlscan_test.go
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725
+
+package db
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestStripNoiseKeepsCodeAndDropsTheRest(t *testing.T) {
+	tests := []struct {
+		name    string
+		sql     string
+		wants   []string
+		unwants []string
+	}{
+		{
+			name:    "line comment",
+			sql:     "CREATE TABLE a (); -- CREATE TABLE b ()\nCREATE TABLE c ();",
+			wants:   []string{"TABLE a", "TABLE c"},
+			unwants: []string{"TABLE b"},
+		},
+		{
+			name:    "nested block comment",
+			sql:     "/* outer /* inner CREATE TABLE b */ still outer */ CREATE TABLE a ();",
+			wants:   []string{"TABLE a"},
+			unwants: []string{"TABLE b"},
+		},
+		{
+			name:    "string literal",
+			sql:     "INSERT INTO t VALUES ('BEGIN; VACUUM;'); CREATE TABLE a ();",
+			unwants: []string{"VACUUM"},
+			wants:   []string{"TABLE a"},
+		},
+		{
+			name:    "escaped quote inside a literal",
+			sql:     "INSERT INTO t VALUES ('it''s VACUUM here'); CREATE TABLE a ();",
+			unwants: []string{"VACUUM"},
+			wants:   []string{"TABLE a"},
+		},
+		{
+			name: "plpgsql body",
+			sql: "DO $$ BEGIN IF true THEN RAISE EXCEPTION 'no'; END IF; END $$;\n" +
+				"CREATE TABLE a ();",
+			unwants: []string{"RAISE"},
+			wants:   []string{"TABLE a"},
+		},
+		{
+			name:  "bind placeholder is not a dollar quote",
+			sql:   "SELECT $1; CREATE TABLE a ();",
+			wants: []string{"TABLE a"},
+		},
+		{
+			name:  "quoted identifiers survive",
+			sql:   `CREATE TABLE "MixedCase" ();`,
+			wants: []string{`"MixedCase"`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stripNoise(tt.sql)
+			for _, want := range tt.wants {
+				if !strings.Contains(got, want) {
+					t.Errorf("stripNoise dropped %q\ngot: %s", want, got)
+				}
+			}
+			for _, unwanted := range tt.unwants {
+				if strings.Contains(got, unwanted) {
+					t.Errorf("stripNoise kept %q\ngot: %s", unwanted, got)
+				}
+			}
+		})
+	}
+}
+
+func TestAtomicityBlockers(t *testing.T) {
+	tests := []struct {
+		name    string
+		sql     string
+		blocked bool
+	}{
+		{"plain ddl", "CREATE TABLE a (id int);", false},
+		{"do block with begin", "DO $$ BEGIN PERFORM 1; END $$;", false},
+		{"begin in a comment", "-- BEGIN;\nCREATE TABLE a ();", false},
+		{"concurrent index", "CREATE INDEX CONCURRENTLY a_idx ON a (id);", true},
+		{"vacuum", "VACUUM ANALYZE a;", true},
+		{"explicit transaction", "BEGIN;\nCREATE TABLE a ();\nCOMMIT;", true},
+		{"alter system", "ALTER SYSTEM SET work_mem = '1GB';", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := atomicityBlockers(tt.sql)
+			if blocked := len(got) > 0; blocked != tt.blocked {
+				t.Errorf("atomicityBlockers = %v, want blocked = %t", got, tt.blocked)
+			}
+		})
+	}
+}
+
+func TestProbes(t *testing.T) {
+	sql := `
+		CREATE TABLE copies (id uuid);
+		CREATE INDEX IF NOT EXISTS copies_idx ON copies (id);
+		CREATE OR REPLACE VIEW held_books AS SELECT 1;
+		ALTER TABLE books ADD COLUMN IF NOT EXISTS sort_title text;
+		CREATE OR REPLACE FUNCTION sort_title(t text) RETURNS text AS $$ BEGIN RETURN t; END $$ LANGUAGE plpgsql;
+		CREATE TEMP TABLE scratch (id int);
+		DO $$ BEGIN CREATE TABLE never_seen (); END $$;
+	`
+
+	var got []string
+	for _, p := range probes(sql) {
+		got = append(got, p.String())
+	}
+
+	want := []string{"copies", "copies_idx", "held_books", "column books.sort_title", "function sort_title"}
+	if len(got) != len(want) {
+		t.Fatalf("probes = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("probe %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestEveryMigrationIsAtomic guards the assumption the whole repair path rests
+// on. golang-migrate sends a migration as one simple query, which Postgres runs
+// in an implicit transaction, so a failure changes nothing and the file can be
+// retried. Add a statement that breaks out of that transaction and rewinding
+// stops being safe, so this fails rather than letting it ship.
+func TestEveryMigrationIsAtomic(t *testing.T) {
+	ups, err := upMigrations()
+	if err != nil {
+		t.Fatalf("reading migrations: %v", err)
+	}
+	if len(ups) == 0 {
+		t.Fatal("no migrations found")
+	}
+
+	for _, source := range ups {
+		if reasons := atomicityBlockers(source.SQL); len(reasons) > 0 {
+			t.Errorf("%06d_%s.up.sql cannot roll back cleanly: %s",
+				source.Version, source.Name, strings.Join(reasons, "; "))
+		}
+	}
+}
+
+// TestMigrationProbeCoverage reports which migrations create nothing that can
+// be looked for afterwards. Those are data-only migrations and are fine, but
+// repair has to stop when it reaches one, so the list is worth seeing rather
+// than growing quietly.
+func TestMigrationProbeCoverage(t *testing.T) {
+	ups, err := upMigrations()
+	if err != nil {
+		t.Fatalf("reading migrations: %v", err)
+	}
+
+	var blind []string
+	for _, source := range ups {
+		if len(probes(source.SQL)) == 0 {
+			blind = append(blind, source.Name)
+		}
+	}
+	t.Logf("%d of %d migrations create nothing repair can probe: %s",
+		len(blind), len(ups), strings.Join(blind, ", "))
+
+	if len(blind) == len(ups) {
+		t.Error("no migration creates anything probeable, which means the extraction is broken")
+	}
+}


### PR DESCRIPTION
A self-hoster hit this on 29 August: `schema_migrations` said 25, none of the tables migration 25 creates existed, migration 26 died on a missing `copies` relation, and rolling back to 26.8.0 failed differently because that build has never heard of version 25.

The cause is that a failed migration leaves a dirty flag, and the intuitive way to clear a dirty flag is to clear the flag. Doing that in place marks the failed migration as applied.

- `Migrate` rewinds the version on its way out of a failure, so the dirty state never persists and every start shows the error that actually caused it. Safe because golang-migrate sends each file as one simple query, which Postgres runs in an implicit transaction; `TestEveryMigrationIsAtomic` fails if a migration appears that breaks that.
- `librarium-api repair` handles the databases already damaged. It probes the objects each migration creates, rewinds to the last version it can prove ran, prints its evidence, and writes nothing without a yes.
- A database migrated by a newer build is refused with a message that names the image instead of a missing file.
- A migration failure reports the migration, line and SQLSTATE rather than printing all 900 lines of the file.

Tested against Postgres 16 with `LIBRARIUM_MIGRATE_TEST_DSN`, including a test that reproduces the reported state and repairs it.