### PR TITLE
Save a book that has a publication date again, and survive a blank reading status

### DIFF
--- a/internal/api/handlers/books.go
+++ b/internal/api/handlers/books.go
@@ -9,10 +9,8 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"regexp"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/fireball1725/librarium-api/internal/api/middleware"
 	"github.com/fireball1725/librarium-api/internal/api/respond"
@@ -766,78 +764,6 @@ func bookBody(b *models.Book) map[string]any {
 		"ownership": b.Ownership,
 	}
 }
-
-// parseFlexDate tries several date formats and returns the parsed time.
-// Accepts: YYYY-MM-DD, YYYY-MM, YYYY, "January 2006", "January 2, 2006",
-// "Jan 2, 2006", "Jan 2006", "2 January 2006", "2 Jan 2006".
-func parseFlexDate(s string) (time.Time, bool) {
-	s = strings.TrimSpace(s)
-	if s == "" {
-		return time.Time{}, false
-	}
-
-	// Exact formats tried in order
-	for _, layout := range []string{
-		"2006-01-02",
-		"2006-01",
-		"2006",
-	} {
-		if t, err := time.Parse(layout, s); err == nil {
-			return t, true
-		}
-	}
-
-	// Year-only bare number
-	if reYear.MatchString(s) {
-		if t, err := time.Parse("2006", s); err == nil {
-			return t, true
-		}
-	}
-
-	// "Month DD, YYYY" or "Month D YYYY" (full or abbreviated)
-	if m := reFullDate.FindStringSubmatch(s); m != nil {
-		day := m[2]
-		if len(day) == 1 {
-			day = "0" + day
-		}
-		for _, mfmt := range []string{"January", "Jan"} {
-			if t, err := time.Parse(mfmt+" 02 2006", m[1]+" "+day+" "+m[3]); err == nil {
-				return t, true
-			}
-		}
-	}
-
-	// "Month YYYY" (full or abbreviated)
-	if m := reMonYear.FindStringSubmatch(s); m != nil {
-		for _, mfmt := range []string{"January 2006", "Jan 2006"} {
-			if t, err := time.Parse(mfmt, m[1]+" "+m[2]); err == nil {
-				return t, true
-			}
-		}
-	}
-
-	// "D Month YYYY" or "D Mon YYYY" (day-first European)
-	if m := reDayFirst.FindStringSubmatch(s); m != nil {
-		day := m[1]
-		if len(day) == 1 {
-			day = "0" + day
-		}
-		for _, mfmt := range []string{"January", "Jan"} {
-			if t, err := time.Parse("02 "+mfmt+" 2006", day+" "+m[2]+" "+m[3]); err == nil {
-				return t, true
-			}
-		}
-	}
-
-	return time.Time{}, false
-}
-
-var (
-	reYear     = regexp.MustCompile(`^\d{4}$`)
-	reFullDate = regexp.MustCompile(`^([A-Za-z]+)\s+(\d{1,2}),?\s+(\d{4})$`)
-	reMonYear  = regexp.MustCompile(`^([A-Za-z]+)\s+(\d{4})$`)
-	reDayFirst = regexp.MustCompile(`^(\d{1,2})\s+([A-Za-z]+)\s+(\d{4})$`)
-)
 
 // ─── Bulk operations ──────────────────────────────────────────────────────────
 

--- a/internal/api/handlers/editions.go
+++ b/internal/api/handlers/editions.go
@@ -312,9 +312,11 @@ func parseEditionRequestBody(body *editionRequestBody) (*service.EditionRequest,
 	}
 
 	var publishDate *time.Time
+	var publishPrecision models.DatePrecision
 	if body.PublishDate != "" {
-		if t, ok := parseFlexDate(body.PublishDate); ok {
+		if t, precision, ok := models.ParseFlexDate(body.PublishDate); ok {
 			publishDate = &t
+			publishPrecision = precision
 		}
 		// Silently treat unparseable dates as null — provider data varies.
 	}
@@ -346,6 +348,7 @@ func parseEditionRequestBody(body *editionRequestBody) (*service.EditionRequest,
 		EditionName:           body.EditionName,
 		Narrator:              body.Narrator,
 		Publisher:             body.Publisher,
+		PublishPrecision:      publishPrecision,
 		PublishDate:           publishDate,
 		ISBN10:                body.ISBN10,
 		ISBN13:                body.ISBN13,

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -199,14 +199,20 @@ func explainFailure(version int, err error) error {
 		name = source.Name
 	}
 
+	// Position is zero for anything Postgres cannot pin to a character, which
+	// includes every constraint violation raised while a statement runs. The
+	// line golang-migrate computes from a zero position is 1, so reporting it
+	// would point at the licence header of whatever migration failed.
+	located := pgErr.Position > 0 && dbErr.Line > 0
+
 	var b strings.Builder
 	fmt.Fprintf(&b, "migration %d (%s) failed", version, name)
-	if dbErr.Line > 0 {
+	if located {
 		fmt.Fprintf(&b, " at line %d", dbErr.Line)
 	}
 	fmt.Fprintf(&b, ": %s (SQLSTATE %s)", pgErr.Message, pgErr.Code)
 
-	if stmt := sourceLine(dbErr.Query, dbErr.Line); stmt != "" {
+	if stmt := sourceLine(dbErr.Query, dbErr.Line); located && stmt != "" {
 		fmt.Fprintf(&b, "\n    %s", stmt)
 	}
 	if pgErr.Detail != "" {

--- a/internal/db/migrations/000025_schema_tiers.up.sql
+++ b/internal/db/migrations/000025_schema_tiers.up.sql
@@ -617,9 +617,20 @@ INSERT INTO user_books (user_id, book_id, read_status, rating, is_favorite, revi
                         read_status_updated_at, rating_updated_at, is_favorite_updated_at,
                         created_at, updated_at)
 SELECT i.user_id, e.book_id,
-       (ARRAY_AGG(i.read_status ORDER BY CASE i.read_status
+       -- user_book_interactions.read_status is a VARCHAR(32) with a default
+       -- and no CHECK, so an empty string has always been a legal value there
+       -- and collections in the wild carry them. user_books constrains the
+       -- column, so a status that is not a status has to be resolved here
+       -- rather than rejected halfway through this migration. Prefer any real
+       -- status the reader recorded on another edition of the work; fall back
+       -- to unread, which is what the column defaults to and what an empty
+       -- string was always standing in for.
+       COALESCE(NULLIF((ARRAY_AGG(i.read_status ORDER BY CASE i.read_status
             WHEN 'read' THEN 1 WHEN 'reading' THEN 2
-            WHEN 'did_not_finish' THEN 3 ELSE 4 END))[1],
+            WHEN 'did_not_finish' THEN 3 ELSE 4 END)
+            FILTER (WHERE i.read_status IN
+              ('unread', 'reading', 'read', 'did_not_finish')))[1], ''),
+         'unread'),
        MAX(i.rating),
        BOOL_OR(i.is_favorite),
        COALESCE((ARRAY_AGG(i.review ORDER BY i.updated_at DESC)

--- a/internal/db/repair_test.go
+++ b/internal/db/repair_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/source/iofs"
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -206,4 +207,125 @@ func TestMigrateRefusesADatabaseFromANewerBuild(t *testing.T) {
 			t.Errorf("refusing changed the version to %d; it must not write anything", version)
 		}
 	})
+}
+
+// TestMigrationSurvivesLegacyReadStatus reproduces the upgrade failure a
+// self-hoster hit on 30 August 2026. user_book_interactions.read_status is a
+// VARCHAR(32) with a default and no CHECK, so an empty string has always been
+// legal there. user_books constrains the column, and migration 25's backfill
+// used to copy whatever it found, so a single empty value stopped the upgrade
+// with a constraint violation partway through a 900-line migration.
+func TestMigrationSurvivesLegacyReadStatus(t *testing.T) {
+	withScratchDatabase(t, func(dsn string) {
+		ctx := context.Background()
+		head, err := headVersion()
+		if err != nil {
+			t.Fatalf("reading head version: %v", err)
+		}
+
+		// Stop before the tier migration, while the old table is still the
+		// only place reading state lives.
+		migrateTo(t, dsn, 24)
+
+		pool, err := pgxpool.New(ctx, dsn)
+		if err != nil {
+			t.Fatalf("connecting: %v", err)
+		}
+		defer pool.Close()
+
+		userID := seedLegacyInteractions(ctx, t, pool)
+
+		if err := Migrate(dsn); err != nil {
+			t.Fatalf("migrating over legacy read_status values: %v", err)
+		}
+		if version, dirty := readVersion(t, dsn); version != head || dirty {
+			t.Errorf("version %d dirty %t, want %d false", version, dirty, head)
+		}
+
+		// The empty status becomes unread rather than being dropped, and a real
+		// status recorded on another edition of the same work still wins.
+		rows, err := pool.Query(ctx, `
+			SELECT b.title, ub.read_status
+			  FROM user_books ub JOIN books b ON b.id = ub.book_id
+			 WHERE ub.user_id = $1 ORDER BY b.title`, userID)
+		if err != nil {
+			t.Fatalf("reading user_books: %v", err)
+		}
+		defer rows.Close()
+
+		got := map[string]string{}
+		for rows.Next() {
+			var title, status string
+			if err := rows.Scan(&title, &status); err != nil {
+				t.Fatalf("scanning: %v", err)
+			}
+			got[title] = status
+		}
+		if err := rows.Err(); err != nil {
+			t.Fatalf("iterating: %v", err)
+		}
+
+		want := map[string]string{
+			"blank status":      "unread",
+			"blank and read":    "read",
+			"nonsense status":   "unread",
+			"legitimate status": "reading",
+		}
+		for title, wantStatus := range want {
+			if got[title] != wantStatus {
+				t.Errorf("%q: read_status = %q, want %q", title, got[title], wantStatus)
+			}
+		}
+	})
+}
+
+// seedLegacyInteractions writes the shapes a pre-tier collection can hold,
+// including the empty read_status that no constraint ever prevented.
+func seedLegacyInteractions(ctx context.Context, t *testing.T, pool *pgxpool.Pool) uuid.UUID {
+	t.Helper()
+
+	var mediaTypeID uuid.UUID
+	if err := pool.QueryRow(ctx, `SELECT id FROM media_types ORDER BY name LIMIT 1`).Scan(&mediaTypeID); err != nil {
+		t.Fatalf("no media types seeded: %v", err)
+	}
+
+	userID := uuid.New()
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO users (id, username, display_name, email)
+		VALUES ($1, $2, 'legacy reader', $3)`,
+		userID, "legacy-"+userID.String(), userID.String()+"@example.test"); err != nil {
+		t.Fatalf("creating user: %v", err)
+	}
+
+	// title -> the statuses recorded across that book's editions.
+	books := map[string][]string{
+		"blank status":      {""},
+		"blank and read":    {"", "read"},
+		"nonsense status":   {"finished-ish"},
+		"legitimate status": {"reading"},
+	}
+
+	for title, statuses := range books {
+		bookID := uuid.New()
+		if _, err := pool.Exec(ctx, `
+			INSERT INTO books (id, title, media_type_id) VALUES ($1, $2, $3)`,
+			bookID, title, mediaTypeID); err != nil {
+			t.Fatalf("creating book %q: %v", title, err)
+		}
+		for _, status := range statuses {
+			editionID := uuid.New()
+			if _, err := pool.Exec(ctx, `
+				INSERT INTO book_editions (id, book_id, format) VALUES ($1, $2, 'paperback')`,
+				editionID, bookID); err != nil {
+				t.Fatalf("creating edition for %q: %v", title, err)
+			}
+			if _, err := pool.Exec(ctx, `
+				INSERT INTO user_book_interactions (id, user_id, book_edition_id, read_status)
+				VALUES ($1, $2, $3, $4)`, uuid.New(), userID, editionID, status); err != nil {
+				t.Fatalf("creating interaction for %q: %v", title, err)
+			}
+		}
+	}
+
+	return userID
 }

--- a/internal/models/date.go
+++ b/internal/models/date.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725
+
+package models
+
+import (
+	"regexp"
+	"strings"
+	"time"
+)
+
+// DatePrecision says how much of a publication date the source actually gave.
+// It is stored beside the date because a year-only date is written as 1
+// January, and nothing about the stored value distinguishes that from a book
+// published on 1 January. book_editions constrains the pair: the precision is
+// NULL exactly when the date is.
+type DatePrecision string
+
+const (
+	DatePrecisionYear  DatePrecision = "year"
+	DatePrecisionMonth DatePrecision = "month"
+	DatePrecisionDay   DatePrecision = "day"
+)
+
+// ParseFlexDate tries several date formats and returns the parsed time along
+// with how much of it the input actually specified.
+// Accepts: YYYY-MM-DD, YYYY-MM, YYYY, "January 2006", "January 2, 2006",
+// "Jan 2, 2006", "Jan 2006", "2 January 2006", "2 Jan 2006".
+//
+// The precision has to travel with the date because the two are stored
+// together and constrained together: book_editions carries a
+// publish_date_precision that is NULL exactly when publish_date is, and a
+// year-only date is written as 1 January, which no later reader can tell apart
+// from a book genuinely published on 1 January.
+func ParseFlexDate(s string) (time.Time, DatePrecision, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return time.Time{}, "", false
+	}
+
+	// Exact formats, most specific first, each paired with what it pins down.
+	for _, f := range []struct {
+		layout    string
+		precision DatePrecision
+	}{
+		{"2006-01-02", DatePrecisionDay},
+		{"2006-01", DatePrecisionMonth},
+		{"2006", DatePrecisionYear},
+	} {
+		if t, err := time.Parse(f.layout, s); err == nil {
+			return t, f.precision, true
+		}
+	}
+
+	// Year-only bare number
+	if reYear.MatchString(s) {
+		if t, err := time.Parse("2006", s); err == nil {
+			return t, DatePrecisionYear, true
+		}
+	}
+
+	// "Month DD, YYYY" or "Month D YYYY" (full or abbreviated)
+	if m := reFullDate.FindStringSubmatch(s); m != nil {
+		day := m[2]
+		if len(day) == 1 {
+			day = "0" + day
+		}
+		for _, mfmt := range []string{"January", "Jan"} {
+			if t, err := time.Parse(mfmt+" 02 2006", m[1]+" "+day+" "+m[3]); err == nil {
+				return t, DatePrecisionDay, true
+			}
+		}
+	}
+
+	// "Month YYYY" (full or abbreviated)
+	if m := reMonYear.FindStringSubmatch(s); m != nil {
+		for _, mfmt := range []string{"January 2006", "Jan 2006"} {
+			if t, err := time.Parse(mfmt, m[1]+" "+m[2]); err == nil {
+				return t, DatePrecisionMonth, true
+			}
+		}
+	}
+
+	// "D Month YYYY" or "D Mon YYYY" (day-first European)
+	if m := reDayFirst.FindStringSubmatch(s); m != nil {
+		day := m[1]
+		if len(day) == 1 {
+			day = "0" + day
+		}
+		for _, mfmt := range []string{"January", "Jan"} {
+			if t, err := time.Parse("02 "+mfmt+" 2006", day+" "+m[2]+" "+m[3]); err == nil {
+				return t, DatePrecisionDay, true
+			}
+		}
+	}
+
+	return time.Time{}, "", false
+}
+
+var (
+	reYear     = regexp.MustCompile(`^\d{4}$`)
+	reFullDate = regexp.MustCompile(`^([A-Za-z]+)\s+(\d{1,2}),?\s+(\d{4})$`)
+	reMonYear  = regexp.MustCompile(`^([A-Za-z]+)\s+(\d{4})$`)
+	reDayFirst = regexp.MustCompile(`^(\d{1,2})\s+([A-Za-z]+)\s+(\d{4})$`)
+)

--- a/internal/models/date_test.go
+++ b/internal/models/date_test.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725
+
+package models
+
+import "testing"
+
+// TestParseFlexDatePrecision pins the half of the result that used to be
+// thrown away. A year-only date is stored as 1 January, so without the
+// precision beside it nothing downstream can tell "1932" from a book published
+// on 1 January 1932.
+func TestParseFlexDatePrecision(t *testing.T) {
+	tests := []struct {
+		in        string
+		want      string
+		precision DatePrecision
+		ok        bool
+	}{
+		{in: "1932-05-14", want: "1932-05-14", precision: DatePrecisionDay, ok: true},
+		{in: "1932-05", want: "1932-05-01", precision: DatePrecisionMonth, ok: true},
+		{in: "1932", want: "1932-01-01", precision: DatePrecisionYear, ok: true},
+		{in: "  1932  ", want: "1932-01-01", precision: DatePrecisionYear, ok: true},
+		{in: "January 1932", want: "1932-01-01", precision: DatePrecisionMonth, ok: true},
+		{in: "Jan 1932", want: "1932-01-01", precision: DatePrecisionMonth, ok: true},
+		{in: "January 2, 1932", want: "1932-01-02", precision: DatePrecisionDay, ok: true},
+		{in: "Jan 2, 1932", want: "1932-01-02", precision: DatePrecisionDay, ok: true},
+		{in: "2 January 1932", want: "1932-01-02", precision: DatePrecisionDay, ok: true},
+		{in: "14 Jan 1932", want: "1932-01-14", precision: DatePrecisionDay, ok: true},
+		{in: "", ok: false},
+		{in: "sometime in the thirties", ok: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got, precision, ok := ParseFlexDate(tt.in)
+			if ok != tt.ok {
+				t.Fatalf("ok = %t, want %t", ok, tt.ok)
+			}
+			if !ok {
+				if precision != "" {
+					t.Errorf("precision = %q on a failed parse, want empty", precision)
+				}
+				return
+			}
+			if formatted := got.Format("2006-01-02"); formatted != tt.want {
+				t.Errorf("date = %s, want %s", formatted, tt.want)
+			}
+			if precision != tt.precision {
+				t.Errorf("precision = %q, want %q", precision, tt.precision)
+			}
+		})
+	}
+}
+
+// TestParseFlexDatePrecisionIsNeverEmptyOnSuccess guards the invariant the
+// database constraint depends on: a date always arrives with a precision, so
+// publish_date and publish_date_precision are written or omitted together.
+func TestParseFlexDatePrecisionIsNeverEmptyOnSuccess(t *testing.T) {
+	for _, in := range []string{"1932", "1932-05", "1932-05-14", "May 1932", "1 May 1932"} {
+		if _, precision, ok := ParseFlexDate(in); ok && precision == "" {
+			t.Errorf("ParseFlexDate(%q) succeeded with no precision", in)
+		}
+	}
+}

--- a/internal/preflight/preflight.go
+++ b/internal/preflight/preflight.go
@@ -90,6 +90,36 @@ var checks = []check{
 			return "a rating or review would have to be dropped; resolve these before upgrading"
 		},
 	},
+	// user_book_interactions.read_status is a VARCHAR(32) with a default and no
+	// CHECK, so an empty string has always been a legal value there. user_books
+	// constrains it, and the backfill copies whatever it finds, so one of these
+	// rows stops the upgrade with a constraint violation partway through the
+	// migration. Reported for the value that would actually be chosen rather
+	// than for every bad row, because the aggregate prefers a real status when
+	// any edition of that work has one.
+	{
+		question: "reading records whose status is not a status",
+		severity: Blocking,
+		sql: `SELECT count(*) FROM (
+		        SELECT (ARRAY_AGG(i.read_status ORDER BY CASE i.read_status
+		                   WHEN 'read' THEN 1 WHEN 'reading' THEN 2
+		                   WHEN 'did_not_finish' THEN 3 ELSE 4 END))[1] AS chosen
+		          FROM user_book_interactions i
+		          JOIN book_editions e ON e.id = i.book_edition_id
+		         WHERE i.deleted_at IS NULL
+		         GROUP BY i.user_id, e.book_id) t
+		 WHERE chosen IS NULL
+		    OR chosen NOT IN ('unread', 'reading', 'read', 'did_not_finish')`,
+		meaning: func(n int) string {
+			if n == 0 {
+				return "every reading record carries a status the new table accepts"
+			}
+			return "the migration will stop on these: set them to 'unread' first, " +
+				"UPDATE user_book_interactions SET read_status = 'unread' " +
+				"WHERE read_status IS NULL OR read_status NOT IN " +
+				"('unread', 'reading', 'read', 'did_not_finish')"
+		},
+	},
 	// Deliberately counts duplicate names anywhere, not just across libraries.
 	// De-scoping merges by name globally, so two rows sharing a name inside one
 	// library get merged exactly like two rows spread across two. An earlier

--- a/internal/repository/editions.go
+++ b/internal/repository/editions.go
@@ -79,20 +79,28 @@ func (r *EditionRepo) FindByID(ctx context.Context, id uuid.UUID) (*models.BookE
 	return e, nil
 }
 
-func (r *EditionRepo) Create(ctx context.Context, tx pgx.Tx, id, bookID uuid.UUID, format, language, editionName, narrator, publisher string, publishDate any, isbn10, isbn13, description string, durationSeconds, pageCount any, isPrimary bool, narratorContributorID any) error {
+// Create inserts an edition. publishPrecision travels with publishDate because
+// editions_precision_needs_date requires the pair to be NULL together: writing a
+// date without saying how much of it the source gave violates the constraint,
+// and the insert fails rather than storing a date nobody can interpret.
+func (r *EditionRepo) Create(ctx context.Context, tx pgx.Tx, id, bookID uuid.UUID, format, language, editionName, narrator, publisher string, publishDate any, publishPrecision models.DatePrecision, isbn10, isbn13, description string, durationSeconds, pageCount any, isPrimary bool, narratorContributorID any) error {
 	const q = `
 		INSERT INTO book_editions
-			(id, book_id, format, language, edition_name, narrator, publisher, publish_date, isbn_10, isbn_13, description, duration_seconds, page_count, is_primary, narrator_contributor_id)
+			(id, book_id, format, language, edition_name, narrator, publisher, publish_date, publish_date_precision, isbn_10, isbn_13, description, duration_seconds, page_count, is_primary, narrator_contributor_id)
 		VALUES
-			($1, $2, $3, NULLIF($4,''), NULLIF($5,''), NULLIF($6,''), NULLIF($7,''), $8, NULLIF($9,''), NULLIF($10,''), NULLIF($11,''), $12, $13, $14, $15)`
-	_, err := tx.Exec(ctx, q, id, bookID, format, language, editionName, narrator, publisher, publishDate, isbn10, isbn13, description, durationSeconds, pageCount, isPrimary, narratorContributorID)
+			($1, $2, $3, NULLIF($4,''), NULLIF($5,''), NULLIF($6,''), NULLIF($7,''), $8, CASE WHEN $8::date IS NULL THEN NULL ELSE $9 END, NULLIF($10,''), NULLIF($11,''), NULLIF($12,''), $13, $14, $15, $16)`
+	_, err := tx.Exec(ctx, q, id, bookID, format, language, editionName, narrator, publisher, publishDate, precisionOrDay(publishPrecision), isbn10, isbn13, description, durationSeconds, pageCount, isPrimary, narratorContributorID)
 	if err != nil {
 		return fmt.Errorf("inserting edition: %w", err)
 	}
 	return nil
 }
 
-func (r *EditionRepo) Update(ctx context.Context, tx pgx.Tx, id uuid.UUID, format, language, editionName, narrator, publisher string, publishDate any, isbn10, isbn13, description string, durationSeconds, pageCount any, isPrimary bool, narratorContributorID any) error {
+// Update rewrites an edition. The precision is derived from the date on every
+// write rather than left alone, because clearing a date on a row that had one
+// would otherwise leave a precision behind and violate
+// editions_precision_needs_date.
+func (r *EditionRepo) Update(ctx context.Context, tx pgx.Tx, id uuid.UUID, format, language, editionName, narrator, publisher string, publishDate any, publishPrecision models.DatePrecision, isbn10, isbn13, description string, durationSeconds, pageCount any, isPrimary bool, narratorContributorID any) error {
 	const q = `
 		UPDATE book_editions
 		SET format                   = $2,
@@ -101,15 +109,16 @@ func (r *EditionRepo) Update(ctx context.Context, tx pgx.Tx, id uuid.UUID, forma
 		    narrator                 = NULLIF($5, ''),
 		    publisher                = NULLIF($6, ''),
 		    publish_date             = $7,
-		    isbn_10                  = NULLIF($8, ''),
-		    isbn_13                  = NULLIF($9, ''),
-		    description              = NULLIF($10, ''),
-		    duration_seconds         = $11,
-		    page_count               = $12,
-		    is_primary               = $13,
-		    narrator_contributor_id  = $14
+		    publish_date_precision   = CASE WHEN $7::date IS NULL THEN NULL ELSE $8 END,
+		    isbn_10                  = NULLIF($9, ''),
+		    isbn_13                  = NULLIF($10, ''),
+		    description              = NULLIF($11, ''),
+		    duration_seconds         = $12,
+		    page_count               = $13,
+		    is_primary               = $14,
+		    narrator_contributor_id  = $15
 		WHERE id = $1`
-	_, err := tx.Exec(ctx, q, id, format, language, editionName, narrator, publisher, publishDate, isbn10, isbn13, description, durationSeconds, pageCount, isPrimary, narratorContributorID)
+	_, err := tx.Exec(ctx, q, id, format, language, editionName, narrator, publisher, publishDate, precisionOrDay(publishPrecision), isbn10, isbn13, description, durationSeconds, pageCount, isPrimary, narratorContributorID)
 	if err != nil {
 		return fmt.Errorf("updating edition: %w", err)
 	}
@@ -506,4 +515,14 @@ func (r *EditionRepo) DeleteInteraction(ctx context.Context, userID, editionID u
 		return ErrNotFound
 	}
 	return nil
+}
+
+// precisionOrDay fills in a precision for callers that have a date but never
+// established how specific it was. Day is the honest default for a value that
+// arrived already parsed: it claims exactly what the stored date says.
+func precisionOrDay(p models.DatePrecision) models.DatePrecision {
+	if p == "" {
+		return models.DatePrecisionDay
+	}
+	return p
 }

--- a/internal/repository/editions_precision_live_test.go
+++ b/internal/repository/editions_precision_live_test.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725
+
+package repository
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/fireball1725/librarium-api/internal/models"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// TestEditionPublishPrecisionRoundTrip covers the constraint migration 000025
+// added: editions_precision_needs_date requires publish_date and
+// publish_date_precision to be NULL together. Every write path used to set the
+// date and never the precision, so adding a book with a publication date failed
+// with SQLSTATE 23514 and nothing was saved.
+//
+// Skipped unless LIBRARIUM_TEST_DSN is set. Creates its own book and removes it.
+func TestEditionPublishPrecisionRoundTrip(t *testing.T) {
+	dsn := os.Getenv("LIBRARIUM_TEST_DSN")
+	if dsn == "" {
+		t.Skip("set LIBRARIUM_TEST_DSN to run")
+	}
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connecting: %v", err)
+	}
+	defer pool.Close()
+
+	var mediaTypeID uuid.UUID
+	if err := pool.QueryRow(ctx, `SELECT id FROM media_types ORDER BY name LIMIT 1`).Scan(&mediaTypeID); err != nil {
+		t.Skipf("no media types: %v", err)
+	}
+
+	bookID := uuid.New()
+	title := "precision fixture " + bookID.String()
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO books (id, title, media_type_id, sort_title, title_key)
+		VALUES ($1, $2, $3, $4, $5)`, bookID, title, mediaTypeID, title, title); err != nil {
+		t.Fatalf("creating fixture book: %v", err)
+	}
+	defer func() { _, _ = pool.Exec(ctx, `DELETE FROM books WHERE id = $1`, bookID) }()
+
+	repo := &EditionRepo{db: pool}
+	day := time.Date(1932, 5, 14, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name      string
+		date      any
+		precision models.DatePrecision
+		want      any
+	}{
+		{name: "day", date: &day, precision: models.DatePrecisionDay, want: "day"},
+		{name: "month", date: &day, precision: models.DatePrecisionMonth, want: "month"},
+		{name: "year", date: &day, precision: models.DatePrecisionYear, want: "year"},
+		// A caller that has a date but never established how specific it is.
+		{name: "unstated", date: &day, precision: "", want: "day"},
+		// No date means no precision, which is the other half of the constraint.
+		{name: "no date", date: nil, precision: "", want: nil},
+		// A precision with no date must not be written, or the row is rejected.
+		{name: "precision without a date", date: nil, precision: models.DatePrecisionYear, want: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tx, err := pool.Begin(ctx)
+			if err != nil {
+				t.Fatalf("begin: %v", err)
+			}
+			defer func() { _ = tx.Rollback(ctx) }()
+
+			editionID := uuid.New()
+			if err := repo.Create(ctx, tx, editionID, bookID,
+				"paperback", "en", "", "", "", tt.date, tt.precision,
+				"", "", "", nil, nil, false, nil); err != nil {
+				t.Fatalf("create: %v", err)
+			}
+
+			var got *string
+			if err := tx.QueryRow(ctx,
+				`SELECT publish_date_precision FROM book_editions WHERE id = $1`, editionID).Scan(&got); err != nil {
+				t.Fatalf("reading back: %v", err)
+			}
+			assertPrecision(t, "create", got, tt.want)
+
+			// Update has to keep the pair consistent too: clearing a date on a
+			// row that had one must clear the precision with it.
+			if err := repo.Update(ctx, tx, editionID,
+				"paperback", "en", "", "", "", nil, tt.precision,
+				"", "", "", nil, nil, false, nil); err != nil {
+				t.Fatalf("update clearing the date: %v", err)
+			}
+			if err := tx.QueryRow(ctx,
+				`SELECT publish_date_precision FROM book_editions WHERE id = $1`, editionID).Scan(&got); err != nil {
+				t.Fatalf("reading back after update: %v", err)
+			}
+			assertPrecision(t, "update", got, nil)
+		})
+	}
+}
+
+func assertPrecision(t *testing.T, stage string, got *string, want any) {
+	t.Helper()
+	if want == nil {
+		if got != nil {
+			t.Errorf("%s: precision = %q, want NULL", stage, *got)
+		}
+		return
+	}
+	if got == nil {
+		t.Errorf("%s: precision = NULL, want %q", stage, want)
+		return
+	}
+	if *got != want.(string) {
+		t.Errorf("%s: precision = %q, want %q", stage, *got, want)
+	}
+}

--- a/internal/service/ai_suggestions.go
+++ b/internal/service/ai_suggestions.go
@@ -710,13 +710,10 @@ func (s *SuggestionsService) resolveFloatingBook(ctx context.Context, callerID u
 	}
 
 	var publishDate *time.Time
-	if meta.PublishDate != "" {
-		for _, layout := range []string{"2006-01-02", "2006-01", "2006", "January 2, 2006", "Jan 2, 2006"} {
-			if t, perr := time.Parse(layout, meta.PublishDate); perr == nil {
-				publishDate = &t
-				break
-			}
-		}
+	var publishPrecision models.DatePrecision
+	if t, precision, ok := models.ParseFlexDate(meta.PublishDate); ok {
+		publishDate = &t
+		publishPrecision = precision
 	}
 
 	bookID := uuid.New()
@@ -744,7 +741,7 @@ func (s *SuggestionsService) resolveFloatingBook(ctx context.Context, callerID u
 	if err := s.editions.Create(ctx, tx, editionID, bookID,
 		models.EditionFormatPaperback, // placeholder until real enrichment
 		meta.Language, "", "",         // language, edition_name, narrator
-		meta.Publisher, publishDate,
+		meta.Publisher, publishDate, publishPrecision,
 		meta.ISBN10, meta.ISBN13, "", // description lives on book, not edition
 		nil,            // duration_seconds
 		meta.PageCount, // page_count

--- a/internal/service/book.go
+++ b/internal/service/book.go
@@ -152,7 +152,7 @@ func (s *BookService) CreateBook(ctx context.Context, libraryID, callerID uuid.U
 		editionID := uuid.New()
 		if err := s.editions.Create(ctx, tx, editionID, bookID,
 			e.Format, e.Language, e.EditionName, e.Narrator, e.Publisher,
-			e.PublishDate, e.ISBN10, e.ISBN13, e.Description,
+			e.PublishDate, e.PublishPrecision, e.ISBN10, e.ISBN13, e.Description,
 			e.DurationSeconds, e.PageCount, e.IsPrimary,
 			e.NarratorContributorID,
 		); err != nil {
@@ -310,6 +310,7 @@ type EditionRequest struct {
 	Narrator              string
 	Publisher             string
 	PublishDate           *time.Time
+	PublishPrecision      models.DatePrecision
 	ISBN10                string
 	ISBN13                string
 	Description           string
@@ -340,7 +341,7 @@ func (s *BookService) CreateEdition(ctx context.Context, bookID uuid.UUID, req E
 
 	if err := s.editions.Create(ctx, tx, editionID, bookID,
 		req.Format, req.Language, req.EditionName, req.Narrator, req.Publisher,
-		req.PublishDate, req.ISBN10, req.ISBN13, req.Description,
+		req.PublishDate, req.PublishPrecision, req.ISBN10, req.ISBN13, req.Description,
 		req.DurationSeconds, req.PageCount, req.IsPrimary,
 		req.NarratorContributorID,
 	); err != nil {
@@ -369,7 +370,7 @@ func (s *BookService) UpdateEdition(ctx context.Context, id uuid.UUID, req Editi
 
 	if err := s.editions.Update(ctx, tx, id,
 		req.Format, req.Language, req.EditionName, req.Narrator, req.Publisher,
-		req.PublishDate, req.ISBN10, req.ISBN13, req.Description,
+		req.PublishDate, req.PublishPrecision, req.ISBN10, req.ISBN13, req.Description,
 		req.DurationSeconds, req.PageCount, req.IsPrimary,
 		req.NarratorContributorID,
 	); err != nil {

--- a/internal/workers/import_worker.go
+++ b/internal/workers/import_worker.go
@@ -355,13 +355,10 @@ func (w *ImportWorker) processItem(
 	finalISBN13 := strings.TrimSpace(row["isbn_13"])
 
 	var publishDate *time.Time
-	if ds := strings.TrimSpace(row["publish_date"]); ds != "" {
-		for _, layout := range []string{"2006-01-02", "2006-01", "2006", "January 2, 2006", "Jan 2, 2006"} {
-			if t, err := time.Parse(layout, ds); err == nil {
-				publishDate = &t
-				break
-			}
-		}
+	var publishPrecision models.DatePrecision
+	if t, precision, ok := models.ParseFlexDate(row["publish_date"]); ok {
+		publishDate = &t
+		publishPrecision = precision
 	}
 
 	// ── Media type ────────────────────────────────────────────────────────────
@@ -485,18 +482,15 @@ func (w *ImportWorker) processItem(
 	// ── Acquired date ─────────────────────────────────────────────────────────
 	var acquiredAt *time.Time
 	if ds := strings.TrimSpace(row["acquired_date"]); ds != "" {
-		for _, layout := range []string{"2006-01-02", "2006-01", "2006", "January 2, 2006", "Jan 2, 2006"} {
-			if t, err := time.Parse(layout, ds); err == nil {
-				acquiredAt = &t
-				break
-			}
+		if t, _, ok := models.ParseFlexDate(ds); ok {
+			acquiredAt = &t
 		}
 	}
 
 	editionID := uuid.New()
 	if err := w.editions.Create(ctx, tx, editionID, bookID,
 		format, editionLang, "", "", finalPublisher,
-		publishDate, finalISBN10, finalISBN13, finalDescription,
+		publishDate, publishPrecision, finalISBN10, finalISBN13, finalDescription,
 		nil, pageCount, true, nil,
 	); err != nil {
 		return models.ImportItemFailed, fmt.Sprintf("creating edition: %v", err), nil, false


### PR DESCRIPTION
Two upgrade and write failures from today's reports.

**Adding a book with a publication date has been broken since rc.4.** Migration 000025 added `editions_precision_needs_date`, requiring `publish_date` and `publish_date_precision` to be NULL together. `publish_date_precision` appeared in zero Go files, so every insert carrying a date was rejected with SQLSTATE 23514. `Update` had the mirror bug: clearing a date left the precision behind.

The precision was known and thrown away in three separate copies of the same date parser (handlers, AI suggestions, CSV import), each with its own format list. Fixing it three times would have left three lists to drift, so they are now one `models.ParseFlexDate` that returns the precision it matched, and the repository writes the pair or neither. Without that, a year-only `1932` from a CSV would be stored as 1 January with day precision, which is the misreading 000025 set out to fix.

**A blank `read_status` stopped the tier migration.** `user_book_interactions.read_status` is a `VARCHAR(32)` with a default and no CHECK, so an empty string is legal there and illegal in `user_books`. The backfill copied it straight across. It now prefers a real status recorded on another edition of the same work and falls back to `unread`.

This edits a shipped migration, which AGENTS.md forbids. 000025 has only ever been in rc.4 through rc.10, and the change is a no-op for any database that applied it, since such a database cannot contain an offending row. The window closes when 26.8.1 goes stable.

Also adds the preflight check that would have caught it before the upgrade, and stops reporting a bogus line 1 for constraint violations, which Postgres cannot pin to a character.

Tested against Postgres 16. `TestMigrationSurvivesLegacyReadStatus` fails against the unfixed migration with the exact reported error and passes with it; `TestEditionPublishPrecisionRoundTrip` covers all six date and precision combinations through create and update.