### PR TITLE
Put a book on a shelf from the CSV it was imported with

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -206,6 +206,7 @@ func main() {
 		repository.NewEditionRepo(pool),
 		repository.NewTagRepo(pool),
 		repository.NewGenreRepo(pool),
+		repository.NewShelfRepo(pool),
 		repository.NewEnrichmentBatchRepo(pool),
 		nil, // riverClient set below after construction
 	)

--- a/internal/repository/shelves.go
+++ b/internal/repository/shelves.go
@@ -246,6 +246,20 @@ func (r *ShelfRepo) AddBook(ctx context.Context, shelfID, bookID, addedBy uuid.U
 	return nil
 }
 
+// AddBookTx puts a book on a shelf inside a caller's transaction, so an import
+// that fails partway leaves no shelf membership pointing at a book that was
+// rolled back. Membership is additive: a book already on the shelf stays put.
+func (r *ShelfRepo) AddBookTx(ctx context.Context, tx pgx.Tx, shelfID, bookID uuid.UUID) error {
+	_, err := tx.Exec(ctx,
+		`INSERT INTO list_books (book_id, list_id) VALUES ($1, $2) ON CONFLICT DO NOTHING`,
+		bookID, shelfID,
+	)
+	if err != nil {
+		return fmt.Errorf("adding book to shelf: %w", err)
+	}
+	return nil
+}
+
 func (r *ShelfRepo) RemoveBook(ctx context.Context, shelfID, bookID uuid.UUID) error {
 	result, err := r.db.Exec(ctx,
 		`DELETE FROM list_books WHERE list_id = $1 AND book_id = $2`,

--- a/internal/workers/import_shelves_live_test.go
+++ b/internal/workers/import_shelves_live_test.go
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 FireBall1725
+
+package workers
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/fireball1725/librarium-api/internal/repository"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// TestResolveShelfFindsOrCreates covers the half of the shelf column that can
+// go wrong quietly: a name that already exists must reuse that shelf rather
+// than create a second one with the same name, and the match is
+// case-insensitive because a spreadsheet is typed by hand.
+//
+// Skipped unless LIBRARIUM_TEST_DSN is set. Creates its own library and
+// removes it.
+func TestResolveShelfFindsOrCreates(t *testing.T) {
+	dsn := os.Getenv("LIBRARIUM_TEST_DSN")
+	if dsn == "" {
+		t.Skip("set LIBRARIUM_TEST_DSN to run")
+	}
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connecting: %v", err)
+	}
+	defer pool.Close()
+
+	userID, libraryID := seedLibrary(ctx, t, pool)
+	w := &ImportWorker{shelves: repository.NewShelfRepo(pool)}
+	cache := map[string]uuid.UUID{}
+
+	first, err := w.resolveShelf(ctx, libraryID, userID, "To Read", cache)
+	if err != nil {
+		t.Fatalf("creating a new shelf: %v", err)
+	}
+
+	// A second row naming the same shelf must land on the same one. The cache
+	// answers this one, which is the common case in a large import.
+	again, err := w.resolveShelf(ctx, libraryID, userID, "To Read", cache)
+	if err != nil {
+		t.Fatalf("resolving an existing shelf: %v", err)
+	}
+	if again != first {
+		t.Errorf("same name resolved to a second shelf: %s then %s", first, again)
+	}
+
+	// Different case, and a cold cache, which is the path that has to fall
+	// through to the list-and-match branch.
+	cold, err := w.resolveShelf(ctx, libraryID, userID, "to read", map[string]uuid.UUID{})
+	if err != nil {
+		t.Fatalf("resolving with a cold cache: %v", err)
+	}
+	if cold != first {
+		t.Errorf("case-insensitive match failed: %s vs %s", cold, first)
+	}
+
+	var shelves int
+	if err := pool.QueryRow(ctx, `
+		SELECT count(*) FROM lists
+		 WHERE shared_library_id = $1 AND kind = 'manual' AND visibility = 'library'`,
+		libraryID).Scan(&shelves); err != nil {
+		t.Fatalf("counting shelves: %v", err)
+	}
+	if shelves != 1 {
+		t.Errorf("library holds %d shelves, want 1", shelves)
+	}
+}
+
+// TestAddBookToShelfIsAdditiveAndRollsBack covers the transaction boundary. An
+// import row that fails after the shelf line must leave no membership behind,
+// and a book already on the shelf must not error on a re-import.
+func TestAddBookToShelfIsAdditiveAndRollsBack(t *testing.T) {
+	dsn := os.Getenv("LIBRARIUM_TEST_DSN")
+	if dsn == "" {
+		t.Skip("set LIBRARIUM_TEST_DSN to run")
+	}
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connecting: %v", err)
+	}
+	defer pool.Close()
+
+	userID, libraryID := seedLibrary(ctx, t, pool)
+	shelves := repository.NewShelfRepo(pool)
+
+	shelf, err := shelves.Create(ctx, uuid.New(), libraryID, "Landing", "", "", "", 0, userID)
+	if err != nil {
+		t.Fatalf("creating shelf: %v", err)
+	}
+	bookID := seedBook(ctx, t, pool, "shelf fixture")
+
+	count := func() int {
+		var n int
+		if err := pool.QueryRow(ctx,
+			`SELECT count(*) FROM list_books WHERE list_id = $1`, shelf.ID).Scan(&n); err != nil {
+			t.Fatalf("counting membership: %v", err)
+		}
+		return n
+	}
+
+	// Rolled back: nothing survives.
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	if err := shelves.AddBookTx(ctx, tx, shelf.ID, bookID); err != nil {
+		t.Fatalf("adding inside a transaction: %v", err)
+	}
+	_ = tx.Rollback(ctx)
+	if n := count(); n != 0 {
+		t.Errorf("rolled-back membership survived: %d rows", n)
+	}
+
+	// Committed twice: still one row, no error the second time.
+	for i := 0; i < 2; i++ {
+		tx, err := pool.Begin(ctx)
+		if err != nil {
+			t.Fatalf("begin: %v", err)
+		}
+		if err := shelves.AddBookTx(ctx, tx, shelf.ID, bookID); err != nil {
+			t.Fatalf("adding on pass %d: %v", i+1, err)
+		}
+		if err := tx.Commit(ctx); err != nil {
+			t.Fatalf("commit on pass %d: %v", i+1, err)
+		}
+	}
+	if n := count(); n != 1 {
+		t.Errorf("membership rows = %d, want 1", n)
+	}
+}
+
+// TestShelfColumnSplitsLikeTags pins the parsing the CSV column relies on, so
+// "Sci-Fi, To Read" is two shelves and stray whitespace is not a third.
+func TestShelfColumnSplitsLikeTags(t *testing.T) {
+	tests := []struct {
+		in   string
+		want []string
+	}{
+		{"To Read", []string{"To Read"}},
+		{"Sci-Fi, To Read", []string{"Sci-Fi", "To Read"}},
+		{" Sci-Fi ,  To Read ", []string{"Sci-Fi", "To Read"}},
+		{"Sci-Fi,,To Read", []string{"Sci-Fi", "To Read"}},
+		{"", nil},
+		{"  ,  ", nil},
+	}
+
+	for _, tt := range tests {
+		var got []string
+		if tt.in != "" {
+			for _, raw := range strings.Split(tt.in, ",") {
+				if name := strings.TrimSpace(raw); name != "" {
+					got = append(got, name)
+				}
+			}
+		}
+		if len(got) != len(tt.want) {
+			t.Errorf("%q split to %v, want %v", tt.in, got, tt.want)
+			continue
+		}
+		for i := range tt.want {
+			if got[i] != tt.want[i] {
+				t.Errorf("%q split to %v, want %v", tt.in, got, tt.want)
+				break
+			}
+		}
+	}
+}
+
+func seedLibrary(ctx context.Context, t *testing.T, pool *pgxpool.Pool) (userID, libraryID uuid.UUID) {
+	t.Helper()
+
+	userID = uuid.New()
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO users (id, username, display_name, email)
+		VALUES ($1, $2, 'import fixture', $3)`,
+		userID, "import-"+userID.String(), userID.String()+"@example.test"); err != nil {
+		t.Fatalf("creating user: %v", err)
+	}
+
+	libraryID = uuid.New()
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO libraries (id, name, slug, owner_id) VALUES ($1, $2, $3, $4)`,
+		libraryID, "import fixture "+libraryID.String(),
+		"import-fixture-"+libraryID.String(), userID); err != nil {
+		t.Fatalf("creating library: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM libraries WHERE id = $1`, libraryID)
+		_, _ = pool.Exec(ctx, `DELETE FROM users WHERE id = $1`, userID)
+	})
+	return userID, libraryID
+}
+
+func seedBook(ctx context.Context, t *testing.T, pool *pgxpool.Pool, title string) uuid.UUID {
+	t.Helper()
+
+	var mediaTypeID uuid.UUID
+	if err := pool.QueryRow(ctx, `SELECT id FROM media_types ORDER BY name LIMIT 1`).Scan(&mediaTypeID); err != nil {
+		t.Fatalf("no media types seeded: %v", err)
+	}
+	bookID := uuid.New()
+	full := title + " " + bookID.String()
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO books (id, title, media_type_id, sort_title, title_key)
+		VALUES ($1, $2, $3, $4, $5)`, bookID, full, mediaTypeID, full, full); err != nil {
+		t.Fatalf("creating book: %v", err)
+	}
+	t.Cleanup(func() { _, _ = pool.Exec(ctx, `DELETE FROM books WHERE id = $1`, bookID) })
+	return bookID
+}

--- a/internal/workers/import_worker.go
+++ b/internal/workers/import_worker.go
@@ -39,6 +39,7 @@ type ImportWorker struct {
 	editions     *repository.EditionRepo
 	tags         *repository.TagRepo
 	genres       *repository.GenreRepo
+	shelves      *repository.ShelfRepo
 	batches      *repository.EnrichmentBatchRepo
 	riverClient  *river.Client[pgx.Tx]
 }
@@ -52,6 +53,7 @@ func NewImportWorker(
 	editions *repository.EditionRepo,
 	tags *repository.TagRepo,
 	genres *repository.GenreRepo,
+	shelves *repository.ShelfRepo,
 	batches *repository.EnrichmentBatchRepo,
 	riverClient *river.Client[pgx.Tx],
 ) *ImportWorker {
@@ -64,6 +66,7 @@ func NewImportWorker(
 		editions:     editions,
 		tags:         tags,
 		genres:       genres,
+		shelves:      shelves,
 		batches:      batches,
 		riverClient:  riverClient,
 	}
@@ -98,7 +101,8 @@ func (w *ImportWorker) Work(ctx context.Context, job *river.Job[models.ImportJob
 		return fmt.Errorf("loading pending items: %w", err)
 	}
 
-	tagCache := make(map[string]uuid.UUID) // lowercase name → id
+	tagCache := make(map[string]uuid.UUID)   // lowercase name → id
+	shelfCache := make(map[string]uuid.UUID) // lowercase name → id
 
 	allGenres, err := w.genres.List(ctx)
 	if err != nil {
@@ -114,7 +118,7 @@ func (w *ImportWorker) Work(ctx context.Context, job *river.Job[models.ImportJob
 			return nil
 		}
 
-		status, msg, bookID, addedToLibrary := w.processItem(ctx, importJob, &item, tagCache, allGenres)
+		status, msg, bookID, addedToLibrary := w.processItem(ctx, importJob, &item, tagCache, shelfCache, allGenres)
 		_ = w.importJobs.UpdateItemStatus(ctx, item.ID, status, msg, bookID)
 
 		switch status {
@@ -268,6 +272,7 @@ func (w *ImportWorker) processItem(
 	job *models.ImportJob,
 	item *models.ImportJobItem,
 	tagCache map[string]uuid.UUID,
+	shelfCache map[string]uuid.UUID,
 	allGenres []*models.Genre,
 ) (models.ImportItemStatus, string, *uuid.UUID, bool) {
 	opts := job.Options
@@ -414,6 +419,30 @@ func (w *ImportWorker) processItem(
 		}
 	}
 
+	// ── Shelves ───────────────────────────────────────────────────────────────
+	// Same shape as tags: a comma-separated list, and a name that does not match
+	// an existing shelf creates one. Both spellings are accepted because a
+	// spreadsheet exported by hand is as likely to say "shelves" as "shelf".
+	var shelfIDs []uuid.UUID
+	shelfStr := row["shelf"]
+	if shelfStr == "" {
+		shelfStr = row["shelves"]
+	}
+	if shelfStr != "" {
+		for _, rawName := range strings.Split(shelfStr, ",") {
+			name := strings.TrimSpace(rawName)
+			if name == "" {
+				continue
+			}
+			id, err := w.resolveShelf(ctx, job.LibraryID, job.CreatedBy, name, shelfCache)
+			if err != nil {
+				slog.Warn("resolving shelf", "name", name, "error", err)
+				continue
+			}
+			shelfIDs = append(shelfIDs, id)
+		}
+	}
+
 	// ── Genres (from CSV tags only; provider enrichment adds more if enabled) ─
 	var genreIDs []uuid.UUID
 	if tagStr := row["tags"]; tagStr != "" {
@@ -471,6 +500,12 @@ func (w *ImportWorker) processItem(
 	if len(genreIDs) > 0 {
 		if err := w.genres.SetBookGenres(ctx, tx, bookID, genreIDs); err != nil {
 			return models.ImportItemFailed, fmt.Sprintf("setting genres: %v", err), nil, false
+		}
+	}
+
+	for _, sid := range shelfIDs {
+		if err := w.shelves.AddBookTx(ctx, tx, sid, bookID); err != nil {
+			return models.ImportItemFailed, fmt.Sprintf("adding to shelf: %v", err), nil, false
 		}
 	}
 
@@ -638,7 +673,42 @@ func (w *ImportWorker) resolveTag(ctx context.Context, libraryID, createdBy uuid
 	return tag.ID, nil
 }
 
-// ─── Genre normalization ──────────────────────────────────────────────────────
+// resolveShelf finds a shelf by name in the library, creating it when nothing
+// matches. A shelf is a manual list shared with the library, so a created one
+// gets the importing user as its owner and no colour or icon.
+//
+// It looks before it creates, which is the opposite of resolveTag. Tag names
+// are unique per library, so resolveTag can insert and treat the conflict as
+// "already there". Shelves are rows in `lists` with no unique constraint on
+// name, so an insert always succeeds and a second row named "To Read" would
+// quietly become a second shelf. The cache means the lookup runs once per
+// distinct name in an import, not once per row.
+func (w *ImportWorker) resolveShelf(ctx context.Context, libraryID, createdBy uuid.UUID, name string, cache map[string]uuid.UUID) (uuid.UUID, error) {
+	key := strings.ToLower(name)
+	if id, ok := cache[key]; ok {
+		return id, nil
+	}
+
+	existing, err := w.shelves.List(ctx, libraryID, "", "")
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("listing shelves: %w", err)
+	}
+	for _, shelf := range existing {
+		if strings.EqualFold(shelf.Name, name) {
+			cache[key] = shelf.ID
+			return shelf.ID, nil
+		}
+	}
+
+	shelf, err := w.shelves.Create(ctx, uuid.New(), libraryID, name, "", "", "", 0, createdBy)
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("creating shelf %q: %w", name, err)
+	}
+	cache[key] = shelf.ID
+	return shelf.ID, nil
+}
+
+// ─── Genre normalization ────────────────────────────────────────────────────
 
 // normalizeCategories maps provider category strings against the known genres.
 // Splits on "/" and ",", skips strings with ">" or ":", caps at 4.


### PR DESCRIPTION
Requested by a user importing from a photo scan: title, author, tags and media type already come from the spreadsheet, but the shelf has to be set by hand afterwards, one book at a time.

A `shelf` column now works like `tags`. Comma-separated, and a name that matches nothing creates the shelf. `shelves` is accepted as the field name too.

Two things worth a look in review:

`resolveShelf` looks before it creates, unlike `resolveTag`. Tag names are unique per library so an insert-and-catch-the-conflict works there. Shelves are `lists` rows with no unique constraint on name, so the insert always succeeds and "To Read" plus "to read" would become two shelves. A test covers that.

`ShelfRepo.AddBookTx` is new so membership joins the import transaction. The existing `AddBook` uses the pool, which would leave a shelf entry pointing at a rolled-back book.

The web client builds the field mapping, so it needs a matching change before this is reachable from the import UI.

Tested against Postgres 16 with `LIBRARIUM_TEST_DSN`: find-or-create with case-insensitive matching, the transaction boundary, and the comma splitting.